### PR TITLE
Adding 2.7.0 and 2.6.0 to the all releases page.

### DIFF
--- a/site2/website-next/release-notes/all.md
+++ b/site2/website-next/release-notes/all.md
@@ -14,9 +14,9 @@ slug: /
 #### 2.8.x
 [2.8.3](/release-notes/versioned/pulsar-2.8.3)&ensp;&ensp;[2.8.2](/release-notes/versioned/pulsar-2.8.2)&ensp;&ensp;[2.8.1](/release-notes/versioned/pulsar-2.8.1)&ensp;&ensp;[2.8.0](/release-notes/versioned/pulsar-2.8.0)&ensp;&ensp;  
 #### 2.7.x
-[2.7.4](/release-notes/versioned/pulsar-2.7.4)&ensp;&ensp;[2.7.3](/release-notes/versioned/pulsar-2.7.3)&ensp;&ensp;[2.7.2](/release-notes/versioned/pulsar-2.7.2)&ensp;&ensp;[2.7.1](/release-notes/versioned/pulsar-2.7.1)&ensp;&ensp;  
+[2.7.4](/release-notes/versioned/pulsar-2.7.4)&ensp;&ensp;[2.7.3](/release-notes/versioned/pulsar-2.7.3)&ensp;&ensp;[2.7.2](/release-notes/versioned/pulsar-2.7.2)&ensp;&ensp;[2.7.1](/release-notes/versioned/pulsar-2.7.1)&ensp;&ensp;[2.7.0](/release-notes/versioned/pulsar-2.7.0)&ensp;&ensp;  
 #### 2.6.x
-[2.6.4](/release-notes/versioned/pulsar-2.6.4)&ensp;&ensp;[2.6.3](/release-notes/versioned/pulsar-2.6.3)&ensp;&ensp;[2.6.2](/release-notes/versioned/pulsar-2.6.2)&ensp;&ensp;[2.6.1](/release-notes/versioned/pulsar-2.6.1)&ensp;&ensp;  
+[2.6.4](/release-notes/versioned/pulsar-2.6.4)&ensp;&ensp;[2.6.3](/release-notes/versioned/pulsar-2.6.3)&ensp;&ensp;[2.6.2](/release-notes/versioned/pulsar-2.6.2)&ensp;&ensp;[2.6.1](/release-notes/versioned/pulsar-2.6.1)&ensp;&ensp;[2.6.0](/release-notes/versioned/pulsar-2.6.0)&ensp;&ensp;  
 #### 2.5.x
 [2.5.2](/release-notes/versioned/pulsar-2.5.2)&ensp;&ensp;[2.5.1](/release-notes/versioned/pulsar-2.5.1)&ensp;&ensp; [2.5.0](/release-notes/versioned/pulsar-2.5.0)&ensp;&ensp;
 


### PR DESCRIPTION
The individual release notes are available as below while they are not indexed at https://pulsar.apache.org/release-notes/.

https://pulsar.apache.org/release-notes/versioned/pulsar-2.7.0/
https://pulsar.apache.org/release-notes/versioned/pulsar-2.6.0/