### PR TITLE
Fix versioned links for clients

### DIFF
--- a/site2/website-next/scripts/replace.js
+++ b/site2/website-next/scripts/replace.js
@@ -91,24 +91,14 @@ function debDistUrl(version, type) {
 }
 
 function clientVersionUrl(version, type) {
-  return `${siteConfig.url}/api/${type}`;
-  // var versions = version.split(".");
-  // var majorVersion = parseInt(versions[0]);
-  // var minorVersion = parseInt(versions[1]);
-  // if (majorVersion === 2 && minorVersion < 5) {
-  //   return `${siteConfig.url}/api/` + type + `/` + version + "/";
-  // } else if (majorVersion >= 2 && minorVersion >= 5) {
-  //   return (
-  //     `${siteConfig.url}/api/` +
-  //     type +
-  //     `/` +
-  //     majorVersion +
-  //     `.` +
-  //     minorVersion +
-  //     `.0` +
-  //     `-SNAPSHOT/`
-  //   );
-  // }
+  var versions = version.split('.')
+  var majorVersion = parseInt(versions[0])
+  var minorVersion = parseInt(versions[1])
+  if ((majorVersion === 2 && minorVersion < 5) || (type === "python" && minorVersion >= 7)) {
+    return `${siteConfig.url}/api/${type}/${version}`;
+  } else if (majorVersion >= 2 && minorVersion >= 5) {
+    return `${siteConfig.url}/api/${type}/${majorVersion}.${minorVersion}.0-SNAPSHOT/`
+  }
 }
 
 function doReplace(options) {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/15984.

## Motivation

We have many versioned links in our docs. We replace those links by running `node replace.js` on the script I update in this PR. The versioning is currently broken.

## Change

* Fix the `clientVersionUrl` method in the `website-next/scripts/replace.js` file. Note that this changes the method so that it matches the `website/scripts/replace.js`.