### PR TITLE
[Blog] Add 2.11 release blog

### DIFF
--- a/blog/2023-01-20-Apache-Pulsar-2-11-0.md
+++ b/blog/2023-01-20-Apache-Pulsar-2-11-0.md
@@ -1,0 +1,169 @@
+---
+title: "What’s New in Apache Pulsar 2.11"
+date: 2023-01-20
+author: "Technoboy-, momo-jun"
+---
+
+The Apache Pulsar community releases version 2.11! 61 contributors provided feature enhancements and fixes that delivered 1617 commits. Thanks for all your contributions.
+
+<!--truncate-->
+
+## Highlights of the 2.11 release
+
+* Support chunking with shared subscriptions ([PR-16202](https://github.com/apache/pulsar/pull/16202)) 
+* Support pluggable topic factory ([PR-12235](https://github.com/apache/pulsar/pull/12235))
+* Support configurable compression type for `ManagedCursorInfo` to balance storage resource usage ([PR-14542](https://github.com/apache/pulsar/pull/14542))
+
+This blog documents the most noteworthy changes in this release. For the complete list, including all feature enhancements and bug fixes, check out the [Pulsar 2.11 Release Notes](https://pulsar.apache.org/release-notes/versioned/pulsar-2.11.0/).
+
+## Notable feature enhancements and fixes
+
+### Broker
+***
+
+#### Store subscription properties within metadata service ([PR-15757](https://github.com/apache/pulsar/pull/15757))
+
+**Issue**
+
+Restarting the broker or unloading topics may lead to the loss of subscription properties since they are not stored in the metadata service.
+
+**Resolution**
+
+Store the subscription properties within the metadata service (`ManagedCursorInfo`).
+***
+
+#### Support configurable compression type for `ManagedCursorInfo` ([PR-14542](https://github.com/apache/pulsar/pull/14542))
+
+**Issue**
+
+When the cursor data becomes more and more, the data size increases and it takes a lot of time to pull the data. It is demanding that cursor data can be compressed to reduce the data size and the time of pulling data.
+
+**Resolution**
+
+Introduce various compression algorithms to support cursor compression.
+
+**Reference documentation:** [managedCursorInfoCompressionType](https://pulsar.apache.org/reference/#/2.11.x/config/reference-configuration-broker?id=managedcursorinfocompressiontype)
+***
+
+#### Sync Pulsar metadata across multiple clouds ([PR-16425](https://github.com/apache/pulsar/pull/16425))
+
+**Issue**
+
+Synchronizing configuration metadata (policies) is a critical path to sharing tenant/namespace/topic policies among clusters and administrating policies uniformly across all clusters. However, syncing the metadata store (global zookeeper) among Pulsar clusters deployed on separate cloud platforms is not supported in earlier versions.
+
+**Resolution**
+
+Use two system topics `metadataSyncEventTopic` and `configurationmetadataSyncEventTopic` along with a metadata synchronizer to sync metadata among clusters deployed on different cloud platforms and persist local topic policies with it.
+
+**Reference documentation** 
+- [metadataSyncEventTopic](https://pulsar.apache.org/reference/#/2.11.x/config/reference-configuration-broker?id=metadatasynceventtopic)
+- [configurationmetadataSyncEventTopic](https://pulsar.apache.org/reference/#/2.11.x/config/reference-configuration-broker?id=configurationmetadatasynceventtopic)
+***
+
+### Producer
+***
+
+#### Fix client memory limit `currentUsage` leak in `ProducerImpl` ([PR-16837](https://github.com/apache/pulsar/pull/16837))
+
+**Issue**
+
+The client memory limit `currentUsage` leaks in `ProducerImpl` and causes the producer’s send rate to be slow.
+
+**Resolution**
+
+Release the memory when there are failed pending batch messages.
+***
+
+#### Release semaphore before discarding messages in `batchMessageContainer` ([PR-17019](https://github.com/apache/pulsar/pull/17019))
+
+**Issue**
+
+There is a race condition in `batchMessageContainer` when discarding the messages and releasing the semaphore, which causes the semaphore could not be released.
+
+**Resolution**
+
+Release the semaphore before discarding the messages in `batchMessageContainer`.
+***
+
+### Consumer
+***
+
+#### Support consumer client memory limit ([PR-15216](https://github.com/apache/pulsar/pull/15216))
+
+**Issue**
+
+It takes time for an application with a large number of producers/consumers to select an appropriate value for its queue size. The same applies to topics with many partitions.
+
+**Resolution**
+
+1. Block the expansion of the consumer receiver’s queue size if memory usage is larger than 75%.
+2. Trigger the shrinking of the consumer receiver’s queue size if memory usage is larger than 95%.
+***
+
+#### Support adding interceptors for readers ([PR-14729](https://github.com/apache/pulsar/pull/14729))
+
+**Issue**
+
+Pulsar supports adding interceptors for producers and consumers to implement message tracing, but there is no way to add interceptors for readers.
+
+**Resolution**
+
+1. Add a new interface `ReaderInterceptor` to customize the reader interceptor.
+2. Support setting reader interceptor and auto-update partition configurations by using `ReaderBuilder`.
+
+**User documentation:** [Create a reader with an interceptor](https://pulsar.apache.org/docs/2.11.x/client-libraries-java/#create-reader-with-interceptor)
+***
+
+### Function
+***
+
+#### Support `Record` as a new output type of Functions ([PR-16041](https://github.com/apache/pulsar/pull/16041))
+
+**Issue**
+
+In earlier versions, if you want to dynamically set an output topic, message properties, or change the output schema in a Pulsar function, the only way is to create a function that returns `Void`. It would be more intuitive to return a structure like `Record` that carries this information.
+
+**Resolution**
+
+Add a utility method `newOutputRecordBuilder` to `Context` that returns a `FunctionRecord` builder initialized with the information from the source record. The builder methods can be used to override these values as needed.
+
+**User documentation:** [Use `Record` as function output](https://pulsar.apache.org/docs/2.11.x/functions-develop-api#use-sdk-for-javapythongo)
+***
+
+### Tiered storage
+***
+
+#### Add a universal S3 provider for the offloader ([PR-15710](https://github.com/apache/pulsar/pull/15710))
+
+**Issue**
+
+Pulsar supports cloud storage compatible with S3 APIs, such as AWS and Aliyun, through existing offloaders, but the forced registration of specific metadata limits their use.
+
+**Resolution**
+
+Provide a more general offloader `S3` to serve more S3-compatible storage, which uses pure JClouds S3 metadata and allows overriding the default JClouds properties through system properties.
+
+**User documentation:** [Use S3 offloader with Pulsar](https://pulsar.apache.org/docs/2.11.x/tiered-storage-s3)
+***
+
+### Proxy
+***
+
+#### Support `PrometheusRawMetricsProvider` for Pulsar proxies ([PR-14681](https://github.com/apache/pulsar/pull/14681))
+
+**Issue**
+
+The metrics of plugins could not be exposed to Prometheus for monitoring.
+
+**Resolution**
+
+Add `PrometheusRawMetricsProvider` in Pulsar proxies so that plugins can add their metrics to Prometheus.
+***
+
+## What’s Next?
+
+If you are interested in learning more about Pulsar 2.11, you can [download](https://pulsar.apache.org/versions/) and try it out now! 
+
+For more information about the Apache Pulsar project and current progress, visit
+the [Pulsar website](https://pulsar.apache.org), follow the project on Twitter
+[@apache_pulsar](https://twitter.com/apache_pulsar), and join [Pulsar Slack](https://apache-pulsar.slack.com/)!

--- a/blog/2023-01-20-Apache-Pulsar-2-11-0.md
+++ b/blog/2023-01-20-Apache-Pulsar-2-11-0.md
@@ -36,7 +36,7 @@ Store the subscription properties within the metadata service (`ManagedCursorInf
 
 **Issue**
 
-When the cursor data becomes more and more, the data size increases and it takes a lot of time to pull the data. It is demanding that cursor data can be compressed to reduce the data size and the time of pulling data.
+When the cursor data expands, the data size increases and it takes a lot of time to pull the data.
 
 **Resolution**
 
@@ -49,7 +49,7 @@ Introduce various compression algorithms to support cursor compression.
 
 **Issue**
 
-Synchronizing configuration metadata (policies) is a critical path to sharing tenant/namespace/topic policies among clusters and administrating policies uniformly across all clusters. However, syncing the metadata store (global zookeeper) among Pulsar clusters deployed on separate cloud platforms is not supported in earlier versions.
+Synchronizing configuration metadata (policies) is a critical path to sharing tenant/namespace/topic policies among clusters and administering policies uniformly across all clusters. However, syncing the metadata store (global zookeeper) among Pulsar clusters deployed on separate cloud platforms is not supported in earlier versions.
 
 **Resolution**
 
@@ -78,7 +78,7 @@ Release the memory when there are failed pending batch messages.
 
 **Issue**
 
-There is a race condition in `batchMessageContainer` when discarding the messages and releasing the semaphore, which causes the semaphore could not be released.
+There is a race condition in `batchMessageContainer` when discarding the messages and releasing the semaphore, which causes the semaphore to be held.
 
 **Resolution**
 
@@ -96,8 +96,8 @@ It takes time for an application with a large number of producers/consumers to s
 
 **Resolution**
 
-1. Block the expansion of the consumer receiver’s queue size if memory usage is larger than 75%.
-2. Trigger the shrinking of the consumer receiver’s queue size if memory usage is larger than 95%.
+1. Block the expansion of the consumer receiver’s queue size if the memory usage exceeds 75%.
+2. Trigger the shrinking of the consumer receiver’s queue size if the memory usage exceeds 95%.
 ***
 
 #### Support adding interceptors for readers ([PR-14729](https://github.com/apache/pulsar/pull/14729))
@@ -162,7 +162,7 @@ Add `PrometheusRawMetricsProvider` in Pulsar proxies so that plugins can add the
 
 ## What’s Next?
 
-If you are interested in learning more about Pulsar 2.11, you can [download](https://pulsar.apache.org/versions/) and try it out now! 
+If you are interested in learning more about Pulsar 2.11, you can [download](https://pulsar.apache.org/download/) and try it out now! 
 
 For more information about the Apache Pulsar project and current progress, visit
 the [Pulsar website](https://pulsar.apache.org), follow the project on Twitter

--- a/data/release-pulsar.js
+++ b/data/release-pulsar.js
@@ -5,7 +5,7 @@ module.exports = [
         "publishedAt": "2023-01-11T01:53:34Z",
         "vtag": "2.11.x",
         "releaseNotes": "/release-notes/versioned/pulsar-2.11.0/",
-        "releaseBlog": "",
+        "releaseBlog": "/blog/2023/01/20/Apache-Pulsar-2-11-0",
         "doc": "/docs/2.11.x",
         "version": "v2.11.x"
     },


### PR DESCRIPTION
Add the release blog for Pulsar version 2.11.0.

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/60642177/213074789-94c8eb5b-b640-4bde-baef-17aa76078153.png">
