### PR TITLE
Make generated python docs go to website-next directory

### DIFF
--- a/site2/tools/api/python/generate-python-client-docs.sh
+++ b/site2/tools/api/python/generate-python-client-docs.sh
@@ -27,4 +27,4 @@ python -m pip install --upgrade pip
 
 pip install pdoc
 pip install pulsar-client==${PULSAR_VERSION}
-pdoc pulsar -o /pulsar/site2/website/static/api/python/${PULSAR_VERSION}
+pdoc pulsar -o /pulsar/site2/website-next/static/api/python/${PULSAR_VERSION}


### PR DESCRIPTION
Put generated python docs into the `website-next` directory, as @tisonkun explains in this comment https://github.com/apache/pulsar-site/pull/182#issuecomment-1230199254.