### PR TITLE
Prettify line number in code blocks

### DIFF
--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -999,11 +999,10 @@ footer .row.footer__links {
 .prism-code .token-line::before {
   counter-increment: line-number;
   content: counter(line-number);
-  margin-right: calc(var(--ifm-pre-padding) * 1.5);
+  margin-right: var(--ifm-pre-padding);
   text-align: right;
   min-width: 1rem;
   display: inline-block;
   opacity: .3;
-  position: sticky;
   left: var(--ifm-pre-padding);
 }


### PR DESCRIPTION
1. Reduce the padding between line number and code.
2. Remove `position: sticky` to eliminate strange scrolling behavior.