### PR TITLE
Add client config override

### DIFF
--- a/site2/website-next/static/reference/next/config/README.md
+++ b/site2/website-next/static/reference/next/config/README.md
@@ -1,1 +1,28 @@
-> Docs for Pulsar Configuration.
+## Pulsar configurations
+
+Pulsar offers several command-line tools that you can use for managing Pulsar installations, performance testing, using command-line producers and consumers, and more.
+
+You can manage Pulsar configurations through configuration files in the [`conf`](https://github.com/apache/pulsar/tree/master/conf) directory of a Pulsar installation.
+
+- [BookKeeper](/next/config/reference-configuration-bookkeeper/)
+- [Broker](/next/config/reference-configuration-broker/)
+- [Client](/next/config/reference-configuration-client/)
+- [Log4j](/next/config/reference-configuration-log4j/)
+- [Log4j shell](/next/config/reference-configuration-log4j-shell/)
+- [Standalone](/next/config/reference-configuration-standalone/)
+- [WebSocket](/next/config/reference-configuration-websocket/)
+- [Pulsar proxy](/next/config/reference-configuration-pulsar-proxy/)
+- [ZooKeeper](/next/config/reference-configuration-zookeeper/)
+
+### Override client configurations
+
+If you want to override the configurations of clients internal to brokers, websockets, and proxies, you can use the following prefix.
+
+|Prefix|Description|
+|---|---|
+|brokerClient_| Configure **all** the Pulsar Clients and Pulsar Admin Clients of brokers, websockets, and proxies. These configurations are applied after hard-coded configurations and before the client configurations named in this site.|
+|bookkeeper_| Configure the broker's BookKeeper clients used by managed ledgers and the BookkeeperPackagesStorage bookkeeper client. Takes precedence over most other configuration values.|
+
+> Notes:
+> * This override feature only applies to Pulsar 2.10.1 and later versions.
+> * When running the function worker within the broker, you have to configure those clients by using the `functions_worker.yml` file. These prefixed configurations do not apply to any of those clients.

--- a/site2/website-next/static/reference/next/config/README.md
+++ b/site2/website-next/static/reference/next/config/README.md
@@ -4,24 +4,24 @@ Pulsar offers several command-line tools that you can use for managing Pulsar in
 
 You can manage Pulsar configurations through configuration files in the [`conf`](https://github.com/apache/pulsar/tree/master/conf) directory of a Pulsar installation.
 
-- [BookKeeper](/next/config/reference-configuration-bookkeeper/)
-- [Broker](/next/config/reference-configuration-broker/)
-- [Client](/next/config/reference-configuration-client/)
-- [Log4j](/next/config/reference-configuration-log4j/)
-- [Log4j shell](/next/config/reference-configuration-log4j-shell/)
-- [Standalone](/next/config/reference-configuration-standalone/)
-- [WebSocket](/next/config/reference-configuration-websocket/)
-- [Pulsar proxy](/next/config/reference-configuration-pulsar-proxy/)
-- [ZooKeeper](/next/config/reference-configuration-zookeeper/)
+- [BookKeeper](/next/config/reference-configuration-bookkeeper)
+- [Broker](/next/config/reference-configuration-broker)
+- [Client](/next/config/reference-configuration-client)
+- [Log4j](/next/config/reference-configuration-log4j)
+- [Log4j shell](/next/config/reference-configuration-log4j-shell)
+- [Standalone](/next/config/reference-configuration-standalone)
+- [WebSocket](/next/config/reference-configuration-websocket)
+- [Pulsar proxy](/next/config/reference-configuration-pulsar-proxy)
+- [ZooKeeper](/next/config/reference-configuration-zookeeper)
 
 ### Override client configurations
 
 If you want to override the configurations of clients internal to brokers, websockets, and proxies, you can use the following prefix.
 
-|Prefix|Description|
-|---|---|
-|brokerClient_| Configure **all** the Pulsar Clients and Pulsar Admin Clients of brokers, websockets, and proxies. These configurations are applied after hard-coded configurations and before the client configurations named in this site.|
-|bookkeeper_| Configure the broker's BookKeeper clients used by managed ledgers and the BookkeeperPackagesStorage bookkeeper client. Takes precedence over most other configuration values.|
+| Prefix        | Description                                                                                                                                                                                                                  |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| brokerClient_ | Configure **all** the Pulsar Clients and Pulsar Admin Clients of brokers, websockets, and proxies. These configurations are applied after hard-coded configurations and before the client configurations named in this site. |
+| bookkeeper_   | Configure the broker's BookKeeper clients used by managed ledgers and the BookkeeperPackagesStorage bookkeeper client. Takes precedence over most other configuration values.                                                |
 
 > Notes:
 > * This override feature only applies to Pulsar 2.10.1 and later versions.


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/18490
1. Add back the configuration override information introduced in https://github.com/apache/pulsar/pull/15818 but missed on the new [Pulsar config](https://pulsar.apache.org/reference/#/next/config/) site.
2. Add an introductory paragraph in the parent config topic.

The preview looks good: 

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/60642177/202182740-1eb5437f-0952-4510-af88-af63165cbe5c.png">
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/60642177/202182777-6ba4b79c-6a98-4c60-977e-a91b9b864002.png">
