### PR TITLE
Fix the doc link mismatch problem.

### DIFF
--- a/site2/website-next/docusaurus.config.js
+++ b/site2/website-next/docusaurus.config.js
@@ -106,14 +106,15 @@ const injectLinkParseForEndpoint = ([, info]) => {
     restBaseUrl = sinkApiUrl;
   }
   let restUrl = "";
-  if (suffix.indexOf("?version") >= 0) {
-    restUrl = suffix + "&apiVersion=" + restApiVersion;
+  if (suffix.indexOf("?version=") >= 0) {
+    const suffixAndVersion = suffix.split("?version=")
+    restUrl = "version=" + suffixAndVersion[1] + "&apiversion=" + restApiVersion + "#" +  suffixAndVersion[0];
   } else {
-    restUrl = suffix + "version=master&apiVersion=" + restApiVersion;
+    restUrl = "version=master&apiversion=" + restApiVersion + "#" + suffix;
   }
   return {
     text: method + " " + path,
-    link: restBaseUrl + "#" + restUrl,
+    link: restBaseUrl + "?" + restUrl,
   };
 };
 


### PR DESCRIPTION
fixes- https://github.com/apache/pulsar/issues/14928.

Now the rest-api website url is: 
https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/healthcheck

But we generate the url is: 
https://pulsar.apache.org/admin-rest-api#operation/getActiveBrokers?version=@pulsar:version_number@&apiVersion=v2

We should generate the link to match rest api url.