### PR TITLE
Update reporting a vulnerability documentation

### DIFF
--- a/site2/website-next/src/pages/community.js
+++ b/site2/website-next/src/pages/community.js
@@ -222,6 +222,7 @@ export default function Community(props) {
                   <div className="sm:w-2/3">
                   <h3>Reporting a Vulnerability</h3>
                   <p>To report a vulnerability for Pulsar, contact the <a className="secondary-cta" href="https://www.apache.org/security/projects.html" target="_blank">Apache Security Team</a>.</p>
+                  <p>The process for reporting a vulnerability is outlined <a className="secondary-cta" href="https://www.apache.org/security/" target="_blank">here</a>. When reporting a vulnerability to <a className="secondary-cta" href="mailto:security@apache.org" target="_blank">security@apache.org</a>, you can copy your email to <a className="secondary-cta" href="mailto:private@pulsar.apache.org" target="_blank">private@pulsar.apache.org</a> to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.</p>
                   </div>
                 </div>
               </div>

--- a/site2/website-next/src/pages/contact.js
+++ b/site2/website-next/src/pages/contact.js
@@ -56,6 +56,23 @@ export default function page(props) {
           </h2>
           <MailTable data={mailingLists}></MailTable>
           <h2>
+            <translate>
+              Reporting a Vulnerability
+            </translate>
+          </h2>
+          <p>
+            To report a vulnerability for Pulsar, contact the <a href="https://www.apache.org/security/projects.html" target="_blank">Apache Security Team</a>.
+          </p>
+          <p>
+            <translate>The process for reporting a vulnerability is outlined </translate>
+            <a href="https://www.apache.org/security/" target="_blank">here</a>
+            <translate>. When reporting a vulnerability to </translate>
+            <a href="mailto:security@apache.org" target="_blank">security@apache.org</a>
+            <translate>, you can copy your email to </translate>
+            <a href="mailto:private@pulsar.apache.org" target="_blank">private@pulsar.apache.org</a>
+            <translate> to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.</translate>
+          </p>
+          <h2>
             <Translate>Stack Overflow</Translate>
           </h2>
           <p>


### PR DESCRIPTION
See https://github.com/apache/pulsar/pull/14610 and https://github.com/apache/pulsar/pull/14610#issuecomment-1067510855 for context.

Adding some detail to the reporting a vulnerability documentation.

@Anonymitaet - I noticed that we have a contact page on the new website https://pulsar-next.staged.apache.org/contact/. I propose adding this contact information on both pages (the "how to contribute" page and the "contact" page).