### PR TITLE
[doc] add new file for Pulsar REST API

### DIFF
--- a/site2/website-next/docs/reference-rest-api-overview.md
+++ b/site2/website-next/docs/reference-rest-api-overview.md
@@ -1,0 +1,17 @@
+---
+id: reference-rest-api-overview
+title: Pulsar REST APIs
+sidebar_label: "Pulsar REST APIs"
+---
+
+A REST API (also known as RESTful API, REpresentational State Transfer Application Programming Interface) is a set of definitions and protocols for building and integrating application software, using HTTP requests to GET, PUT, POST, and DELETE data following the REST standards. In essence, REST API is a set of remote calls using standard methods to request and return data in a specific format between two systems. 
+
+Pulsar provides a variety of REST APIs that enable you to interact with Pulsar to retrieve information or perform an action. 
+
+| REST API category | Description 
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for Function-specific operations.
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for Source-specific operations.
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for Sink-specific operations.
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST API for Package-specific operations. A package can be a group of functions, sources, and sinks.
+

--- a/site2/website-next/docs/reference-rest-api-overview.md
+++ b/site2/website-next/docs/reference-rest-api-overview.md
@@ -8,10 +8,11 @@ A REST API (also known as RESTful API, REpresentational State Transfer Applicati
 
 Pulsar provides a variety of REST APIs that enable you to interact with Pulsar to retrieve information or perform an action. 
 
-| REST API category | Description 
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for Function-specific operations.
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for Source-specific operations.
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for Sink-specific operations.
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST API for Package-specific operations. A package can be a group of functions, sources, and sinks.
+| REST API category | Description |
+| --- | --- |
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for Function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for Source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for Sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST API for Package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/site2/website-next/sidebars.json
+++ b/site2/website-next/sidebars.json
@@ -233,7 +233,8 @@
         "reference-terminology",
         "reference-cli-tools",
         "reference-configuration",
-        "reference-metrics"
+        "reference-metrics",
+        "reference-rest-api-overview"
       ]
     }
   ]


### PR DESCRIPTION
## Motivation
As discussed, the drop-down menu for REST APIs will be removed in the new Pulsar doc site.
Alternatively, we need a topic to provide an overview and links to each category of Pulsar REST APIs.

## Modifications
1. Add a new `reference-rest-api-overview.md` file with an overview and links to each category of Pulsar REST APIs.
2. Modify the `sidebar.json` file to add the ID `reference-rest-api-overview`.