### PR TITLE
Fix release json gen script does not work

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -31,6 +31,10 @@ VERSION=latest
 
 export NODE_OPTIONS="--max-old-space-size=16000"
 "$TOOLS_DIR"/generate-api-docs.sh
+
+# Generate document for release table.
+"$TOOLS_DIR"/release-json-gen.sh "$GH_TOKEN" "$WEBSITE_DIR"
+
 cd "$WEBSITE_DIR"
 
 npm install
@@ -47,8 +51,6 @@ bash scripts/split-version-build.sh $@
 "$TOOLS_DIR"/pulsar-perf-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
 "$TOOLS_DIR"/pulsar-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
 "$TOOLS_DIR"/pulsar-config-doc-gen.sh "$WEBSITE_DIR" "$VERSION"
-# Generate document for release table.
-"$TOOLS_DIR"/release-json-gen.sh "$GH_TOKEN" "$WEBSITE_DIR"
 cd "$WEBSITE_DIR"
 
 CONTENT_DIR="$GEN_SITE_DIR"/content


### PR DESCRIPTION
This PR moves `release-json-gen.sh` upward so that it can actually take effect.