### PR TITLE
Remove trailing slash from clientVersionUrl

### DIFF
--- a/site2/website-next/scripts/replace.js
+++ b/site2/website-next/scripts/replace.js
@@ -97,7 +97,7 @@ function clientVersionUrl(version, type) {
   if ((majorVersion === 2 && minorVersion < 5) || (type === "python" && minorVersion >= 7)) {
     return `${siteConfig.url}/api/${type}/${version}`;
   } else if (majorVersion >= 2 && minorVersion >= 5) {
-    return `${siteConfig.url}/api/${type}/${majorVersion}.${minorVersion}.0-SNAPSHOT/`
+    return `${siteConfig.url}/api/${type}/${majorVersion}.${minorVersion}.0-SNAPSHOT`
   }
 }
 


### PR DESCRIPTION
In #124, I incorrectly included a trailing slash, which led to URLS getting generated with `//` at the end. This PR fixes that mistake.