### PR TITLE
Workaround Docusaurus links issue 

### DIFF
--- a/site2/website-next/docs/client-libraries.md
+++ b/site2/website-next/docs/client-libraries.md
@@ -4,16 +4,20 @@ title: Pulsar client libraries
 sidebar_label: "Overview"
 ---
 
+````mdx-code-block
+import useBaseUrl from '@docusaurus/useBaseUrl';
+````
+
 Pulsar supports the following language-specific client libraries:
 
-| Language  | Documentation                                                          | Release note                                                                      | Code repo                                                             |
-| --------- |------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)   | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
-| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](/api/cpp/3.0.0) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
-| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)       | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
-| Go client | [User doc](client-libraries-go.md)                                     | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
-| Node.js   | [User doc](client-libraries-node.md)                                   | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                                 | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| Language  | Documentation                                                                                                      | Release note                                                                      | Code repo                                                             |
+| --------- |--------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)                                               | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> <a href={useBaseUrl('/api/cpp/3.0.0/')} target={"_blank"}>API doc</a> | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)                                     | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
+| Go client | [User doc](client-libraries-go.md)                                                                                 | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
+| Node.js   | [User doc](client-libraries-node.md)                                                                               | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
+| C#        | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 Pulsar supports the following language-agnostic client libraries:
 

--- a/site2/website-next/docs/client-libraries.md
+++ b/site2/website-next/docs/client-libraries.md
@@ -4,10 +4,6 @@ title: Pulsar client libraries
 sidebar_label: "Overview"
 ---
 
-````mdx-code-block
-import useBaseUrl from '@docusaurus/useBaseUrl';
-````
-
 Pulsar supports the following language-specific client libraries:
 
 | Language  | Documentation                                                                     | Release note                                                                      | Code repo                                                             |

--- a/site2/website-next/docs/client-libraries.md
+++ b/site2/website-next/docs/client-libraries.md
@@ -10,14 +10,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Pulsar supports the following language-specific client libraries:
 
-| Language  | Documentation                                                                                                      | Release note                                                                      | Code repo                                                             |
-| --------- |--------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)                                               | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
-| C++       | [User doc](client-libraries-cpp.md)    <br/> <a href={useBaseUrl('/api/cpp/3.0.0/')} target={"_blank"}>API doc</a> | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
-| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)                                     | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
-| Go client | [User doc](client-libraries-go.md)                                                                                 | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
-| Node.js   | [User doc](client-libraries-node.md)                                                                               | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| Language  | Documentation                                                                     | Release note                                                                      | Code repo                                                             |
+| --------- |-----------------------------------------------------------------------------------| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Java      | [User doc](client-libraries-java.md)   <br/> [API doc](/api/client/)              | [Bundled](/release-notes/)                                                        | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-client) |
+| C++       | [User doc](client-libraries-cpp.md)    <br/> [API doc](pathname:///api/cpp/3.0.0) | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar/pulsar-client-cpp)      |
+| Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)    | [Bundled](/release-notes/)                                                        | [Standalone](https://github.com/apache/pulsar-client-python)          |
+| Go client | [User doc](client-libraries-go.md)                                                | [Standalone](https://github.com/apache/pulsar-client-go/releases)                 | [Standalone](https://github.com/apache/pulsar-client-go)              |
+| Node.js   | [User doc](client-libraries-node.md)                                              | [Standalone](https://github.com/apache/pulsar-client-node/releases)               | [Standalone](https://github.com/apache/pulsar-client-node)            |
+| C#        | [User doc](client-libraries-dotnet.md)                                            | [Standalone](https://github.com/apache/pulsar-dotpulsar/blob/master/CHANGELOG.md) | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 Pulsar supports the following language-agnostic client libraries:
 

--- a/site2/website-next/scripts/replace.js
+++ b/site2/website-next/scripts/replace.js
@@ -173,7 +173,6 @@ const from = [
 
   /@pulsar:apidoc:python@/g,
   /@pulsar:apidoc:cpp@/g,
-  /\(\/api\/cpp/g,
   /\(\/api\/pulsar-functions/g,
   /\(\/api\/client/g,
   /\(\/api\/admin/g,
@@ -208,7 +207,6 @@ const options = {
 
     multiClientVersionUrl(`${latestVersion}`, "python"),
     multiClientVersionUrl(`${latestVersion}`, "cpp"),
-    `(${siteConfig.url}/api/cpp`,
     clientVersionUrl(`${latestVersion}`, "pulsar-functions"),
     clientVersionUrl(`${latestVersion}`, "client"),
     clientVersionUrl(`${latestVersion}`, "admin"),
@@ -253,7 +251,6 @@ for (let _v of versions) {
       debDistUrl(`${v}`, "-dev"),
       multiClientVersionUrl(`${v}`, "python"),
       multiClientVersionUrl(`${v}`, "cpp"),
-      `(${siteConfig.url}/api/cpp`,
       clientVersionUrl(`${v}`, "pulsar-functions"),
       clientVersionUrl(`${v}`, "client"),
       clientVersionUrl(`${v}`, "admin"),


### PR DESCRIPTION
Workaround Docusaurus links issue
    
Reported at https://github.com/facebook/docusaurus/issues/8344.
    
See also https://docusaurus.io/docs/static-assets#in-markdown. `require` causes:

```
Module not found: Error: Can't resolve './../static/api/cpp/3.0.0' in '/pulsar/site2/website-next/docs'
```