### PR TITLE
[fix][doc] Correct configuration requirements for the HDFS sinks

### DIFF
--- a/docs/io-hdfs2-sink.md
+++ b/docs/io-hdfs2-sink.md
@@ -26,8 +26,8 @@ The configuration of the HDFS2 sink connector has the following properties.
 | `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY<br /></li><li>ZSTANDARD</li>|
 | `kerberosUserPrincipal` |String| false| None|The principal account of Kerberos user used for authentication. |
 | `keytab` | String|false|None| The full pathname of the Kerberos keytab file used for authentication. |
-| `filenamePrefix` |String| true, if `compression` is set to `None`. | None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |
-| `fileExtension` | String| true | None | The extension added to the files written to HDFS.<br /><br />**Example**<br />'.txt'<br /> '.seq' |
+| `filenamePrefix` |String| true | None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |
+| `fileExtension` | String| true, if `compression` is set to `None`. | None | The extension added to the files written to HDFS.<br /><br />**Example**<br />'.txt'<br /> '.seq' |
 | `separator` | char|false |None |The character used to separate records in a text file. <br /><br />If no value is provided, the contents from all records are concatenated together in one continuous byte array. |
 | `syncInterval` | long| false |0| The interval between calls to flush data to HDFS disk in milliseconds. |
 | `maxPendingRecords` |int| false|Integer.MAX_VALUE |  The maximum number of records that hold in memory before acking. <br /><br />Setting this property to 1 makes every record send to disk before the record is acked.<br /><br />Setting this property to a higher value allows buffering records before flushing them to disk. 

--- a/docs/io-hdfs3-sink.md
+++ b/docs/io-hdfs3-sink.md
@@ -26,8 +26,8 @@ The configuration of the HDFS3 sink connector has the following properties.
 | `compression` | Compression |false |None |The compression code used to compress or de-compress the files on HDFS. <br /><br />Below are the available options:<br /><li>BZIP2<br /></li><li>DEFLATE<br /></li><li>GZIP<br /></li><li>LZ4<br /></li><li>SNAPPY<br /></li><li>ZSTANDARD</li>|
 | `kerberosUserPrincipal` |String| false| None|The principal account of Kerberos user used for authentication. |
 | `keytab` | String|false|None| The full pathname of the Kerberos keytab file used for authentication. |
-| `filenamePrefix` |String| false |None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |
-| `fileExtension` | String| false | None| The extension added to the files written to HDFS.<br /><br />**Example**<br />'.txt'<br /> '.seq' |
+| `filenamePrefix` |String| true |None |The prefix of the files created inside the HDFS directory.<br /><br />**Example**<br /> The value of topicA result in files named topicA-. |
+| `fileExtension` | String| true, if `compression` is set to `None`. | None| The extension added to the files written to HDFS.<br /><br />**Example**<br />'.txt'<br /> '.seq' |
 | `separator` | char|false |None |The character used to separate records in a text file. <br /><br />If no value is provided, the contents from all records are concatenated together in one continuous byte array. |
 | `syncInterval` | long| false |0| The interval between calls to flush data to HDFS disk in milliseconds. |
 | `maxPendingRecords` |int| false|Integer.MAX_VALUE |  The maximum number of records that hold in memory before acking. <br /><br />Setting this property to 1 makes every record send to disk before the record is acked.<br /><br />Setting this property to a higher value allows buffering records before flushing them to disk. 


### PR DESCRIPTION
[The HDFS2 sink documentation refers to the `filenamePrefix` configuration as "(Required) true, if compression is set to None"](https://pulsar.apache.org/docs/next/io-hdfs2-sink/#property), but [it's always required actually. Instead, either `fileExtension` or `compression` should be set at least](https://github.com/apache/pulsar/blob/master/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java#L96-L99).
[This behaviour is the same for HDFS3](https://github.com/apache/pulsar/blob/master/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkConfig.java#L86-L89
), so its documentation also should be fixed.

