### PR TITLE
Remove locales we don't support yet

### DIFF
--- a/site2/website-next/scripts/split-version-build.sh
+++ b/site2/website-next/scripts/split-version-build.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 node scripts/split-version.js
 
-locals=("en" "zh-CN" "zh-TW" "ja" "ko" "fr")
+locals=("en" "zh-CN")
 latest=$(cat scripts/.latest)
 BUILD_ALL_LANGUAGE="0"
 buildVersion="next"
@@ -22,7 +22,7 @@ function _build() {
 function _buildVersion() {
     if [[ $buildVersion = "next" ]]; then
         echo "..." ${buildVersion} "and" $latest" begin build..."
-        echo "[\"en\", \"zh-CN\", \"zh-TW\", \"ja\", \"fr\", \"ko\"]" >./.build-languages.json
+        echo "[\"en\", \"zh-CN\"]" >./.build-languages.json
         echo "[\"current\", \"${latest}\"]" >.build-versions.json
     else
         echo "..." $buildVersion "begin build..."

--- a/site2/website-next/scripts/write-redirect.js
+++ b/site2/website-next/scripts/write-redirect.js
@@ -5,7 +5,7 @@ const mkdirp = require("mkdirp");
 let versions = require("../versions.json");
 const latestVersion = versions[0];
 versions.push("next");
-const locales = ["en", "zh-CN", "zh-TW", "ja", "ko", "fr"];
+const locales = ["en", "zh-CN"];
 
 function _template(locale, version, docsId) {
   locale = locale == "en" ? "" : "/" + locale;


### PR DESCRIPTION
Otherwise when a user change the language but found the result is just English, it's not a good experience.

If we don't support it, we don't mention it. We can always add them back when there is real translated contents.