### PR TITLE
[fix] Concept link jump to the default version of doc

### DIFF
--- a/site2/website-next/docusaurus.config.js
+++ b/site2/website-next/docusaurus.config.js
@@ -162,8 +162,7 @@ module.exports = {
           position: "right",
           items: [
             {
-              type: "doc",
-              docId: "concepts-overview",
+              to: "/docs/concepts-overview",
               label: "Pulsar Concepts",
             },
             {


### PR DESCRIPTION
The `Pulsar Concepts` jumps to the next version document:

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/37220920/196325238-2421287c-e614-46a0-abec-e377f9c358ce.png">

But it should jump to the default version document as other buttons do.