### PR TITLE
Change link to Slack workspace auto-invite

### DIFF
--- a/site2/website-next/src/pages/community.js
+++ b/site2/website-next/src/pages/community.js
@@ -335,7 +335,7 @@ export default function Community(props) {
                     discussions to the issue tracking system and/or the dev
                     mailing list.
                   </p>
-                  <p>Not signed up? Use our Heroku App to self-register </p>
+                  <p>Not signed up? Use our Slack App to self-register </p>
                   <PillButton
                     variant=""
                     target="_blank"
@@ -346,7 +346,7 @@ export default function Community(props) {
                   <PillButton
                     variant="grey"
                     target="_blank"
-                    href="https://apache-pulsar.herokuapp.com/"
+                    href="https://communityinviter.com/apps/apache-pulsar/apache-pulsar"
                   >
                     PULSAR SLACK SIGN-UP
                   </PillButton>

--- a/site2/website-next/src/pages/contact.js
+++ b/site2/website-next/src/pages/contact.js
@@ -91,8 +91,8 @@ export default function page(props) {
 
           <p>
             <Translate>You can self-register at </Translate>{" "}
-            <a href="https://apache-pulsar.herokuapp.com/" target="_blank">
-              https://apache-pulsar.herokuapp.com/
+            <a href="https://communityinviter.com/apps/apache-pulsar/apache-pulsar" target="_blank">
+              https://communityinviter.com/apps/apache-pulsar/apache-pulsar
             </a>
           </p>
 

--- a/site2/website-next/src/pages/contributing.md
+++ b/site2/website-next/src/pages/contributing.md
@@ -74,7 +74,7 @@ do not require an associated issue.
 ### Online discussions
 
 We are using [Apache Pulsar Slack channel](https://apache-pulsar.slack.com/) for online discussions.
-You can self-invite yourself by accessing [this link](https://apache-pulsar.herokuapp.com/).
+You can self-invite yourself by accessing [this link](https://communityinviter.com/apps/apache-pulsar/apache-pulsar).
 
 Slack channels are great for quick questions or discussions on specialized topics. Remember that we
 strongly encourage communication via the mailing lists, and we prefer to discuss more complex subjects


### PR DESCRIPTION
The Heroku app that was being used to automate the Slack invite of new users has stopped working since Heroku has terminated the free tier.

I've added a new Slack app that does the email invite.