### PR TITLE
Fix Website Trademark Attribution

### DIFF
--- a/site2/website-next/docusaurus.config.js
+++ b/site2/website-next/docusaurus.config.js
@@ -338,7 +338,7 @@ module.exports = {
         },
       ],
       copyright: `<p>Apache Pulsar is available under the Apache License, version 2.0.</p>
-      <p>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. All Rights Reserved. Apache, Apache Pulsar and the Apache feather logo are trademarks of The Apache Software Foundation.</p>`,
+      <p>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. All Rights Reserved. Apache, Pulsar, Apache Pulsar, and the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.</p>`,
     },
     prism: {
       // theme: lightCodeTheme,


### PR DESCRIPTION
We need to make clear that Pulsar is a trademark of the ASF.