### PR TITLE
[improve][doc] Add note on client/broker compatibility

### DIFF
--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -26,7 +26,7 @@ Pulsar supports the following language-agnostic client libraries:
 
 **Client / Broker compatibility**
 
-A design goal of Pulsar is to ensure full compatibility between the same major version clients and brokers, e.g. 2.x clients are compatible with all 2.x brokers, etc.
+A design goal of Pulsar is to ensure full compatibility between all versions of the client and the broker. When a client connects to a broker they agree upon a version of the protocol to use. As a result, new features that rely on an updates to the protocol are only available when using both newer clients and newer brokers.
 
 :::
 

--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -22,6 +22,14 @@ Pulsar supports the following language-agnostic client libraries:
 | REST      | [User doc](client-libraries-rest.md)      | [Bundled](pathname:///release-notes/)             | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-broker)    |
 | WebSocket | [User doc](client-libraries-websocket.md) | [Standalone](pathname:///release-notes/client-ws) | [Bundled](https://github.com/apache/pulsar/tree/master/pulsar-websocket) |
 
+:::note 
+
+**Client / Broker compatibility**
+
+A design goal of Pulsar is to ensure full compatibility between the same major version clients and brokers, e.g. 2.x clients are compatible with all 2.x brokers, etc.
+
+:::
+
 ## Feature matrix
 
 Pulsar client feature matrix for different languages is listed on [Pulsar Feature Matrix (Client and Function)](https://docs.google.com/spreadsheets/d/1YHYTkIXR8-Ql103u-IMI18TXLlGStK8uJjDsOOA0T20/edit#gid=1784579914) page.


### PR DESCRIPTION
### Documentation

Adds a note to the client overview page that mentions the client/broker compatibility.

#### Screenshot

<img width="1137" alt="Screen Shot 2023-02-13 at 14 58 46" src="https://user-images.githubusercontent.com/28907971/218574112-fe4da7f0-6da7-410e-9224-ab559edb20d5.png">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->

@michaeljmarshall @lhotari @david-streamlio can you take a peek?