### PR TITLE
[fix][schema] Fix incorrect field name of `isSchemaValidationEnforced`

### DIFF
--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -396,7 +396,7 @@ admin.namespaces().setIsAllowAutoUpdateSchema("my-namspace", false);
 
 ### Enable schema validation enforcement
 
-To enforce schema validation enforcement at the **cluster** level, you can configure `schemaValidationEnforced` to `true` in the `conf/broker.conf` file. 
+To enforce schema validation enforcement at the **cluster** level, you can configure `isSchemaValidationEnforced` to `true` in the `conf/broker.conf` file. 
 
 To enable schema validation enforcement at the **namespace** level, you can use one of the following commands.
 

--- a/versioned_docs/version-2.11.x/admin-api-schemas.md
+++ b/versioned_docs/version-2.11.x/admin-api-schemas.md
@@ -396,7 +396,7 @@ admin.namespaces().setIsAllowAutoUpdateSchema("my-namspace", false);
 
 ### Enable schema validation enforcement
 
-To enforce schema validation enforcement at the **cluster** level, you can configure `schemaValidationEnforced` to `true` in the `conf/broker.conf` file. 
+To enforce schema validation enforcement at the **cluster** level, you can configure `isSchemaValidationEnforced` to `true` in the `conf/broker.conf` file. 
 
 To enable schema validation enforcement at the **namespace** level, you can use one of the following commands.
 


### PR DESCRIPTION
### Documentation

The field name of toggling the schema validation enforced is `isSchemaValidationEnforced`. See [broker.conf](https://github.com/apache/pulsar/blob/8eb7ee1e9e96d4686e452320cdaba92d5eca7b4f/conf/broker.conf#L1502-L1504) and [the code](https://github.com/apache/pulsar/blob/8eb7ee1e9e96d4686e452320cdaba92d5eca7b4f/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#L2633)

This PR fixes the incorrect name.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
