### PR TITLE
[blog] Add 2.10.3 release blog

### DIFF
--- a/blog/2022-07-12-Apache-Pulsar-2-10-1.md
+++ b/blog/2022-07-12-Apache-Pulsar-2-10-1.md
@@ -10,6 +10,7 @@ The highlight of the 2.10.1 release is introducing 30+ transaction fixes and imp
 
 This blog walks through the most noteworthy changes. For the complete list including all feature enhancements and bug fixes, check out the [Pulsar 2.10.1 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.10.1/).
 
+<!--truncate-->
 
 ### Fixed ineffective load manager due to broker’s zero resource usage. [PR-15314](https://github.com/apache/pulsar/pull/15314)
 

--- a/blog/2022-07-27-Apache-Pulsar-2-9-3.md
+++ b/blog/2022-07-27-Apache-Pulsar-2-9-3.md
@@ -10,6 +10,7 @@ The highlight of the 2.9.3 release is introducing 30+ transaction fixes and impr
 
 This blog walks through the most noteworthy changes. For the complete list including all feature enhancements and bug fixes, check out the [Pulsar 2.9.3 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.9.3/).
 
+<!--truncate-->
 
 ### Enabled cursor data compression to reduce persistent cursor data size. [14542](https://github.com/apache/pulsar/pull/14542)
 

--- a/blog/2022-09-09-Apache-Pulsar-2-7-5.md
+++ b/blog/2022-09-09-Apache-Pulsar-2-7-5.md
@@ -10,6 +10,8 @@ The highlight of the 2.7.5 release is that it fixes some critical bugs on broker
 
 This blog walks through the most noteworthy changes. For the complete list, including all feature enhancements and bug fixes, check out the [Pulsar 2.7.5 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.7.5/).
 
+<!--truncate-->
+
 ### Fixed the deadlock on metadata cache missing while checking replications. [PR-16889](https://github.com/apache/pulsar/pull/16889)
 
 #### Issue

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -43,7 +43,7 @@ In earlier versions, `BlockAwareSegmentInputStreamImpl` never releases the BookK
 In earlier versions, when you delete a namespace by force, if `__transaction_buffer_snapshot` and `__change_events` (system topic for topic policies) have been deleted, then the deletion of regular topics will fail because it cannot clear the snapshots and topic policies.
 
 #### Resolution
-Delete regular topics before deleting system topics when deleting a namesapce and does not clear the topic policies.
+Delete regular topics before deleting system topics when deleting a namesapce. And deleting the system topic `__change_events` does not clear its topic policy.
 
 # What’s Next?
 

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -8,6 +8,8 @@ The Apache Pulsar community releases version 2.10.3! 50 contributors provided im
 
 This blog walks through the most noteworthy changes. For the complete list including all feature enhancements and bug fixes, check out the [Pulsar 2.10.3 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.10.3/).
 
+<!--truncate-->
+
 ### Add `getState` in transactions for client APIs ([PR-17423](https://github.com/apache/pulsar/pull/17423))
 
 #### Issue

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -11,7 +11,7 @@ This blog walks through the most noteworthy changes. For the complete list inclu
 ### Add `getState` in transactions for client APIs ([PR-17423](https://github.com/apache/pulsar/pull/17423))
 
 #### Issue
-In earlier versions, the state of transactions on the client side cannot be obtained with the client APIs. Users have no way to check the state of transactions before ending them.
+In earlier versions, the state of transactions on the client side could not be obtained with the client APIs. Users have no way to check the state of transactions before ending them.
 
 #### Resolution
 Add an interface to get the state of transactions.
@@ -19,7 +19,7 @@ Add an interface to get the state of transactions.
 ### Enable delayed transaction messages ([PR-17548](https://github.com/apache/pulsar/pull/17548))
 
 #### Issue
-In earlier versions, delayed message delivery and transaction messages cannot be used simultaneously. When sending a transaction message with a certain delay and committing this transaction, the messages sent by transactions are immediately received by consumers without any expected delay.
+In earlier versions, delayed message delivery and transaction messages could not be used simultaneously. When sending a transaction message with a certain delay and committing this transaction, the messages sent by transactions are immediately received by consumers without any expected delay.
 
 #### Resolution
 Allow clients to send delayed messages with transactions using `trackDelayedDelivery`.

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -43,7 +43,7 @@ In earlier versions, `BlockAwareSegmentInputStreamImpl` never releases the BookK
 In earlier versions, when you delete a namespace by force, if `__transaction_buffer_snapshot` and `__change_events` (system topic for topic policies) have been deleted, then the deletion of regular topics will fail because it cannot clear the snapshots and topic policies.
 
 #### Resolution
