### PR TITLE
Merge pulsar-site issues to the main repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,6 @@
 github:
   description: "Apache Pulsar Site"
   homepage: https://pulsar.apache.org/
-  features:
-    issues: true
   enabled_merge_buttons:
     squash:  true
     merge:   false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,10 @@
 github:
   description: "Apache Pulsar Site"
   homepage: https://pulsar.apache.org/
+  features:
+    issues: false
+    projects: false
+    wiki: false
   enabled_merge_buttons:
     squash:  true
     merge:   false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Apache Pulsar Site
 
 This repository will be used to store the generated Apache Pulsar website in the asf-site-next branch.
+
+## Contact Us
+
+* Submit [an issue](https://github.com/apache/pulsar/issues/new) on the [main repo](http://github.com/apache/pulsar)
+* Send an email to the [dev mailing list](mailto:dev@pulsar.apache.org) ([subscribe](mailto:dev-subscribe@pulsar.apache.org))
+* Ask on the [#contributors channel on Pulsar Slack](https://apache-pulsar.slack.com/channels/contributors) ([join](https://pulsar.apache.org/community#section-discussions))


### PR DESCRIPTION
This is proposed by @Anonymitaet at https://github.com/apache/pulsar-site/issues/173#issuecomment-1225320929.

Before we merge this PR, a committer should be involved to transfer all existing issues to the `apache/pulsar` repo.

cc @Anonymitaet @urfreespace @lhotari @michaeljmarshall @dave2wave