### PR TITLE
[feat][workflow] add links of doc contribution guides to Pulsar contribution page

### DIFF
--- a/site2/website-next/src/pages/contributing.md
+++ b/site2/website-next/src/pages/contributing.md
@@ -24,10 +24,17 @@ We use a review-then-commit workflow in Pulsar for all contributions.
 
 1. **Code:** code changes are always welcomed. 
 2. **Doc**: it is worth taking the time to make users know your code changes. Pulsar's long-term success rests on its ease of use, maintainability, etc. 
-3. **Review:** Submit a pull request with your contribution to our
+   
+:::tip
+
+For how to make contributions to Pulsar documentation, see [Pulsar Documentation Contribution Guide](https://docs.google.com/document/d/11DTnNPpvcPrebLkMAFcDEIFlD8ARD-k6F-LXoIwdD9Y/edit#).
+
+:::
+
+1. **Review:** Submit a pull request with your contribution to our
    [GitHub Repo](https://github.com/apache/pulsar). Work with a committer to review and
    iterate on the code, if needed.
-4. **Commit:** Once at least 2 Pulsar committers have approved the pull request, a Pulsar committer
+2. **Commit:** Once at least 2 Pulsar committers have approved the pull request, a Pulsar committer
     will merge it into the master branch (and potentially backport to stable branches in case of
     bug fixes).
 

--- a/site2/website-next/src/pages/contributing.md
+++ b/site2/website-next/src/pages/contributing.md
@@ -31,10 +31,10 @@ For how to make contributions to Pulsar documentation, see [Pulsar Documentation
 
 :::
 
-1. **Review:** Submit a pull request with your contribution to our
+3. **Review:** Submit a pull request with your contribution to our
    [GitHub Repo](https://github.com/apache/pulsar). Work with a committer to review and
    iterate on the code, if needed.
-2. **Commit:** Once at least 2 Pulsar committers have approved the pull request, a Pulsar committer
+4. **Commit:** Once at least 2 Pulsar committers have approved the pull request, a Pulsar committer
     will merge it into the master branch (and potentially backport to stable branches in case of
     bug fixes).
 


### PR DESCRIPTION
Preview looks good:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/50226895/173533563-c35c7372-1f23-43fc-ba5d-9122b04bf7f6.png">
