### PR TITLE
Sync language tab choices

### DIFF
--- a/site2/website-next/docs/admin-api-brokers.md
+++ b/site2/website-next/docs/admin-api-brokers.md
@@ -42,7 +42,7 @@ In addition to being configurable when you start them up, brokers can also be [d
 Fetch all available active brokers that are serving traffic.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -83,7 +83,7 @@ admin.brokers().getActiveBrokers(clusterName)
 Fetch the information of the leader broker, for example, the service url.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -126,7 +126,7 @@ For the detail of the code above, see [here](https://github.com/apache/pulsar/bl
 It finds all namespaces which are owned and served by a given broker.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -181,7 +181,7 @@ But since all broker configuration in Pulsar is stored in ZooKeeper, configurati
 ### Update dynamic configuration
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -217,7 +217,7 @@ admin.brokers().updateDynamicConfiguration(configName, configValue);
 
 Fetch a list of all potentially updatable configuration parameters.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -253,7 +253,7 @@ admin.brokers().getDynamicConfigurationNames();
 Fetch a list of all parameters that have been dynamically updated.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">

--- a/site2/website-next/docs/admin-api-clusters.md
+++ b/site2/website-next/docs/admin-api-clusters.md
@@ -38,7 +38,7 @@ New clusters can be provisioned using the admin interface.
 > Please note that this operation requires superuser privileges.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -119,7 +119,7 @@ You'll need to use `--*-tls` flags only if you're using [TLS authentication](sec
 You can fetch the [configuration](reference-configuration) for an existing cluster at any time.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -163,7 +163,7 @@ admin.clusters().getCluster(clusterName);
 You can update the configuration for an existing cluster at any time.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -208,7 +208,7 @@ admin.clusters().updateCluster(clusterName, clusterData);
 Clusters can be deleted from a Pulsar [instance](reference-terminology.md#instance).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -245,7 +245,7 @@ admin.clusters().deleteCluster(clusterName);
 You can fetch a list of all clusters in a Pulsar [instance](reference-terminology.md#instance).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">
@@ -284,7 +284,7 @@ admin.clusters().getClusters();
 Peer clusters can be configured for a given cluster in a Pulsar [instance](reference-terminology.md#instance).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
 <TabItem value="pulsar-admin">

--- a/site2/website-next/docs/admin-api-functions.md
+++ b/site2/website-next/docs/admin-api-functions.md
@@ -43,7 +43,7 @@ You can perform the following operations on functions.
 You can create a Pulsar function in cluster mode (deploy it on a Pulsar cluster) using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -101,9 +101,9 @@ admin.functions().createFunction(functionConfig, fileName);
 You can update a Pulsar function that has been deployed to a Pulsar cluster using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST Admin API","value":"REST Admin API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`update`](reference-pulsar-admin.md#functions-update) subcommand. 
@@ -122,7 +122,7 @@ $ pulsar-admin functions update \
 ```
 
 </TabItem>
-<TabItem value="REST Admin API">
+<TabItem value="REST API">
 
 {@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=@pulsar:version_number@}
 
@@ -154,7 +154,7 @@ admin.functions().updateFunction(functionConfig, userCodeFile, updateOptions);
 You can start a stopped function instance with `instance-id` using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -195,9 +195,9 @@ admin.functions().startFunction(tenant, namespace, functionName, Integer.parseIn
 You can start all stopped function instances using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`start`](reference-pulsar-admin.md#functions-start) subcommand. 
@@ -219,7 +219,7 @@ $ pulsar-admin functions start \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java">
+<TabItem value="Java Admin API">
 
 ```java
 
@@ -237,7 +237,7 @@ admin.functions().startFunction(tenant, namespace, functionName);
 You can stop a function instance with `instance-id` using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -280,7 +280,7 @@ admin.functions().stopFunction(tenant, namespace, functionName, Integer.parseInt
 You can stop all function instances using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -322,7 +322,7 @@ admin.functions().stopFunction(tenant, namespace, functionName);
 Restart a function instance with `instance-id` using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -365,7 +365,7 @@ admin.functions().restartFunction(tenant, namespace, functionName, Integer.parse
 You can restart all function instances using Admin CLI, REST API or Java admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -407,7 +407,7 @@ admin.functions().restartFunction(tenant, namespace, functionName);
 You can list all Pulsar functions running under a specific tenant and namespace using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -448,7 +448,7 @@ admin.functions().getFunctions(tenant, namespace);
 You can delete a Pulsar function that is running on a Pulsar cluster using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -490,7 +490,7 @@ admin.functions().deleteFunction(tenant, namespace, functionName);
 You can get information about a Pulsar function currently running in cluster mode using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -531,7 +531,7 @@ admin.functions().getFunction(tenant, namespace, functionName);
 
 You can get the current status of a Pulsar function instance with `instance-id` using Admin CLI, REST API or Java Admin API.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -574,7 +574,7 @@ admin.functions().getFunctionStatus(tenant, namespace, functionName, Integer.par
 You can get the current status of a Pulsar function instance using Admin CLI, REST API or Java Admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -615,7 +615,7 @@ admin.functions().getFunctionStatus(tenant, namespace, functionName);
 
 You can get the current stats of a Pulsar Function instance with `instance-id` using Admin CLI, REST API or Java admin API.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -658,7 +658,7 @@ admin.functions().getFunctionStats(tenant, namespace, functionName, Integer.pars
 You can get the current stats of a Pulsar function using Admin CLI, REST API or Java admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -700,7 +700,7 @@ admin.functions().getFunctionStats(tenant, namespace, functionName);
 You can trigger a specified Pulsar function with a supplied value using Admin CLI, REST API or Java admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -745,7 +745,7 @@ admin.functions().triggerFunction(tenant, namespace, functionName, topic, trigge
 You can put the state associated with a Pulsar function using Admin CLI, REST API or Java admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
@@ -790,9 +790,9 @@ admin.functions().putFunctionState(tenant, namespace, functionName, stateRepr);
 You can fetch the current state associated with a Pulsar function using Admin CLI, REST API or Java admin API.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin CLI","value":"Java Admin CLI"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`querystate`](reference-pulsar-admin.md#functions-querystate) subcommand. 
@@ -815,7 +815,7 @@ $ pulsar-admin functions querystate \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin CLI">
+<TabItem value="Java Admin API">
 
 ```java
 

--- a/site2/website-next/docs/admin-api-namespaces.md
+++ b/site2/website-next/docs/admin-api-namespaces.md
@@ -35,7 +35,7 @@ Namespaces can be managed via:
 You can create new namespaces under a given [tenant](reference-terminology.md#tenant).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -76,7 +76,7 @@ admin.namespaces().createNamespace(namespace);
 You can fetch the current policies associated with a namespace at any time.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -138,7 +138,7 @@ admin.namespaces().getPolicies(namespace);
 You can list all namespaces within a given Pulsar [tenant](reference-terminology.md#tenant).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -181,7 +181,7 @@ admin.namespaces().getNamespaces(tenant);
 You can delete existing namespaces from a tenant.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -224,7 +224,7 @@ admin.namespaces().deleteNamespace(namespace);
 You can set replication clusters for a namespace to enable Pulsar to internally replicate the published messages from one colocation facility to another.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -264,7 +264,7 @@ admin.namespaces().setNamespaceReplicationClusters(namespace, clusters);
 You can get the list of replication clusters for a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -319,7 +319,7 @@ Backlog quota helps the broker to restrict bandwidth/storage of a namespace once
 Backlog quota restriction can be taken care by defining restriction of backlog-quota-type: destination_storage.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -358,7 +358,7 @@ admin.namespaces().setBacklogQuota(namespace, new BacklogQuota(limit, limitTime,
 You can get a configured backlog quota for a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -408,7 +408,7 @@ admin.namespaces().getBacklogQuotaMap(namespace);
 You can remove backlog quota policies for a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -457,7 +457,7 @@ Persistence policies allow users to configure persistency-level for all topic me
   -   Ml-mark-delete-max-rate: Throttling rate of mark-delete operation (0 means no throttle), default: 0.0
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -496,7 +496,7 @@ admin.namespaces().setPersistence(namespace,new PersistencePolicies(bookkeeperEn
 You can get the configured persistence policies of a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -548,7 +548,7 @@ admin.namespaces().getPersistence(namespace)
 The namespace bundle is a virtual group of topics which belong to the same namespace. If the broker gets overloaded with the number of bundles, this command can help unload a bundle from that broker, so it can be served by some other less-loaded brokers. The namespace bundle ID ranges from 0x00000000 to 0xffffffff.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -587,7 +587,7 @@ admin.namespaces().unloadNamespaceBundle(namespace, bundle)
 One namespace bundle can contain multiple topics but can be served by only one broker. If a single bundle is creating an excessive load on a broker, an admin can split the bundle using the command below, permitting one or more of the new bundles to be unloaded, thus balancing the load across the brokers.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -628,7 +628,7 @@ admin.namespaces().splitNamespaceBundle(namespace, bundle)
 You can configure the time to live (in seconds) duration for messages. In the example below, the message-ttl is set as 100s.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -667,7 +667,7 @@ admin.namespaces().setNamespaceMessageTTL(namespace, messageTTL)
 When the message-ttl for a namespace is set, you can use the command below to get the configured value. This example comtinues the example of the command `set message-ttl`, so the returned value is 100(s).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -724,7 +724,7 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 Remove a message TTL of the configured namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -766,7 +766,7 @@ admin.namespaces().removeNamespaceMessageTTL(namespace)
 It clears all message backlog for all the topics that belong to a specific namespace. You can also clear backlog for a specific subscription as well.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -805,7 +805,7 @@ admin.namespaces().clearNamespaceBacklogForSubscription(namespace, subscription)
 It clears all message backlog for all the topics that belong to a specific NamespaceBundle. You can also clear backlog for a specific subscription as well.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -846,7 +846,7 @@ admin.namespaces().clearNamespaceBundleBacklogForSubscription(namespace, bundle,
 Each namespace contains multiple topics and the retention size (storage size) of each topic should not exceed a specific threshold or it should be stored for a certain period. This command helps configure the retention size and time of topics in a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -885,7 +885,7 @@ admin.namespaces().setRetention(namespace, new RetentionPolicies(retentionTimeIn
 It shows retention information of a given namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -946,7 +946,7 @@ disables the throttling.
 :::
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -988,7 +988,7 @@ admin.namespaces().setDispatchRate(namespace, new DispatchRate(1000, 1048576, 1)
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1042,7 +1042,7 @@ dispatch rate is in second and it can be configured with `dispatch-rate-period`.
 disables the throttling.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1084,7 +1084,7 @@ admin.namespaces().setSubscriptionDispatchRate(namespace, new DispatchRate(1000,
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1138,7 +1138,7 @@ dispatch rate is in second and it can be configured with `dispatch-rate-period`.
 disables the throttling.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1180,7 +1180,7 @@ admin.namespaces().setReplicatorDispatchRate(namespace, new DispatchRate(1000, 1
 It shows configured message-rate for the namespace (topics under this namespace can dispatch this many messages per second)
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1231,7 +1231,7 @@ admin.namespaces().getReplicatorDispatchRate(namespace)
 It shows configured `deduplicationSnapshotInterval` for a namespace (Each topic under the namespace will take a deduplication snapshot according to this interval)
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1271,7 +1271,7 @@ Set configured `deduplicationSnapshotInterval` for a namespace. Each topic under
 `brokerDeduplicationEnabled` must be set to `true` for this property to take effect.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1318,7 +1318,7 @@ admin.namespaces().setDeduplicationSnapshotInterval(namespace, 1000)
 Remove configured `deduplicationSnapshotInterval` of a namespace (Each topic under the namespace will take a deduplication snapshot according to this interval)
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1365,9 +1365,9 @@ You can unload a namespace, or a [namespace bundle](reference-terminology.md#nam
 Use the [`unload`](reference-pulsar-admin.md#unload) subcommand of the [`namespaces`](reference-pulsar-admin.md#namespaces) command.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST","value":"REST"},{"label":"Java","value":"Java"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -1377,7 +1377,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ```
 
 </TabItem>
-<TabItem value="REST">
+<TabItem value="REST API">
 
 ```
 

--- a/site2/website-next/docs/admin-api-packages.md
+++ b/site2/website-next/docs/admin-api-packages.md
@@ -88,9 +88,9 @@ packagesManagementLedgerRootPath=/ledgers
 You can use the following commands to upload a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -105,13 +105,13 @@ bin/pulsar-admin packages upload function://public/default/example@v0.1 --path p
 {@inject: endpoint|POST|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 Upload a package to the package management service synchronously.
 
 ```java
 
-  void upload(PackageMetadata metadata, String packageName, String path) throws PulsarAdminException;
+void upload(PackageMetadata metadata, String packageName, String path) throws PulsarAdminException;
 
 ```
 
@@ -119,7 +119,7 @@ Upload a package to the package management service asynchronously.
 
 ```java
 
-  CompletableFuture<Void> uploadAsync(PackageMetadata metadata, String packageName, String path);
+CompletableFuture<Void> uploadAsync(PackageMetadata metadata, String packageName, String path);
 
 ```
 
@@ -133,9 +133,9 @@ Upload a package to the package management service asynchronously.
 You can use the following commands to download a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -150,13 +150,13 @@ bin/pulsar-admin packages download function://public/default/example@v0.1 --path
 {@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 Download a package from the package management service synchronously.
 
 ```java
 
-  void download(String packageName, String path) throws PulsarAdminException;
+void download(String packageName, String path) throws PulsarAdminException;
 
 ```
 
@@ -164,7 +164,7 @@ Download a package from the package management service asynchronously.
 
 ```java
 
-  CompletableFuture<Void> downloadAsync(String packageName, String path);
+CompletableFuture<Void> downloadAsync(String packageName, String path);
 
 ```
 
@@ -178,9 +178,9 @@ Download a package from the package management service asynchronously.
 You can use the following commands to delete a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 The following command deletes a package of version 0.1.
@@ -197,13 +197,13 @@ bin/pulsar-admin packages delete functions://public/default/example@v0.1
 {@inject: endpoint|DELETE|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 Delete a specified package synchronously.
 
 ```java
 
-  void delete(String packageName) throws PulsarAdminException;
+void delete(String packageName) throws PulsarAdminException;
 
 ```
 
@@ -211,7 +211,7 @@ Delete a specified package asynchronously.
 
 ```java
 
-  CompletableFuture<Void> deleteAsync(String packageName);
+CompletableFuture<Void> deleteAsync(String packageName);
 
 ```
 
@@ -225,9 +225,9 @@ Delete a specified package asynchronously.
 You can use the following commands to get the metadate of a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -242,13 +242,13 @@ bin/pulsar-admin packages get-metadata function://public/default/test@v1
 {@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 Get the metadata of a package synchronously.
 
 ```java
 
-  PackageMetadata getMetadata(String packageName) throws PulsarAdminException;
+PackageMetadata getMetadata(String packageName) throws PulsarAdminException;
 
 ```
 
@@ -256,7 +256,7 @@ Get the metadata of a package asynchronously.
 
 ```java
 
-  CompletableFuture<PackageMetadata> getMetadataAsync(String packageName);
+CompletableFuture<PackageMetadata> getMetadataAsync(String packageName);
 
 ```
 
@@ -270,9 +270,9 @@ Get the metadata of a package asynchronously.
 You can use the following commands to update the metadata of a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -287,13 +287,13 @@ bin/pulsar-admin packages update-metadata function://public/default/example@v0.1
 {@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 Update the metadata of a package synchronously.
 
 ```java
 
-  void updateMetadata(String packageName, PackageMetadata metadata) throws PulsarAdminException;
+void updateMetadata(String packageName, PackageMetadata metadata) throws PulsarAdminException;
 
 ```
 
@@ -301,7 +301,7 @@ Update the metadata of a package asynchronously.
 
 ```java
 
-  CompletableFuture<Void> updateMetadataAsync(String packageName, PackageMetadata metadata);
+CompletableFuture<Void> updateMetadataAsync(String packageName, PackageMetadata metadata);
 
 ```
 
@@ -315,9 +315,9 @@ Update the metadata of a package asynchronously.
 You can use the following commands to list all versions of a package.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 ```shell
@@ -332,13 +332,13 @@ bin/pulsar-admin packages list-versions type://tenant/namespace/packageName
 {@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 List all versions of a package synchronously.
 
 ```java
 
-  List<String> listPackageVersions(String packageName) throws PulsarAdminException;
+List<String> listPackageVersions(String packageName) throws PulsarAdminException;
 
 ```
 
@@ -346,7 +346,7 @@ List all versions of a package asynchronously.
 
 ```java
 
-  CompletableFuture<List<String>> listPackageVersionsAsync(String packageName);
+CompletableFuture<List<String>> listPackageVersionsAsync(String packageName);
 
 ```
 
@@ -360,9 +360,9 @@ List all versions of a package asynchronously.
 You can use the following commands to list all packages of a specific type under a namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="pulsar-admin">
 
@@ -378,13 +378,13 @@ bin/pulsar-admin packages list --type function public/default
 {@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 List all packages of a specific type under a namespace synchronously.
 
 ```java
 
-  List<String> listPackages(String type, String namespace) throws PulsarAdminException;
+List<String> listPackages(String type, String namespace) throws PulsarAdminException;
 
 ```
 
@@ -392,7 +392,7 @@ List all packages of a specific type under a namespace asynchronously.
 
 ```java
 
-  CompletableFuture<List<String>> listPackagesAsync(String type, String namespace);
+CompletableFuture<List<String>> listPackagesAsync(String type, String namespace);
 
 ```
 

--- a/site2/website-next/docs/admin-api-permissions.md
+++ b/site2/website-next/docs/admin-api-permissions.md
@@ -33,7 +33,7 @@ The chapters below demonstrate how to grant namespace-level permissions to users
 You can grant permissions to specific roles for lists of operations such as `produce` and `consume`.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -111,7 +111,7 @@ admin.namespaces().grantPermissionOnNamespace(namespace, role, getAuthActions(ac
 You can see which permissions have been granted to which roles in a namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -154,7 +154,7 @@ admin.namespaces().getPermissions(namespace);
 You can revoke permissions from specific roles, which means that those roles will no longer have access to the specified namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">

--- a/site2/website-next/docs/admin-api-tenants.md
+++ b/site2/website-next/docs/admin-api-tenants.md
@@ -32,9 +32,9 @@ Tenants, like namespaces, can be managed using the [admin API](admin-api-overvie
 You can list all of the tenants associated with an [instance](reference-terminology.md#instance).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 Use the [`list`](reference-pulsar-admin.md#tenants-list) subcommand.
@@ -53,7 +53,7 @@ my-tenant-2
 {@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 ```java
 
@@ -71,9 +71,9 @@ admin.tenants().getTenants();
 You can create a new tenant.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 Use the [`create`](reference-pulsar-admin.md#tenants-create) subcommand:
@@ -106,7 +106,7 @@ $ pulsar-admin tenants create my-tenant \
 {@inject: endpoint|PUT|/admin/v2/tenants/:tenant|operation/createTenant?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 ```java
 
@@ -124,9 +124,9 @@ admin.tenants().createTenant(tenantName, tenantInfo);
 You can fetch the [configuration](reference-configuration) for an existing tenant at any time.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 Use the [`get`](reference-pulsar-admin.md#tenants-get) subcommand and specify the name of the tenant. Here's an example:
@@ -153,7 +153,7 @@ $ pulsar-admin tenants get my-tenant
 {@inject: endpoint|GET|/admin/v2/tenants/:tenant|operation/getTenant?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 ```java
 
@@ -171,9 +171,9 @@ admin.tenants().getTenantInfo(tenantName);
 Tenants can be deleted from a Pulsar [instance](reference-terminology.md#instance).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 Use the [`delete`](reference-pulsar-admin.md#tenants-delete) subcommand and specify the name of the tenant.
@@ -190,7 +190,7 @@ $ pulsar-admin tenants delete my-tenant
 {@inject: endpoint|DELETE|/admin/v2/tenants/:tenant|operation/deleteTenant?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 ```java
 
@@ -208,9 +208,9 @@ admin.Tenants().deleteTenant(tenantName);
 You can update a tenant's configuration.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"JAVA","value":"JAVA"}]}>
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
 Use the [`update`](reference-pulsar-admin.md#tenants-update) subcommand.
@@ -227,7 +227,7 @@ $ pulsar-admin tenants update my-tenant
 {@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/updateTenant?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="JAVA">
+<TabItem value="Java">
 
 ```java
 

--- a/site2/website-next/docs/admin-api-topics.md
+++ b/site2/website-next/docs/admin-api-topics.md
@@ -51,7 +51,7 @@ Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getLi
 You can get the list of topics under a given namespace in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -88,7 +88,7 @@ admin.topics().getList(namespace);
 You can grant permissions on a client role to perform specific actions on a given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -128,7 +128,7 @@ admin.topics().grantPermission(topic, role, actions);
 You can fetch permission in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -171,7 +171,7 @@ admin.topics().getPermissions(topic);
 
 You can revoke a permission granted on a client role in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -217,7 +217,7 @@ admin.topics().revokePermissions(topic, role);
 You can delete a topic in the following ways. You cannot delete a topic if any active subscription or producers is connected to the topic.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -253,7 +253,7 @@ admin.topics().delete(topic);
 
 You can unload a topic in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -574,7 +574,7 @@ The following is an example of a topic status.
 To get the status of a topic, you can use the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -754,7 +754,7 @@ The following is an example of the detailed statistics of a topic.
 
 To get the internal status of a topic, you can use the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -790,7 +790,7 @@ admin.topics().getInternalStats(topic);
 
 You can peek a number of messages for a specific subscription of a given topic in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -834,7 +834,7 @@ admin.topics().peekMessages(topic, subName, numMessages);
 You can fetch the message with the given ledger ID and entry ID in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -874,7 +874,7 @@ admin.topics().getMessageById(topic, ledgerId, entryId);
 You can examine a specific message on a topic by position relative to the earliest or the latest message.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -912,7 +912,7 @@ admin.topics().examineMessage(topic, "latest", 1);
 You can get message ID published at or just after the given datetime.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -952,7 +952,7 @@ admin.topics().getMessageIdByTimestamp(topic, timestamp);
 You can skip a number of messages for a specific subscription of a given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -992,7 +992,7 @@ admin.topics().skipMessages(topic, subName, numMessages);
 You can skip all the old messages for a specific subscription of a given topic.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1031,7 +1031,7 @@ admin.topics().skipAllMessages(topic, subName);
 You can reset a subscription cursor position back to the position which is recorded X minutes before. It essentially calculates time and position of cursor at X minutes before and resets it at that position. You can reset the cursor in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1071,7 +1071,7 @@ admin.topics().resetCursor(topic, subName, timestamp);
 You can locate the broker URL which is serving the given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1110,7 +1110,7 @@ admin.lookup().lookupDestination(topic);
 You can locate the broker URL of each partitioned topic which is serving the given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1158,7 +1158,7 @@ $ pulsar-admin topics partitioned-lookup \
 You can check the range of the bundle which contains given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1197,7 +1197,7 @@ admin.lookup().getBundleRange(topic);
 You can check all subscription names for a given topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1236,7 +1236,7 @@ admin.topics().getSubscriptions(topic);
 You can get the last committed message ID for a persistent topic. It is available since 2.3.0 release.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1272,7 +1272,7 @@ admin.topics().getLastMessage(topic);
 You can get the backlog size of a single partition topic or a non-partitioned topic with a given message ID (in bytes).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1314,10 +1314,10 @@ admin.topics().getBacklogSizeByMessageId(topic, messageId);
 To get the topic-level deduplication snapshot interval, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1335,7 +1335,7 @@ pulsar-admin topics get-deduplication-snapshot-interval options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1355,10 +1355,10 @@ To set the topic-level deduplication snapshot interval, use one of the following
 > **Prerequisite** `brokerDeduplicationEnabled` must be set to `true`.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1384,7 +1384,7 @@ pulsar-admin topics set-deduplication-snapshot-interval options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1402,10 +1402,10 @@ admin.topics().setDeduplicationSnapshotInterval(topic, 1000)
 To remove the topic-level deduplication snapshot interval, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1423,7 +1423,7 @@ pulsar-admin topics remove-deduplication-snapshot-interval options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1444,10 +1444,10 @@ admin.topics().removeDeduplicationSnapshotInterval(topic)
 To get the topic-level inactive topic policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1465,7 +1465,7 @@ pulsar-admin topics get-inactive-topic-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1483,10 +1483,10 @@ admin.topics().getInactiveTopicPolicies(topic)
 To set the topic-level inactive topic policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1504,7 +1504,7 @@ pulsar-admin topics set-inactive-topic-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1522,10 +1522,10 @@ admin.topics().setInactiveTopicPolicies(topic, inactiveTopicPolicies)
 To remove the topic-level inactive topic policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1543,7 +1543,7 @@ pulsar-admin topics remove-inactive-topic-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1564,10 +1564,10 @@ admin.topics().removeInactiveTopicPolicies(topic)
 To get the topic-level offload policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1585,7 +1585,7 @@ pulsar-admin topics get-offload-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1603,10 +1603,10 @@ admin.topics().getOffloadPolicies(topic)
 To set the topic-level offload policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1624,7 +1624,7 @@ pulsar-admin topics set-offload-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1642,10 +1642,10 @@ admin.topics().setOffloadPolicies(topic, offloadPolicies)
 To remove the topic-level offload policies, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
-  defaultValue="Pulsar-admin API"
-  values={[{"label":"Pulsar-admin API","value":"Pulsar-admin API"},{"label":"REST API","value":"REST API"},{"label":"Java API","value":"Java API"}]}>
-<TabItem value="Pulsar-admin API">
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
 ```
 
@@ -1663,7 +1663,7 @@ pulsar-admin topics remove-offload-policies options
 ```
 
 </TabItem>
-<TabItem value="Java API">
+<TabItem value="Java">
 
 ```java
 
@@ -1689,7 +1689,7 @@ For more information about the two parameters, see [here](reference-configuratio
 
 You can create non-partitioned topics in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1732,7 +1732,7 @@ admin.topics().createNonPartitionedTopic(topicName);
 ### Delete
 You can delete non-partitioned topics in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1767,7 +1767,7 @@ admin.topics().delete(topic);
 
 You can get the list of topics under a given namespace in the following ways.  
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1840,7 +1840,7 @@ You can check the current statistics of a given topic. The following is an examp
 
 You can check the current statistics of a given topic and its connected producers and consumers in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1885,7 +1885,7 @@ For more information about the two parameters, see [here](reference-configuratio
 
 You can create partitioned topics in the following ways.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1933,7 +1933,7 @@ admin.topics().createPartitionedTopic(topicName, numPartitions);
 When topic auto-creation is disabled, and you have a partitioned topic without any partitions, you can use the [`create-missed-partitions`](reference-pulsar-admin.md#create-missed-partitions) command to create partitions for the topic.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -1976,7 +1976,7 @@ Field | Description
 `partitions` | The number of partitions into which the topic is divided.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2020,7 +2020,7 @@ You can update the number of partitions for an existing partitioned topic *if* t
 Producers and consumers can find the newly created partitions automatically.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2058,7 +2058,7 @@ admin.topics().updatePartitionedTopic(topic, numPartitions);
 You can delete partitioned topics with the [`delete-partitioned-topic`](reference-pulsar-admin.md#delete-partitioned-topic) command, REST API and Java. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2092,7 +2092,7 @@ admin.topics().delete(topic);
 ### List
 You can get the list of partitioned topics under a given namespace in the following ways.  
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2188,7 +2188,7 @@ Note that in the subscription JSON object, `chuckedMessageRate` is deprecated. P
 You can check the current statistics of a given partitioned topic and its connected producers and consumers in the following ways. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2266,7 +2266,7 @@ You can check the detailed statistics of a topic. The following is an example. F
 You can get the internal stats for the partitioned topic in the following ways.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -2400,7 +2400,7 @@ You can use [Pulsar admin API](admin-api-overview) to create, check, and delete 
 You can create a subscription for a topic using one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
@@ -2440,7 +2440,7 @@ admin.topics().createSubscription(topic, subscriptionName, MessageId.latest);
 You can check all subscription names for a given topic using one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
@@ -2479,7 +2479,7 @@ admin.topics().getSubscriptions(topic);
 When a subscription does not process messages any more, you can unsubscribe it using one of the following methods. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 

--- a/site2/website-next/docs/administration-isolation.md
+++ b/site2/website-next/docs/administration-isolation.md
@@ -21,7 +21,7 @@ In Pulsar, when namespaces (more specifically, namespace bundles) are assigned d
 You can set a namespace isolation policy for a cluster using one of the following methods. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java admin API","value":"Java admin API"}]}>
 
@@ -69,7 +69,7 @@ A namespace can be isolated into user-defined groups of bookies, which guarantee
 You can set a bookie affinity group using one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java admin API","value":"Java admin API"}]}>
 

--- a/site2/website-next/docs/client-libraries-java.md
+++ b/site2/website-next/docs/client-libraries-java.md
@@ -211,7 +211,7 @@ This chapter helps you better understand the concept of cluster-level failover.
 > ##### Concept of cluster-level failover
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="failover-choice"
   defaultValue="Automatic cluster-level failover"
   values={[{"label":"Automatic cluster-level failover","value":"Automatic cluster-level failover"},{"label":"Controlled cluster-level failover","value":"Controlled cluster-level failover"}]}>
 <TabItem value="Automatic cluster-level failover">
@@ -255,7 +255,7 @@ The cluster-level failover protects your environment in a number of ways, includ
 > ##### When cluster-level failover is triggered?
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="failover-choice"
   defaultValue="Automatic cluster-level failover"
   values={[{"label":"Automatic cluster-level failover","value":"Automatic cluster-level failover"},{"label":"Controlled cluster-level failover","value":"Controlled cluster-level failover"}]}>
 <TabItem value="Automatic cluster-level failover">
@@ -333,7 +333,7 @@ This section guides you through every step on how to configure cluster-level fai
 * Set `replicateSubscriptionState` to `true` when creating consumers.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="failover-choice"
   defaultValue="Automatic cluster-level failover"
   values={[{"label":"Automatic cluster-level failover","value":"Automatic cluster-level failover"},{"label":"Controlled cluster-level failover","value":"Controlled cluster-level failover"}]}>
 <TabItem value="Automatic cluster-level failover">
@@ -456,7 +456,7 @@ Assume that you want to connect Pulsar client 1 to cluster A.
 This chapter explains the working process of cluster-level failover. For more implementation details, see [PIP-121](https://github.com/apache/pulsar/issues/13315).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="failover-choice"
   defaultValue="Automatic cluster-level failover"
   values={[{"label":"Automatic cluster-level failover","value":"Automatic cluster-level failover"},{"label":"Controlled cluster-level failover","value":"Controlled cluster-level failover"}]}>
 <TabItem value="Automatic cluster-level failover">

--- a/site2/website-next/docs/cookbooks-retention-expiry.md
+++ b/site2/website-next/docs/cookbooks-retention-expiry.md
@@ -67,7 +67,7 @@ For more information of the two parameters, refer to the [`broker.conf`](referen
 You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -159,7 +159,7 @@ admin.namespaces().setRetention(namespace, policies);
 You can fetch the retention policy for a namespace by specifying the namespace. The output will be a JSON object with two keys: `retentionTimeInMinutes` and `retentionSizeInMB`.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -231,7 +231,7 @@ Backlog quotas are handled at the namespace level. They can be managed via:
 You can set a size and/or time threshold and backlog retention policy for all of the topics in a [namespace](reference-terminology.md#namespace) by specifying the namespace, a size limit and/or a time limit in second, and a policy by name.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -284,7 +284,7 @@ admin.namespaces().setBacklogQuota(namespace, quota);
 You can see which size threshold and backlog retention policy has been applied to a namespace.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -326,7 +326,7 @@ Map<BacklogQuota.BacklogQuotaType,BacklogQuota> quotas =
 ### Remove backlog quotas
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -386,7 +386,7 @@ The diagram below illustrates the concept of TTL.
 ### Set the TTL for a namespace
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -424,7 +424,7 @@ admin.namespaces().setNamespaceMessageTTL(namespace, ttlInSeconds);
 ### Get the TTL configuration for a namespace
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
@@ -462,7 +462,7 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 ### Remove the TTL configuration for a namespace
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">

--- a/site2/website-next/docs/functions-develop.md
+++ b/site2/website-next/docs/functions-develop.md
@@ -25,7 +25,7 @@ Extended Pulsar Function SDK for Java | An extension to Pulsar-specific librarie
 The language-native function, which adds an exclamation point to all incoming strings and publishes the resulting string to a topic, has no external dependencies. The following example is language-native function.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">
@@ -80,7 +80,7 @@ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 ### Pulsar Function SDK for Java/Python/Go
 The following example uses Pulsar Functions SDK.
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -166,7 +166,7 @@ Before using it, you need to set up Pulsar Function worker 2.10.0 or later versi
 The following example uses the extended interface of Pulsar Function SDK for Java to initialize RedisClient when the function instance starts and release it when the function instance closes.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"}]}>
 <TabItem value="Java">
@@ -216,7 +216,7 @@ Pulsar has a built-in schema registry and is bundled with popular schema types, 
 SerDe stands for **Ser**ialization and **De**serialization. Pulsar Functions uses SerDe when publishing data to and consuming data from Pulsar topics. How SerDe works by default depends on the language you use for a particular function.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -292,7 +292,7 @@ Currently, the feature is not available in Go.
 Imagine that you're writing Pulsar Functions that are processing tweet objects, you can refer to the following example of `Tweet` class.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">
@@ -418,7 +418,7 @@ Java, Python and Go SDKs provide access to a **context object** that can be used
 * (Java) get Pulsar admin client.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -660,7 +660,7 @@ $ bin/pulsar-admin functions create \
 ```
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java"> 
@@ -809,7 +809,7 @@ func contextFunc(ctx context.Context) {
 ### Logger
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -1134,7 +1134,7 @@ Additionally, you can specify the function log level through the broker XML file
 Pulsar Functions using the Java SDK has access to the Pulsar admin client, which allows the Pulsar admin client to manage API calls to current Pulsar clusters or external clusters (if `external-pulsars` is provided).
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"}]}>
 <TabItem value="Java">
@@ -1215,7 +1215,7 @@ You can monitor Pulsar Functions that have been deployed with the following meth
 Here are examples of how to customize metrics for Java and Python functions.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -1303,7 +1303,7 @@ Pulsar Functions can support the following providers:
 At the same time, Pulsar Functions provides two interfaces, **SecretsProvider** and **SecretsProviderConfigurator**, allowing users to customize secret provider.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
@@ -1383,7 +1383,7 @@ State storage is not available in Go.
 ### API
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">
@@ -1622,7 +1622,7 @@ If `--watch` is specified, the CLI will watch the value of the provided `state-k
 ### Example
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">

--- a/site2/website-next/docs/io-overview.md
+++ b/site2/website-next/docs/io-overview.md
@@ -73,7 +73,7 @@ When creating a connector, you can set the processing guarantee with the followi
 Here takes **Admin CLI** as an example. For more information about **REST API** or **JAVA Admin API**, see [here](io-use.md#create). 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="io-choice"
   defaultValue="Source"
   values={[{"label":"Source","value":"Source"},{"label":"Sink","value":"Sink"}]}>
 
@@ -120,7 +120,7 @@ After creating a connector, you can update the processing guarantee with the fol
 Here takes **Admin CLI** as an example. For more information about **REST API** or **JAVA Admin API**, see [here](io-use.md#create). 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="io-choice"
   defaultValue="Source"
   values={[{"label":"Source","value":"Source"},{"label":"Sink","value":"Sink"}]}>
 

--- a/site2/website-next/docs/io-use.md
+++ b/site2/website-next/docs/io-use.md
@@ -193,7 +193,7 @@ You can create a connector using **Admin CLI**, **REST API** or **JAVA admin API
 Create a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -284,7 +284,7 @@ Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/source
 Create a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -379,7 +379,7 @@ You can start a connector using **Admin CLI** or **REST API**.
 Start a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"}]}>
 
@@ -416,7 +416,7 @@ For more information, see [here](io-cli.md#start).
 Start a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"}]}>
 
@@ -457,7 +457,7 @@ You can run a connector locally rather than deploying it on a Pulsar cluster usi
 Run a source connector locally.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"}]}>
 
@@ -483,7 +483,7 @@ For more information, see [here](io-cli.md#localrun).
 Run a sink connector locally.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"}]}>
 
@@ -523,7 +523,7 @@ You can get the information of a connector using **Admin CLI**, **REST API** or 
 Get the information of a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -636,7 +636,7 @@ For more information, see [`getSource`](https://pulsar.apache.org/api/admin/org/
 Get the information of a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -746,7 +746,7 @@ You can get the list of all running connectors using **Admin CLI**, **REST API**
 Get the list of all running source connectors.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -805,7 +805,7 @@ For more information, see [`listSource`](https://pulsar.apache.org/api/admin/org
 Get the list of all running sink connectors.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -868,7 +868,7 @@ You can get the current status of a connector using **Admin CLI**, **REST API** 
 Get the current status of a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -964,7 +964,7 @@ For more information, see [here](io-cli.md#status).
 Get the current status of a Pulsar sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1066,7 +1066,7 @@ You can update a running connector using **Admin CLI**, **REST API** or **JAVA a
 Update a running Pulsar source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1161,7 +1161,7 @@ For more information, see [`createSourceWithUrl`](https://pulsar.apache.org/api/
 Update a running Pulsar sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1262,7 +1262,7 @@ You can stop a connector using **Admin CLI**, **REST API** or **JAVA admin API**
 Stop a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1358,7 +1358,7 @@ For more information, see [here](io-cli.md#stop).
 Stop a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1460,7 +1460,7 @@ You can restart a connector using **Admin CLI**, **REST API** or **JAVA admin AP
 Restart a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1556,7 +1556,7 @@ For more information, see [here](io-cli.md#restart).
 Restart a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1658,7 +1658,7 @@ You can delete a connector using **Admin CLI**, **REST API** or **JAVA admin API
 Delete a source connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -1724,7 +1724,7 @@ For more information, see [`deleteSource`](https://pulsar.apache.org/api/admin/o
 Delete a sink connector.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 

--- a/site2/website-next/docs/schema-manage.md
+++ b/site2/website-next/docs/schema-manage.md
@@ -168,7 +168,7 @@ To manage schemas, you can use one of the following methods.
 To upload (register) a new schema for a topic, you can use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -296,7 +296,7 @@ admin.createSchema("my-tenant/my-ns/my-topic", payload);
 To get the latest schema for a topic, you can use one of the following methods. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -388,7 +388,7 @@ SchemaInfo si = admin.getSchema("my-tenant/my-ns/my-topic");
 To get a specific version of a schema, you can use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -469,7 +469,7 @@ SchemaInfo si = admin.getSchema("my-tenant/my-ns/my-topic", 1L);
 To provide a schema via a topic, you can use the following method.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"}]}>
 
@@ -499,7 +499,7 @@ In any case, the **delete** action deletes **all versions** of a schema register
 :::
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -655,7 +655,7 @@ The schema compatibility check strategy set at different levels has priority: to
 To set a schema compatibility check strategy at the topic level, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -701,7 +701,7 @@ admin.topicPolicies().setSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic",
 To get the topic-level schema compatibility check strategy, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -751,7 +751,7 @@ admin.topicPolicies().getSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic",
 To remove the topic-level schema compatibility check strategy, use one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
   values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
@@ -800,9 +800,9 @@ admin.removeSchemaCompatibilityStrategy("my-tenant/my-ns/my-topic");
 You can set schema compatibility check strategy at namespace level using one of the following methods.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin CLI","value":"Java Admin CLI"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -820,7 +820,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin CLI">
+<TabItem value="Java Admin API">
 
 Use the [`setSchemaCompatibilityStrategy`](https://pulsar.apache.org/api/admin/)method.
 

--- a/site2/website-next/docs/security-encryption.md
+++ b/site2/website-next/docs/security-encryption.md
@@ -60,7 +60,7 @@ Pulsar does not store the encryption key anywhere in the Pulsar service. If you 
 5. Configure a `CryptoKeyReader` to a producer, consumer or reader. 
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"},{"label":"Python","value":"Python"},{"label":"Node.js","value":"Node.js"}]}>
 <TabItem value="Java">
@@ -218,7 +218,7 @@ await client.close();
 6. Below is an example of a **customized** `CryptoKeyReader` implementation.
 
 ````mdx-code-block
-<Tabs 
+<Tabs groupId="lang-choice"
   defaultValue="Java"
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"},{"label":"Python","value":"Python"},{"label":"Node.js","value":"Node.js"}]}>
 <TabItem value="Java">


### PR DESCRIPTION
Fix apache/pulsar#10282. Please see the original issue for more details. This PR has been split into 3 commits for easier review, which may be squashed when merging.

Note that some pages use options like `pulsar-admin`, `REST API` and `Java`, while others use `Admin CLI`, `REST API` and `Java Admin API`. Not sure if we should make these options consistent, but I've ensured that the options on the same page is consistent so that the tab choices are synced on the same page.