-Delete regular topics before deleting system topics when deleting a namesapce. And deleting the system topic `__change_events` does not clear its topic policy.
+Delete regular topics before deleting system topics when deleting a namespace. And deleting the system topic `__change_events` does not clear its topic policy.
 
 # What’s Next?
 

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -1,0 +1,46 @@
+---
+title: "What’s New in Apache Pulsar 2.10.3"
+date: 2023-01-09
+author: "liangyepianzhou, momo-jun"
+---
+
+The Apache Pulsar community releases version 2.10.3! 50 contributors provided improvements and bug fixes that delivered 155 commits. Thanks for all your contributions.
+
+This blog walks through the most noteworthy changes. For the complete list including all feature enhancements and bug fixes, check out the [Pulsar 2.10.3 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.10.3/).
+
+### Add `getState` in transactions for client APIs ([PR-17423](https://github.com/apache/pulsar/pull/17423))
+
+#### Issue
+In earlier versions, the state of transactions on the client side cannot be obtained with the client APIs.
+
+#### Resolution
+Add an interface to get the state of transactions.
+
+### Enable delayed transaction messages ([PR-17548](https://github.com/apache/pulsar/pull/17548))
+
+#### Issue
+In earlier versions, delayed message delivery and transaction messages cannot be used simultaneously. When sending a transaction message with a certain delay and committing this transaction, the messages sent by transactions are immediately received by consumers without any expected delay.
+
+#### Resolution
+Allow clients to send delayed messages with transactions using `trackDelayedDelivery`.
+
+### Allow configuring and disabling the size of `lookahead` for detecting fixed delays in messages ([PR-17907](https://github.com/apache/pulsar/pull/17907))
+
+#### Issue
+In earlier versions, the size of `lookahead` is not allowed to be configured.
+
+#### Resolution
+Allow to configure and disable the size of `lookahead` for detecting fixed delays in messages.
+
+### Fix memory leak while offloading ledgers ([PR-18500](https://github.com/apache/pulsar/pull/18500))
+
+#### Issue
+In earlier versions, `BlockAwareSegmentInputStreamImpl` never releases the BookKeeper entries in the `close` method, leading to `OutOfDirectMemory` errors on brokers that frequently run offloading activities. This PR fixes the incorrect `if` conditions.
+
+# What’s Next?
+
+If you are interested in learning more about Pulsar 2.10.3, you can [download](https://pulsar.apache.org/download/) and try it out now! 
+
+For more information about the Apache Pulsar project and current progress, visit
+the [Pulsar website](https://pulsar.apache.org), follow the project on Twitter
+[@apache_pulsar](https://twitter.com/apache_pulsar), and join [Pulsar Slack](https://apache-pulsar.slack.com/)!

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -11,7 +11,7 @@ This blog walks through the most noteworthy changes. For the complete list inclu
 ### Add `getState` in transactions for client APIs ([PR-17423](https://github.com/apache/pulsar/pull/17423))
 
 #### Issue
-In earlier versions, the state of transactions on the client side cannot be obtained with the client APIs.
+In earlier versions, the state of transactions on the client side cannot be obtained with the client APIs. Users have no way to check the state of transactions before ending them.
 
 #### Resolution
 Add an interface to get the state of transactions.
@@ -27,15 +27,23 @@ Allow clients to send delayed messages with transactions using `trackDelayedDeli
 ### Allow configuring and disabling the size of `lookahead` for detecting fixed delays in messages ([PR-17907](https://github.com/apache/pulsar/pull/17907))
 
 #### Issue
-In earlier versions, the size of `lookahead` is not allowed to be configured.
+When detecting that all messages have a fixed delay time, it’s helpful that users can configure the size of `lookahead` to detect and pause the reads from cursors. But in earlier versions, the size of `lookahead is pre-defined and fixed, which lacks flexibility and limits the usage.
 
 #### Resolution
-Allow to configure and disable the size of `lookahead` for detecting fixed delays in messages.
+Allow configuring and disabling the size of `lookahead` for detecting fixed delays in messages.
 
 ### Fix memory leak while offloading ledgers ([PR-18500](https://github.com/apache/pulsar/pull/18500))
 
 #### Issue
 In earlier versions, `BlockAwareSegmentInputStreamImpl` never releases the BookKeeper entries in the `close` method, leading to `OutOfDirectMemory` errors on brokers that frequently run offloading activities. This PR fixes the incorrect `if` conditions.
+
+### Fix namespace cannot be deleted by force [PR-18307](https://github.com/apache/pulsar/pull/18307)
+
+#### Issue
+In earlier versions, when you delete a namespace by force, if `__transaction_buffer_snapshot` and `__change_events` (system topic for topic policies) have been deleted, then the deletion of regular topics will fail because it cannot clear the snapshots and topic policies.
+
+#### Resolution
+Delete regular topics before deleting system topics when deleting a namesapce and does not clear the topic policies.
 
 # What’s Next?
 

--- a/blog/2023-01-09-Apache-Pulsar-2-10-3.md
+++ b/blog/2023-01-09-Apache-Pulsar-2-10-3.md
@@ -37,7 +37,7 @@ Allow configuring and disabling the size of `lookahead` for detecting fixed dela
 #### Issue
 In earlier versions, `BlockAwareSegmentInputStreamImpl` never releases the BookKeeper entries in the `close` method, leading to `OutOfDirectMemory` errors on brokers that frequently run offloading activities. This PR fixes the incorrect `if` conditions.
 
-### Fix namespace cannot be deleted by force [PR-18307](https://github.com/apache/pulsar/pull/18307)
+### Fix namespace cannot be deleted by force ([PR-18307](https://github.com/apache/pulsar/pull/18307))
 
 #### Issue
 In earlier versions, when you delete a namespace by force, if `__transaction_buffer_snapshot` and `__change_events` (system topic for topic policies) have been deleted, then the deletion of regular topics will fail because it cannot clear the snapshots and topic policies.

--- a/data/release-pulsar.js
+++ b/data/release-pulsar.js
@@ -5,7 +5,7 @@ module.exports = [
         "publishedAt": "2023-01-04T01:53:34Z",
         "vtag": "2.10.x",
         "releaseNotes": "/release-notes/versioned/pulsar-2.10.3/",
-        "releaseBlog": "",
+        "releaseBlog": "/blog/2023/01/09/Apache-Pulsar-2-10-3",
         "doc": "/docs/2.10.x",
         "version": "v2.10.x"
     },


### PR DESCRIPTION
Add the release blog for Pulsar version 2.10.3.

<img width="1449" alt="image" src="https://user-images.githubusercontent.com/60642177/211995653-5f50f96d-3b76-42ab-a292-99d93df9327e.png">