### PR TITLE
Add trailingslash for SiteMap URLs

### DIFF
--- a/site2/website-next/docusaurus.config.js
+++ b/site2/website-next/docusaurus.config.js
@@ -136,6 +136,7 @@ module.exports = {
     githubUrl,
     oldUrl,
   },
+  trailingSlash: true,
   themeConfig: {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     announcementBar: {


### PR DESCRIPTION
This closes https://github.com/apache/pulsar/issues/17899.

Reference: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap

cc @urfreespace I don't know whether this change causes unintentional breaking changes, please review.