### PR TITLE
Add bookies command to pulsar-admin cli documentation page

### DIFF
--- a/site2/website-next/brodocs/pulsar-admin-manifest.json
+++ b/site2/website-next/brodocs/pulsar-admin-manifest.json
@@ -2,6 +2,7 @@
   "docs": [
     { "filename": "broker-stats.md" },
     { "filename": "brokers.md" },
+    { "filename": "bookies.md" },
     { "filename": "clusters.md" },
     { "filename": "functions-worker.md" },
     { "filename": "functions.md" },


### PR DESCRIPTION
Currently, the `bin/pulsar-admin bookies` documentation is not on the website. See here: https://pulsar.apache.org/tools/pulsar-admin/2.10.0-SNAPSHOT/ and https://pulsar.apache.org/tools/pulsar-admin/2.11.0-SNAPSHOT/.

I think the issue is likely a missing entry in the modified manifest file. I generated the code for this PR by running the following:

```bash
cp -r site2/website/brodocs/ site2/website-next/brodocs/
```