### PR TITLE
[feat] GitHub badge without dep to shields

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -257,16 +257,15 @@ module.exports = {
                     ],
                 },
                 {
+                    href: "https://github.com/apache/pulsar",
+                    position: "right",
+                    className: "github-nav",
+                },
+                {
                     to: "/download",
                     label: "Download",
                     position: "right",
                     className: "download-btn pill-btn",
-                },
-                {
-                    href: "https://github.com/apache/pulsar",
-                    label: "Github",
-                    position: "right",
-                    className: "github-nav",
                 },
             ],
         },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -225,20 +225,25 @@ html[data-theme="dark"] .navbar-sidebar {
 .dropdown__link--active {
   background-color: transparent;
 }
-.github-nav.navbar__link {
-  color: transparent;
-  font-size: 0px;
-  top: 10px;
-  position: relative;
-  left: -84px;
-  top: -50px;
+
+.github-nav:hover {
+  opacity: 0.6;
 }
+
 .github-nav::before {
-  content: url("https://img.shields.io/github/stars/apache/pulsar?label=%20&style=social");
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
+  no-repeat;
 }
-.github-nav.navbar__link:hover::before {
-  content: url("https://img.shields.io/github/stars/apache/pulsar?label=%20&style=social");
+
+[data-theme='dark'] .github-nav::before {
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
+  no-repeat;
 }
+
 .navbar div[class^="toggle_node_"],
 .colorModeToggle_vKtC {
   top: 9px;
@@ -1079,7 +1084,7 @@ footer .row.footer__links {
     display: none;
   }
   .navbar.navbar--fixed-top {
-    padding-top: 0px;
+    padding-top: 0;
   }
   div[class^="searchBox_"] {
     position: relative;
@@ -1090,7 +1095,7 @@ footer .row.footer__links {
     --ifm-navbar-height: 75px;
   }
   .menu__link.github-nav {
-    font-size: 0px;
+    font-size: 0;
   }
 }
 


### PR DESCRIPTION
Current issue:

![image](https://user-images.githubusercontent.com/18818196/219070348-9bffcf49-9751-4702-b935-6476aebd9792.png)


Fixed image:

![Screenshot_Hello from Apache Pulsar | Apache Pulsar - Google Chrome_1](https://user-images.githubusercontent.com/18818196/219070230-3c8c0bfa-0015-4c41-8edc-56dc0430ab40.png)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
