### PR TITLE
[fix][doc] Fix JDK version for release process

### DIFF
--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -34,7 +34,7 @@ If you haven't already done it, [create and publish the GPG key](create-gpg-keys
 
 Before you start the next release steps, make sure you have installed these software:
 
-* JDK 17
+* JDK 11 (up to 2.10.x) or 17 (2.11+)
 * Maven 3.8.6
 * Zip
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -34,7 +34,7 @@ If you haven't already done it, [create and publish the GPG key](create-gpg-keys
 
 Before you start the next release steps, make sure you have installed these software:
 
-* JDK 11
+* JDK 17
 * Maven 3.8.6
 * Zip
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -34,7 +34,7 @@ If you haven't already done it, [create and publish the GPG key](create-gpg-keys
 
 Before you start the next release steps, make sure you have installed these software:
 
-* JDK 11 (up to 2.10.x) or 17 (2.11+)
+* JDK 17 (for Pulsar version >= 2.11) or JDK 11 (for earlier versions)
 * Maven 3.8.6
 * Zip
 


### PR DESCRIPTION
[The release process document says JDK 11 is required](https://pulsar.apache.org/contribute/release-process/#preparation), but 17 is supposed to be required for recent releases actually.