### PR TITLE
style: improve table css style

### DIFF
--- a/site2/website-next/src/components/CommonTable.js
+++ b/site2/website-next/src/components/CommonTable.js
@@ -16,7 +16,7 @@ export default function VersionsTable(props) {
           {props.header.map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -31,7 +31,7 @@ export default function VersionsTable(props) {
                 <TableCell
                   key={key}
                   className="border-gray-300"
-                  sx={{ border: 1 }}
+                  sx={{ border: 1, color: "inherit" }}
                   align="left"
                 >
                   {(() => {

--- a/site2/website-next/src/components/ConnectorTable.js
+++ b/site2/website-next/src/components/ConnectorTable.js
@@ -16,7 +16,7 @@ export default function VersionsTable(props) {
           {["IO connector", "Archive", "Crypto files"].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -28,7 +28,7 @@ export default function VersionsTable(props) {
           <TableRow key={index}>
             <TableCell
               className="border-gray-300"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Link

--- a/site2/website-next/src/components/GuideTable.js
+++ b/site2/website-next/src/components/GuideTable.js
@@ -15,8 +15,8 @@ export default function VersionsTable(props) {
         <TableRow key="header">
           {["Client guide", "API docs"].map((header) => (
             <TableCell
-              className="border-gray-300 font-bold text-black"
-              sx={{ border: 1 }}
+              className="border-gray-300 font-bold"
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -28,7 +28,7 @@ export default function VersionsTable(props) {
           <TableRow key={index}>
             <TableCell
               className="border-gray-300"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Link
@@ -42,7 +42,7 @@ export default function VersionsTable(props) {
             </TableCell>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               {row.description}

--- a/site2/website-next/src/components/MailTable.js
+++ b/site2/website-next/src/components/MailTable.js
@@ -16,7 +16,7 @@ export default function VersionsTable(props) {
           {["Name", "Scope", "", "", ""].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -28,21 +28,21 @@ export default function VersionsTable(props) {
           <TableRow key={index}>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               {row.email}
             </TableCell>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               {row.desc}
             </TableCell>
             <TableCell
               className="border-gray-300"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Link
@@ -56,7 +56,7 @@ export default function VersionsTable(props) {
             </TableCell>
             <TableCell
               className="border-gray-300"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Link
@@ -70,7 +70,7 @@ export default function VersionsTable(props) {
             </TableCell>
             <TableCell
               className="border-gray-300"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Link

--- a/site2/website-next/src/components/OldReleaseTable.js
+++ b/site2/website-next/src/components/OldReleaseTable.js
@@ -16,7 +16,7 @@ export default function VersionsTable(props) {
           {["Release", "Binary", "Source", "Release notes"].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -28,7 +28,7 @@ export default function VersionsTable(props) {
           <TableRow key={index}>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Translate>{row.release}</Translate>

--- a/site2/website-next/src/components/ReleaseTable.js
+++ b/site2/website-next/src/components/ReleaseTable.js
@@ -16,7 +16,7 @@ export default function VersionsTable(props) {
           {["Release", "Link", "Crypto files"].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
               key={header}
             >
@@ -28,7 +28,7 @@ export default function VersionsTable(props) {
           <TableRow key={row.release}>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <Translate>{row.release}</Translate>

--- a/site2/website-next/src/components/TeamTable.js
+++ b/site2/website-next/src/components/TeamTable.js
@@ -14,7 +14,7 @@ export default function VersionsTable(props) {
       <TableHead>
         <TableRow>
           {["Name", "Apache Id"].map(header => (
-            <TableCell className="font-bold" sx={{ border: 0 }} key={header}>
+            <TableCell className="font-bold" sx={{ border: 0, color: "inherit" }} key={header}>
               <Translate>{header}</Translate>
             </TableCell>
           ))}
@@ -23,8 +23,8 @@ export default function VersionsTable(props) {
       <TableBody>
         {props.data.map((row, index) => (
           <TableRow key={index}>
-            <TableCell sx={{ border: 0 }}>{row.name}</TableCell>
-            <TableCell sx={{ border: 0 }}>{row.apacheId}</TableCell>
+            <TableCell sx={{ border: 0 , color: "inherit" }}>{row.name}</TableCell>
+            <TableCell sx={{ border: 0 , color: "inherit" }}>{row.apacheId}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/site2/website-next/src/components/VersionsTable.js
+++ b/site2/website-next/src/components/VersionsTable.js
@@ -23,7 +23,7 @@ export default function VersionsTable(props) {
           <TableRow key={row.name}>
             <TableCell
               className="border-gray-300 font-bold"
-              sx={{ border: 1 }}
+              sx={{ border: 1, color: "inherit" }}
               align="left"
             >
               <span>{row.name}</span>

--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -92,7 +92,7 @@ table tr {
   background-color: transparent;
 }
 html[data-theme="dark"] table tr {
-  background-color: white;
+  background-color: initial;
 }
 
 .docusaurus-highlight-code-line {
@@ -391,11 +391,6 @@ div[class^="searchBox_"] {
 
 .markdown table tbody {
   overflow-wrap: anywhere;
-}
-
-html[data-theme="dark"] .markdown table td,
-html[data-theme="dark"] .markdown table th {
-  color: #333;
 }
 
 .waves-bg:before,
@@ -928,8 +923,13 @@ html[data-theme="dark"] .featured-card--inner {
 }
 
 table tr:nth-child(2n) {
-  background-color: #fff;
+  background-color: initial;
 }
+
+html[data-theme="dark"] table tr:nth-child(2n) {
+  background-color: initial;
+}
+
 .blog-wrapper .main-wrapper.blog-list-page::before {
   content: "Pulsar Blog";
   position: relative;


### PR DESCRIPTION
Fix #173 

Two style improvements:

**1. Improve dark mode table view:**

Original:

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/37220920/187413231-71732844-72f6-4149-91a4-b6a0a4736cb9.png">

Improved:

<img width="1917" alt="image" src="https://user-images.githubusercontent.com/37220920/187413331-63ecbd09-ad5f-48ef-8f40-b239007cbdca.png">

**2. Improve light mode table view:**

Original:

<img width="782" alt="image" src="https://user-images.githubusercontent.com/37220920/187405083-b9672955-fae9-4ae8-b875-5c84ba98b9fd.png">

Improved:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/37220920/187404911-910f24a2-ec43-4fa3-b764-d2cf9642df94.png">

BTW, this PR reverts some changes of #181. Because PR 181 fixes some font styles, I revert them to make style self-adaption.