### PR TITLE
Use ® and ™ on first use of Apache and Pulsar

### DIFF
--- a/site2/website-next/src/pages/index.js
+++ b/site2/website-next/src/pages/index.js
@@ -165,7 +165,7 @@ export default function Home() {
             <div className="md:float-left md:w-2/3">
               <h1>Cloud-Native, Distributed Messaging and Streaming</h1>
               <p>
-                Apache Pulsar is a distributed, open source pub-sub messaging
+                Apache® Pulsar™ is a distributed, open source pub-sub messaging
                 and streaming platform for real-time workloads, managing
                 hundreds of billions of events per day.
               </p>


### PR DESCRIPTION
We should properly attribute the trademarks for Apache® Pulsar™ on first use