### PR TITLE
Improve doc gen scripts

### DIFF
--- a/.github/workflows/ci-pulsar-website-next-build.yaml
+++ b/.github/workflows/ci-pulsar-website-next-build.yaml
@@ -103,7 +103,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.NEXT_CROWDIN_DOCUSAURUS_API_TOKEN }}
-          VERSION: latest
         run: |
           echo "Building Website"
           sed -i "s#CROWDIN_PERSONAL_TOKEN#$CROWDIN_PERSONAL_TOKEN#g" site2/website-next/crowdin.yml

--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -29,6 +29,7 @@ if [ -n "$NEXT" ]; then
 fi
 TOOLS_DIR=${ROOT_DIR}/site2/tools
 GEN_SITE_DIR=${ROOT_DIR}/generated-site
+VERSION=latest
 
 function workaround_crowdin_problem_by_copying_files() {
   # TODO: remove this after figuring out why crowdin removed code tab when generating translated files
@@ -69,8 +70,8 @@ EOF
 set -x -e
 
 export NODE_OPTIONS="--max-old-space-size=16000"
-$TOOLS_DIR/generate-api-docs.sh
-cd $WEBSITE_DIR
+"$TOOLS_DIR"/generate-api-docs.sh
+cd "$WEBSITE_DIR"
 
 npm install
 
@@ -88,25 +89,25 @@ else
 fi
 
 # Generate document for command line tools.
-$TOOLS_DIR/pulsar-admin-doc-gen.sh $WEBSITE_DIR $VERSION
-$TOOLS_DIR/pulsar-client-doc-gen.sh $WEBSITE_DIR $VERSION
-$TOOLS_DIR/pulsar-perf-doc-gen.sh $WEBSITE_DIR $VERSION
-$TOOLS_DIR/pulsar-doc-gen.sh $WEBSITE_DIR $VERSION
-$TOOLS_DIR/pulsar-config-doc-gen.sh $WEBSITE_DIR $VERSION
-cd $WEBSITE_DIR
+"$TOOLS_DIR"/pulsar-admin-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
+"$TOOLS_DIR"/pulsar-client-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
+"$TOOLS_DIR"/pulsar-perf-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
+"$TOOLS_DIR"/pulsar-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
+"$TOOLS_DIR"/pulsar-config-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
+cd "$WEBSITE_DIR"
 
-mkdir -p $GEN_SITE_DIR/reference
-cp -r docsify/* $GEN_SITE_DIR/reference
+mkdir -p "$GEN_SITE_DIR"/reference
+cp -r docsify/* "$GEN_SITE_DIR"/reference
 
-CONTENT_DIR=$GEN_SITE_DIR/content
+CONTENT_DIR="$GEN_SITE_DIR"/content
 
-rm -rf $CONTENT_DIR
-mkdir -p $CONTENT_DIR
-cp -R $GEN_SITE_DIR/reference $CONTENT_DIR
-cp -R $GEN_SITE_DIR/api $CONTENT_DIR
+rm -rf "$CONTENT_DIR"
+mkdir -p "$CONTENT_DIR"
+cp -R "$GEN_SITE_DIR"/reference "$CONTENT_DIR"
+cp -R "$GEN_SITE_DIR"/api "$CONTENT_DIR"
 if [ -n "$NEXT" ]; then
-  cp -R ./build/* $CONTENT_DIR
+  cp -R ./build/* "$CONTENT_DIR"
 else
-  cp -R ./build/pulsar/* $CONTENT_DIR
+  cp -R ./build/pulsar/* "$CONTENT_DIR"
 fi
-cp -R $WEBSITE_DIR/static/swagger/* $CONTENT_DIR/swagger/
+cp -R "$WEBSITE_DIR"/static/swagger/* "$CONTENT_DIR"/swagger/

--- a/site2/tools/pulsar-admin-doc-gen.sh
+++ b/site2/tools/pulsar-admin-doc-gen.sh
@@ -31,5 +31,5 @@ COMMANDS="broker-stats brokers bookies clusters functions functions-worker names
 
 for CMD in $COMMANDS
 do
-    $DOC_GEN $CMD > $DOCS_DIR/$CMD.md
+    $DOC_GEN "$CMD" > "$DOCS_DIR/$CMD".md
 done

--- a/site2/tools/pulsar-client-doc-gen.sh
+++ b/site2/tools/pulsar-client-doc-gen.sh
@@ -25,6 +25,6 @@ WEBSITE=$1
 VERSION=$2
 DOCS_DIR=$WEBSITE/docsify/$VERSION/pulsar-client
 
-$ROOT_DIR/bin/pulsar-client generate_documentation > $DOCS_DIR/pulsar-client.md
+"$ROOT_DIR"/bin/pulsar-client generate_documentation > "$DOCS_DIR"/pulsar-client.md
 
 

--- a/site2/tools/pulsar-config-doc-gen.sh
+++ b/site2/tools/pulsar-config-doc-gen.sh
@@ -38,17 +38,17 @@ CLIENT_CONF=org.apache.pulsar.client.impl.conf
 GEN_DOCS_CLIENT=$CLIENT_CONF.CmdGenerateDocumentation
 
 # config doc gen
-cp $WEBSITE/docs/reference-configuration*.md $DOCS_DIR
+cp "$WEBSITE"/docs/reference-configuration*.md "$DOCS_DIR"
 
-$JAVA -cp "$(cat $f)" $GEN_DOCS_BROKER -c org.apache.pulsar.broker.ServiceConfiguration > $DOCS_DIR/reference-configuration-broker.md
-$JAVA -cp "$(cat $f)" $GEN_DOCS_BROKER -c org.apache.pulsar.client.impl.conf.ClientConfigurationData > $DOCS_DIR/reference-configuration-client.md
-$JAVA -cp "$(cat $f)" $GEN_DOCS_BROKER -c org.apache.pulsar.websocket.service.WebSocketProxyConfiguration > $DOCS_DIR/reference-configuration-websocket.md
-$JAVA -cp "$(cat $f)" $GEN_DOCS_PROXY -c org.apache.pulsar.proxy.server.ProxyConfiguration > $DOCS_DIR/reference-configuration-pulsar-proxy.md
+$JAVA -cp "$(cat "$f")" $GEN_DOCS_BROKER -c org.apache.pulsar.broker.ServiceConfiguration > "$DOCS_DIR"/reference-configuration-broker.md
+$JAVA -cp "$(cat "$f")" $GEN_DOCS_BROKER -c org.apache.pulsar.client.impl.conf.ClientConfigurationData > "$DOCS_DIR"/reference-configuration-client.md
+$JAVA -cp "$(cat "$f")" $GEN_DOCS_BROKER -c org.apache.pulsar.websocket.service.WebSocketProxyConfiguration > "$DOCS_DIR"/reference-configuration-websocket.md
+$JAVA -cp "$(cat "$f")" $GEN_DOCS_PROXY -c org.apache.pulsar.proxy.server.ProxyConfiguration > "$DOCS_DIR"/reference-configuration-pulsar-proxy.md
 
-cp $DOCS_DIR/reference-configuration-broker.md $DOCS_DIR/reference-configuration-standalone.md
+cp "$DOCS_DIR"/reference-configuration-broker.md "$DOCS_DIR"/reference-configuration-standalone.md
 
 # client config doc gen
-$JAVA -cp $CLIENT_CP:"$(cat $f)" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ClientConfigurationData > $CLIENT_DIR/client-configuration-client.md
-$JAVA -cp $CLIENT_CP:"$(cat $f)" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ProducerConfigurationData > $CLIENT_DIR/client-configuration-producer.md
-$JAVA -cp $CLIENT_CP:"$(cat $f)" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ConsumerConfigurationData > $CLIENT_DIR/client-configuration-consumer.md
-$JAVA -cp $CLIENT_CP:"$(cat $f)" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ReaderConfigurationData > $CLIENT_DIR/client-configuration-reader.md
+$JAVA -cp "$CLIENT_CP:$(cat "$f")" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ClientConfigurationData > "$CLIENT_DIR"/client-configuration-client.md
+$JAVA -cp "$CLIENT_CP:$(cat "$f")" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ProducerConfigurationData > "$CLIENT_DIR"/client-configuration-producer.md
+$JAVA -cp "$CLIENT_CP:$(cat "$f")" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ConsumerConfigurationData > "$CLIENT_DIR"/client-configuration-consumer.md
+$JAVA -cp "$CLIENT_CP:$(cat "$f")" $GEN_DOCS_CLIENT -c $CLIENT_CONF.ReaderConfigurationData > "$CLIENT_DIR"/client-configuration-reader.md

--- a/site2/tools/pulsar-doc-gen.sh
+++ b/site2/tools/pulsar-doc-gen.sh
@@ -27,18 +27,18 @@ DOCS_DIR=$WEBSITE/docsify/$VERSION/pulsar
 
 PULSAR="$ROOT_DIR/bin/pulsar"
 
-$PULSAR broker -g > $DOCS_DIR/broker.md
-$PULSAR broker-tool gen-doc > $DOCS_DIR/broker-tool.md
-$PULSAR compact-topic -t tmp -g > $DOCS_DIR/compact-topic.md
-$PULSAR tokens gen-doc > $DOCS_DIR/tokens.md
-$PULSAR proxy -g > $DOCS_DIR/proxy.md
-$PULSAR functions-worker -g > $DOCS_DIR/functions-worker.md
-$PULSAR standalone -g > $DOCS_DIR/standalone.md
-$PULSAR initialize-cluster-metadata -cs cs -uw uw -zk zk -c c -g > $DOCS_DIR/initialize-cluster-metadata.md
-$PULSAR delete-cluster-metadata -zk zk -g > $DOCS_DIR/delete-cluster-metadata.md
-$PULSAR initialize-transaction-coordinator-metadata -cs cs -c c -g > $DOCS_DIR/initialize-transaction-coordinator-metadata.md
-$PULSAR initialize-namespace -cs cs -c c -g demo > $DOCS_DIR/initialize-namespace.md
-$PULSAR version -g > $DOCS_DIR/version.md
-$PULSAR websocket -g > $DOCS_DIR/websocket.md
+$PULSAR broker -g > "$DOCS_DIR"/broker.md
+$PULSAR broker-tool gen-doc > "$DOCS_DIR"/broker-tool.md
+$PULSAR compact-topic -t tmp -g > "$DOCS_DIR"/compact-topic.md
+$PULSAR tokens gen-doc > "$DOCS_DIR"/tokens.md
+$PULSAR proxy -g > "$DOCS_DIR"/proxy.md
+$PULSAR functions-worker -g > "$DOCS_DIR"/functions-worker.md
+$PULSAR standalone -g > "$DOCS_DIR"/standalone.md
+$PULSAR initialize-cluster-metadata -cs cs -uw uw -zk zk -c c -g > "$DOCS_DIR"/initialize-cluster-metadata.md
+$PULSAR delete-cluster-metadata -zk zk -g > "$DOCS_DIR"/delete-cluster-metadata.md
+$PULSAR initialize-transaction-coordinator-metadata -cs cs -c c -g > "$DOCS_DIR"/initialize-transaction-coordinator-metadata.md
+$PULSAR initialize-namespace -cs cs -c c -g demo > "$DOCS_DIR"/initialize-namespace.md
+$PULSAR version -g > "$DOCS_DIR"/version.md
+$PULSAR websocket -g > "$DOCS_DIR"/websocket.md
 
 

--- a/site2/tools/pulsar-perf-doc-gen.sh
+++ b/site2/tools/pulsar-perf-doc-gen.sh
@@ -25,7 +25,7 @@ WEBSITE=$1
 VERSION=$2
 DOCS_DIR=$WEBSITE/docsify/$VERSION/pulsar-perf
 
-$ROOT_DIR/bin/pulsar-perf gen-doc > $DOCS_DIR/pulsar-perf.md
+"$ROOT_DIR"/bin/pulsar-perf gen-doc > "$DOCS_DIR"/pulsar-perf.md
 
 
 


### PR DESCRIPTION
Add double quote to shell variables and add `VERSION` env variable to `build-site.sh`.