### PR TITLE
Fix replace script for clientVersionUrls

### DIFF
--- a/site2/website-next/scripts/replace.js
+++ b/site2/website-next/scripts/replace.js
@@ -95,9 +95,9 @@ function clientVersionUrl(version, type) {
   var majorVersion = parseInt(versions[0])
   var minorVersion = parseInt(versions[1])
   if ((majorVersion === 2 && minorVersion < 5) || (type === "python" && minorVersion >= 7)) {
-    return `${siteConfig.url}/api/${type}/${version}`;
+    return `(${siteConfig.url}/api/${type}/${version}`;
   } else if (majorVersion >= 2 && minorVersion >= 5) {
-    return `${siteConfig.url}/api/${type}/${majorVersion}.${minorVersion}.0-SNAPSHOT`
+    return `(${siteConfig.url}/api/${type}/${majorVersion}.${minorVersion}.0-SNAPSHOT`
   }
 }
 


### PR DESCRIPTION
In https://github.com/apache/pulsar-site/pull/138, I forgot to add the `(` to the replaced string. Without the right paren, the links were rendering incorrectly on the website. This PR fixes those links.