### PR TITLE
Update out-of-sync url to get openssl.cnf in TLS transport documentation

### DIFF
--- a/site2/website-next/docs/security-tls-transport.md
+++ b/site2/website-next/docs/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.1.1-incubating/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.1.1-incubating/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.10.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.10.0/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.2.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.2.0/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.2.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.2.1/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.3.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.3.0/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.3.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.3.1/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.3.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.3.2/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.4.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.4.0/security-tls-transport.md
@@ -45,7 +45,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.4.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.4.1/security-tls-transport.md
@@ -45,7 +45,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.4.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.4.2/security-tls-transport.md
@@ -45,7 +45,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.5.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.5.0/security-tls-transport.md
@@ -45,7 +45,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.5.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.5.1/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.5.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.5.2/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.6.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.6.0/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.6.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.6.1/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.6.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.6.2/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.6.3/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.6.3/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.6.4/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.6.4/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.7.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.7.0/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.7.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.7.1/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.7.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.7.2/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.7.3/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.7.4/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.7.4/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.8.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.8.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.8.1/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.8.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.8.2/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.8.3/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.8.3/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.9.0/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.9.0/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.9.1/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.9.1/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website-next/versioned_docs/version-2.9.2/security-tls-transport.md
+++ b/site2/website-next/versioned_docs/version-2.9.2/security-tls-transport.md
@@ -47,7 +47,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 
 ```

--- a/site2/website/docs/security-tls-transport.md
+++ b/site2/website/docs/security-tls-transport.md
@@ -45,7 +45,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.10.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.10.0/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.0/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.2.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.2.1/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.0/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.3.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.3.2/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.4.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.0/security-tls-transport.md
@@ -44,7 +44,7 @@ Create a directory for your CA, and place [this openssl configuration file](http
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.1/security-tls-transport.md
@@ -44,7 +44,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.4.2/security-tls-transport.md
@@ -44,7 +44,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.0/security-tls-transport.md
@@ -44,7 +44,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.5.2/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.6.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.6.0/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.6.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.6.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.6.3/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.6.3/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.6.4/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.6.4/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.7.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.7.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.7.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.7.3/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.7.4/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.8.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.0/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.8.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.1/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.8.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.2/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.8.3/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.8.3/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.9.0/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.9.0/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.9.1/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.9.1/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 

--- a/site2/website/versioned_docs/version-2.9.2/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.9.2/security-tls-transport.md
@@ -46,7 +46,7 @@ Follow the guide below to set up a certificate authority. You can also refer to 
 ```bash
 mkdir my-ca
 cd my-ca
-wget https://raw.githubusercontent.com/apache/pulsar/master/site2/website/static/examples/openssl.cnf
+wget https://raw.githubusercontent.com/apache/pulsar-site/main/site2/website/static/examples/openssl.cnf
 export CA_HOME=$(pwd)
 ```
 


### PR DESCRIPTION
Examples in the static folder were removed from pulsar repo by https://github.com/apache/pulsar/pull/15636.