### PR TITLE
[fix][doc] fix 404 URL

### DIFF
--- a/site2/website-next/contribute/develop-labels.md
+++ b/site2/website-next/contribute/develop-labels.md
@@ -11,7 +11,7 @@ After [PR-17693](https://github.com/apache/pulsar/pull/17693) merged, pull reque
 
 When a committer believe the PR is ready to test, they will label `ready-to-test` to the PR, and then you can rerun the CI tasks by commenting `/pulsarbot run-failure-checks` and trigger the full CI validation.
 
-See also [CI Testing in Fork](testing-and-ci/personal-ci.md).
+See also [CI Testing in Fork](personal-ci.md).
 
 ## doc-*
 


### PR DESCRIPTION
`[CI Testing in Fork](testing-and-ci/personal-ci.md)` is 404. 

This PR corrects it to `[CI Testing in Fork](personal-ci.md)`.

Preview looks good:
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/50226895/207017254-5d4c0f1d-4ce9-4e8c-8765-0df1f21a8282.png">
