### PR TITLE
Fix gpg command in validate-release-candidate.md

### DIFF
--- a/site2/website-next/contribute/validate-release-candidate.md
+++ b/site2/website-next/contribute/validate-release-candidate.md
@@ -32,7 +32,7 @@ and place them in the `connectors` directory.
 Download the `*.asc` file and verify the GPG signature:
 
 ```bash
-gpg verify apache-pulsar-<release>-bin.tar.gz.asc
+gpg --verify apache-pulsar-<release>-bin.tar.gz.asc
 ```
 
 ### Validate Pub/Sub and Java Functions


### PR DESCRIPTION
The gpg command example in `validate-release-candidate` is wrong. This PR fixes it.