### PR TITLE
[fix][doc] fix StreamNative logo URL on /powered-by page

### DIFF
--- a/data/users.js
+++ b/data/users.js
@@ -92,7 +92,7 @@ module.exports = [
   {
     name: "StreamNative",
     url: "https://streamnative.io/",
-    logo: "https://streamnative.io/assets/static/sn-logo-vertical-dark.c516648.a34f97839dee38e7499aa0c21d0b2255.png",
+    logo: "https://global-uploads.webflow.com/638a1dc72083d166ed6e3d76/63926c17a52727a15e13decd_Logo-streamnative-150px.svg",
   },
   {
     name: "EMQ",


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

Some logos are not visible on the page. Their URLs are wrong.
I fixed the StreamNative logo URL.
I tried to fix the others, but I'm not 100% sure I would take the right URLs, so I did not fix the other logos in this PR.
Here is the preview:
![preview](https://user-images.githubusercontent.com/351773/216388202-4892a1a7-670f-4245-82d7-d000166f897c.png)
