### PR TITLE
Add Pulsar shell to the download page

### DIFF
--- a/src/components/downloads.tsx
+++ b/src/components/downloads.tsx
@@ -85,6 +85,31 @@ export function CurrentPulsarConnectorsDownloadTable(): JSX.Element {
     </div>
 }
 
+export function CurrentPulsarShellDownloadTable(): JSX.Element {
+    const latestVersion = pulsarReleases[0]
+    const latestArchiveUrl = distShellUrl(latestVersion, "tar.gz")
+    const latestArchiveUrlZip = distShellUrl(latestVersion, "zip")
+    const data = [
+        {
+            release: "Unix",
+            link: latestArchiveUrl,
+            linkText: `apache-pulsar-shell-${latestVersion}-bin.tar.gz`,
+            asc: `${latestArchiveUrl}.asc`,
+            sha512: `${latestArchiveUrl}.sha512`,
+        },
+        {
+            release: "Windows",
+            link: latestArchiveUrlZip,
+            linkText: `apache-pulsar-shell-${latestVersion}-bin.zip`,
+            asc: `${latestArchiveUrl}.asc`,
+            sha512: `${latestArchiveUrl}.sha512`,
+        }
+    ]
+    return <div className="tailwind">
+        <ReleaseTable data={data}></ReleaseTable>
+    </div>
+}
+
 const legacyReleaseNoteVersions = [
     "2.5.0",
     "2.4.2",
@@ -266,6 +291,10 @@ function distOffloadersUrl(version) {
 
 function distAdaptersUrl(version) {
     return `https://downloads.apache.org/pulsar/pulsar-adapters-${version}/apache-pulsar-adapters-${version}-src.tar.gz`;
+}
+
+function distShellUrl(version, ext) {
+    return `https://downloads.apache.org/pulsar/pulsar-${version}/apache-pulsar-shell-${version}-bin.${ext}`;
 }
 
 function archiveUrl(version, type) {

--- a/src/components/downloads.tsx
+++ b/src/components/downloads.tsx
@@ -91,7 +91,7 @@ export function CurrentPulsarShellDownloadTable(): JSX.Element {
     const latestArchiveUrlZip = distShellUrl(latestVersion, "zip")
     const data = [
         {
-            release: "Unix",
+            release: "Linux / MacOS",
             link: latestArchiveUrl,
             linkText: `apache-pulsar-shell-${latestVersion}-bin.tar.gz`,
             asc: `${latestArchiveUrl}.asc`,

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -12,6 +12,7 @@ import {
     CurrentPulsarDownloadTable,
     CurrentPulsarOffloadersDownloadTable,
     CurrentPulsarConnectorsDownloadTable,
+    CurrentPulsarShellDownloadTable,
     ArchivedPulsarDownloadTable,
     CppReleasesDownloadTable,
     CurrentPulsarAdapterDownloadTable,
@@ -30,6 +31,12 @@ import {
 You can download all previous versions of Pulsar at [the archive page](https://archive.apache.org/dist/pulsar/).
 
 <CurrentPulsarDownloadTable/>
+
+### Shell
+
+You can download all previous versions of Pulsar shell at [the archive page](https://archive.apache.org/dist/pulsar/).
+
+<CurrentPulsarShellDownloadTable/>
 
 ### Offloaders
 


### PR DESCRIPTION
Pulsar 2.11.0 contains Pulsar shell new artifacts and we need make the download links available.

* Added after Pulsar distribution
* One row for unix (.tar.gz) and one for Windows (.zip)

Preview:
![Screen Shot 2023-01-13 at 2 58 32 PM](https://user-images.githubusercontent.com/23314389/212337061-611bc61d-c9f8-433f-9c07-fa7a532bbbfa.png)

