### PR TITLE
[BLOG] Add a blog to the website

### DIFF
--- a/site2/website-next/data/resources.js
+++ b/site2/website-next/data/resources.js
@@ -1,6 +1,14 @@
 module.exports = {
   articles: [
   {
+      forum: 'StreamNative Blog',
+      forum_link: 'https://streamnative.io/blogs/',
+      date: 'August 2022',
+      title: "Troubleshooting and Optimization: Managing Pulsar Clusters with over 100 Billion Messages Daily",
+      link: 'https://streamnative.io/blog/case/2022-08-18-client-optimization-how-tencent-maintains-apache-pulsar-clusters-with-over-100-billion-messages-daily/',
+      tags: 'Pulsar, troubleshooting, optimization, best practices'
+    },
+    {
       forum: 'DZone',
       forum_link: 'https://dzone.com/',
       date: 'August 2022',


### PR DESCRIPTION
Add a blog to the Pulsar website. Two engineers from Tencent contributed it to the community. It talks about optimization and troubleshooting tips for managing large Pulsar clusters.

Preview image:
![image](https://user-images.githubusercontent.com/65327072/185284349-292d58d7-9382-4e80-b269-82dd6e40345a.png)
