### PR TITLE
Fix default VERSION error in build-site.sh

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -27,7 +27,7 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 WEBSITE_DIR=${ROOT_DIR}/site2/website-next
 TOOLS_DIR=${ROOT_DIR}/site2/tools
 GEN_SITE_DIR=${ROOT_DIR}/generated-site
-VERSION=latest
+VERSION=next
 
 export NODE_OPTIONS="--max-old-space-size=16000"
 "$TOOLS_DIR"/generate-api-docs.sh


### PR DESCRIPTION
`VERSION` in `build-site.sh` was set to `latest` by default, but it should be `next` now.