### PR TITLE
Fix wrong step number caused by #75

### DIFF
--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -996,14 +996,14 @@ footer .row.footer__links {
   counter-reset: line-number;
 }
 
-.prism-code .token-line::marker {
-  color: var(--ifm-color-gray-700);
-  content: counter(line-number);
-}
-
-.prism-code .token-line {
+.prism-code .token-line::before {
   counter-increment: line-number;
-  display: list-item;
-  padding-left: var(--ifm-pre-padding);
-  margin-left: var(--ifm-global-spacing);
+  content: counter(line-number);
+  margin-right: calc(var(--ifm-pre-padding) * 1.5);
+  text-align: right;
+  min-width: 1rem;
+  display: inline-block;
+  opacity: .3;
+  position: sticky;
+  left: var(--ifm-pre-padding);
 }


### PR DESCRIPTION
In #75, `display: list-item` and `counter-reset` are used to add line number in code blocks, which impacts the index of normal `<ol>` elements. This PR uses `display: inline-block` and a number of styles instead and should fix apache/pulsar#15662.