### PR TITLE
Fix tab highlighting error

### DIFF
--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -1258,6 +1258,7 @@ div[role="tabpanel"] {
   padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
 }
 
-.tabs-container>.margin-vert--md {
+.tabs-container>.margin-vert--md
+.tabs-container>.margin-top--md {
   margin-top: 0 !important;
 }


### PR DESCRIPTION
Something's different between local `yarn start` site and published site and I haven't figured out why. Hopefully this temporary fix will resolve the style error in tab highlighting.