### PR TITLE
[PIP-87][Website] Publish website from asf-site-next branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,2 @@
-staging:
-  profile: next
+publish:
   whoami:  asf-site-next


### PR DESCRIPTION
Motivation
We are ready to switch over website publishing to the pulsar-site repository.

Modifications
Update the .asf.yaml file which to publish the website from the asf-site-next branch.

