### PR TITLE
[fix] make font size consistent in table

### DIFF
--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -389,6 +389,10 @@ div[class^="searchBox_"] {
   font-size: 14px;
 }
 
+.markdown table td li {
+  font-size: 14px;
+}
+
 .markdown table tbody {
   overflow-wrap: anywhere;
 }

--- a/site2/website-next/src/css/custom.css
+++ b/site2/website-next/src/css/custom.css
@@ -389,7 +389,7 @@ div[class^="searchBox_"] {
   font-size: 14px;
 }
 
-.markdown table td li {
+.docs-doc-page .markdown table td li {
   font-size: 14px;
 }
 


### PR DESCRIPTION
Fixes: #18104

Before:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/37220920/204481334-8ef32677-87ec-4a3e-819e-80085954b7ef.png">

After:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/37220920/204481727-60e08a29-d532-4ab9-a733-583495858b9f.png">
