### PR TITLE
Add back release notes of 2.8.4

### DIFF
--- a/site2/website-next/data/release-cpp.js
+++ b/site2/website-next/data/release-cpp.js
@@ -24,6 +24,12 @@ module.exports = [
   "doc": "https://pulsar.apache.org/docs/2.9.x/client-libraries-cpp"
 },
 {
+  "tagName": "v2.8.4",
+  "vtag": "2.8.x",
+  "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-cpp-2.8.4/",
+  "doc": "https://pulsar.apache.org/docs/2.8.x/client-libraries-cpp"
+},
+{
   "tagName": "v2.8.3",
   "vtag": "2.8.x",
   "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-cpp-2.8.3/",

--- a/site2/website-next/data/release-java.js
+++ b/site2/website-next/data/release-java.js
@@ -24,6 +24,12 @@ module.exports = [
   "doc": "https://pulsar.apache.org/docs/2.9.x/client-libraries-java"
 },
 {
+  "tagName": "v2.8.4",
+  "vtag": "2.8.x",
+  "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-java-2.8.4/",
+  "doc": "https://pulsar.apache.org/docs/2.8.x/client-libraries-java"
+},
+{
   "tagName": "v2.8.3",
   "vtag": "2.8.x",
   "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-java-2.8.3/",

--- a/site2/website-next/data/release-pulsar.js
+++ b/site2/website-next/data/release-pulsar.js
@@ -36,6 +36,15 @@ module.exports = [
   "doc": "https://pulsar.apache.org/docs/2.9.x"
 },
 {
+  "author": "BewareMyPower",
+  "tagName": "v2.8.4",
+  "publishedAt": "2022-09-13T21:27:18Z",
+  "vtag": "2.8.x",
+  "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/pulsar-2.8.4/",
+  "releaseBlog": "N/A",
+  "doc": "https://pulsar.apache.org/docs/2.8.x"
+},
+{
   "author": "michaeljmarshall",
   "tagName": "v2.8.3",
   "publishedAt": "2022-04-08T03:27:18Z",

--- a/site2/website-next/data/release-python.js
+++ b/site2/website-next/data/release-python.js
@@ -24,6 +24,12 @@ module.exports = [
   "doc": "https://pulsar.apache.org/docs/2.9.x/client-libraries-python"
 },
 {
+  "tagName": "v2.8.4",
+  "vtag": "2.8.x",
+  "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-python-2.8.4/",
+  "doc": "https://pulsar.apache.org/docs/2.8.x/client-libraries-python"
+},
+{
   "tagName": "v2.8.3",
   "vtag": "2.8.x",
   "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-python-2.8.3/",

--- a/site2/website-next/data/release-ws.js
+++ b/site2/website-next/data/release-ws.js
@@ -24,6 +24,12 @@ module.exports = [
   "doc": "https://pulsar.apache.org/docs/2.9.x/client-libraries-websocket"
 },
 {
+  "tagName": "v2.8.4",
+  "vtag": "2.8.x",
+  "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-websocket-2.8.4/",
+  "doc": "https://pulsar.apache.org/docs/2.8.x/client-libraries-websocket"
+},
+{
   "tagName": "v2.8.3",
   "vtag": "2.8.x",
   "releaseNotes": "https://pulsar.apache.org/release-notes/versioned/client-websocket-2.8.3/",


### PR DESCRIPTION
The release notes of 2.8.4 (added in https://github.com/apache/pulsar-site/pull/209) was lost after https://github.com/apache/pulsar-site/pull/227, this PR adds back them.

P.S. I don't know where can I get the `publishedAt` field in `release-pulsar.js` and I cannot found any instruction. IMO, adding a JSON block is harder than maintaining them in a Markdown document.

<img width="1109" alt="Screen Shot 2022-10-04 at 21 25 50" src="https://user-images.githubusercontent.com/18204803/193831413-15beca6c-f436-475a-81f6-ff34b6363489.png">

<img width="831" alt="Screen Shot 2022-10-04 at 21 16 54" src="https://user-images.githubusercontent.com/18204803/193830090-20e5c4f5-5692-4f5a-8387-61944106ea80.png">

<img width="1098" alt="Screen Shot 2022-10-04 at 21 17 18" src="https://user-images.githubusercontent.com/18204803/193830133-b4f8c17f-d963-4ede-8d30-040dbc498873.png">

<img width="1099" alt="Screen Shot 2022-10-04 at 21 17 05" src="https://user-images.githubusercontent.com/18204803/193830913-a2dd734e-11fc-495d-a565-c91f222c2b6d.png">

<img width="1087" alt="Screen Shot 2022-10-04 at 21 17 43" src="https://user-images.githubusercontent.com/18204803/193830152-64001aa3-590b-46e5-852a-3c51f576d27a.png">
