### PR TITLE
[fix][doc] correct default values of tiered storage offloaders

### DIFF
--- a/docs/tiered-storage-aliyun.md
+++ b/docs/tiered-storage-aliyun.md
@@ -46,8 +46,8 @@ You can configure the Aliyun OSS offloader driver in the configuration file `bro
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Block size for each individual read when reading back data from S3-compatible storage. | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Maximum block size sent during a multi-part upload to S3-compatible storage. It **cannot** be smaller than 5 MB. | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />It's **not** recommended to change the default value in a production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />It's **not** recommended to change the default value in a production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/docs/tiered-storage-aws.md
+++ b/docs/tiered-storage-aws.md
@@ -48,8 +48,8 @@ You can configure the AWS S3 offloader driver in the configuration file `broker.
   `s3ManagedLedgerOffloadRegion` | Bucket region <br /><br />**Note**: before specifying a value for this parameter, you need to set the following configurations. Otherwise, you might get an error.<br /><br />- Set [`s3ManagedLedgerOffloadServiceEndpoint`](https://docs.aws.amazon.com/general/latest/gr/s3.html).<br /><br />Example<br />`s3ManagedLedgerOffloadServiceEndpoint=https://s3.YOUR_REGION.amazonaws.com`<br /><br />- Grant `GetBucketLocation` permission to a user.<br /><br />For how to grant `GetBucketLocation` permission to a user, see [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-buckets).| eu-west-3
   `s3ManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `s3ManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/docs/tiered-storage-azure.md
+++ b/docs/tiered-storage-azure.md
@@ -47,8 +47,8 @@ You can configure the Azure BlobStore offloader driver in the configuration file
   |---|---|---
   `managedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `managedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/docs/tiered-storage-filesystem.md
+++ b/docs/tiered-storage-filesystem.md
@@ -59,8 +59,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 <TabItem value="NFS">
@@ -76,8 +76,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 

--- a/docs/tiered-storage-gcs.md
+++ b/docs/tiered-storage-gcs.md
@@ -49,8 +49,8 @@ You can configure GCS offloader driver in the configuration file `broker.conf` o
   |---|---|---
   `gcsManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `gcsManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|2
-  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|10
+  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|50000
 
 #### Bucket (required)
 

--- a/docs/tiered-storage-s3.md
+++ b/docs/tiered-storage-s3.md
@@ -49,8 +49,8 @@ You can configure the S3 offloader driver in the configuration file `broker.conf
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Block size for each individual read when reading back data from S3-compatible storage. | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Maximum block size sent during a multi-part upload to S3-compatible storage. It **cannot** be smaller than 5 MB. | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.10.x/tiered-storage-aliyun.md
+++ b/versioned_docs/version-2.10.x/tiered-storage-aliyun.md
@@ -70,8 +70,8 @@ You can configure the Aliyun OSS offloader driver in the configuration file `bro
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Size of block read | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Size of block write | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.10.x/tiered-storage-aws.md
+++ b/versioned_docs/version-2.10.x/tiered-storage-aws.md
@@ -99,8 +99,8 @@ You can configure the AWS S3 offloader driver in the configuration file `broker.
   `s3ManagedLedgerOffloadRegion` | Bucket region <br /><br />**Note**: before specifying a value for this parameter, you need to set the following configurations. Otherwise, you might get an error.<br /><br />- Set [`s3ManagedLedgerOffloadServiceEndpoint`](https://docs.aws.amazon.com/general/latest/gr/s3.html).<br /><br />Example<br />`s3ManagedLedgerOffloadServiceEndpoint=https://s3.YOUR_REGION.amazonaws.com`<br /><br />- Grant `GetBucketLocation` permission to a user.<br /><br />For how to grant `GetBucketLocation` permission to a user, see [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-buckets).| eu-west-3
   `s3ManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `s3ManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.10.x/tiered-storage-azure.md
+++ b/versioned_docs/version-2.10.x/tiered-storage-azure.md
@@ -98,8 +98,8 @@ You can configure the Azure BlobStore offloader driver in the configuration file
   |---|---|---
   `managedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `managedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.10.x/tiered-storage-filesystem.md
+++ b/versioned_docs/version-2.10.x/tiered-storage-filesystem.md
@@ -116,8 +116,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 <TabItem value="NFS">

--- a/versioned_docs/version-2.10.x/tiered-storage-gcs.md
+++ b/versioned_docs/version-2.10.x/tiered-storage-gcs.md
@@ -101,8 +101,8 @@ You can configure GCS offloader driver in the configuration file `broker.conf` o
   |---|---|---
   `gcsManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `gcsManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|2
-  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|10
+  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.11.x/tiered-storage-aliyun.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-aliyun.md
@@ -46,8 +46,8 @@ You can configure the Aliyun OSS offloader driver in the configuration file `bro
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Block size for each individual read when reading back data from S3-compatible storage. | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Maximum block size sent during a multi-part upload to S3-compatible storage. It **cannot** be smaller than 5 MB. | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />It's **not** recommended to change the default value in a production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />It's **not** recommended to change the default value in a production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.11.x/tiered-storage-aws.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-aws.md
@@ -48,8 +48,8 @@ You can configure the AWS S3 offloader driver in the configuration file `broker.
   `s3ManagedLedgerOffloadRegion` | Bucket region <br /><br />**Note**: before specifying a value for this parameter, you need to set the following configurations. Otherwise, you might get an error.<br /><br />- Set [`s3ManagedLedgerOffloadServiceEndpoint`](https://docs.aws.amazon.com/general/latest/gr/s3.html).<br /><br />Example<br />`s3ManagedLedgerOffloadServiceEndpoint=https://s3.YOUR_REGION.amazonaws.com`<br /><br />- Grant `GetBucketLocation` permission to a user.<br /><br />For how to grant `GetBucketLocation` permission to a user, see [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-buckets).| eu-west-3
   `s3ManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `s3ManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.11.x/tiered-storage-azure.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-azure.md
@@ -47,8 +47,8 @@ You can configure the Azure BlobStore offloader driver in the configuration file
   |---|---|---
   `managedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `managedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.11.x/tiered-storage-filesystem.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-filesystem.md
@@ -59,8 +59,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 <TabItem value="NFS">
@@ -76,8 +76,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 

--- a/versioned_docs/version-2.11.x/tiered-storage-gcs.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-gcs.md
@@ -49,8 +49,8 @@ You can configure GCS offloader driver in the configuration file `broker.conf` o
   |---|---|---
   `gcsManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `gcsManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|2
-  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|10
+  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.11.x/tiered-storage-s3.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-s3.md
@@ -49,8 +49,8 @@ You can configure the S3 offloader driver in the configuration file `broker.conf
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Block size for each individual read when reading back data from S3-compatible storage. | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Maximum block size sent during a multi-part upload to S3-compatible storage. It **cannot** be smaller than 5 MB. | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: It's **not** recommended to change the default value in a production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.8.x/tiered-storage-aliyun.md
+++ b/versioned_docs/version-2.8.x/tiered-storage-aliyun.md
@@ -70,8 +70,8 @@ You can configure the Aliyun OSS offloader driver in the configuration file `bro
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Size of block read | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Size of block write | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.8.x/tiered-storage-aws.md
+++ b/versioned_docs/version-2.8.x/tiered-storage-aws.md
@@ -99,8 +99,8 @@ You can configure the AWS S3 offloader driver in the configuration file `broker.
   `s3ManagedLedgerOffloadRegion` | Bucket region <br /><br />**Note**: before specifying a value for this parameter, you need to set the following configurations. Otherwise, you might get an error.<br /><br />- Set [`s3ManagedLedgerOffloadServiceEndpoint`](https://docs.aws.amazon.com/general/latest/gr/s3.html).<br /><br />Example<br />`s3ManagedLedgerOffloadServiceEndpoint=https://s3.YOUR_REGION.amazonaws.com`<br /><br />- Grant `GetBucketLocation` permission to a user.<br /><br />For how to grant `GetBucketLocation` permission to a user, see [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-buckets).| eu-west-3
   `s3ManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `s3ManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.8.x/tiered-storage-azure.md
+++ b/versioned_docs/version-2.8.x/tiered-storage-azure.md
@@ -98,8 +98,8 @@ You can configure the Azure BlobStore offloader driver in the configuration file
   |---|---|---
   `managedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `managedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.8.x/tiered-storage-filesystem.md
+++ b/versioned_docs/version-2.8.x/tiered-storage-filesystem.md
@@ -115,8 +115,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 <TabItem value="NFS">
@@ -133,8 +133,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
 
   Parameter| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|50000
 
 </TabItem>
 

--- a/versioned_docs/version-2.8.x/tiered-storage-gcs.md
+++ b/versioned_docs/version-2.8.x/tiered-storage-gcs.md
@@ -101,8 +101,8 @@ You can configure GCS offloader driver in the configuration file `broker.conf` o
   |---|---|---
   `gcsManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `gcsManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|2
-  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|10
+  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.9.x/tiered-storage-aliyun.md
+++ b/versioned_docs/version-2.9.x/tiered-storage-aliyun.md
@@ -70,8 +70,8 @@ You can configure the Aliyun OSS offloader driver in the configuration file `bro
   | --- | --- | --- |
   | `managedLedgerOffloadReadBufferSizeInBytes` | Size of block read | 1 MB |
   | `managedLedgerOffloadMaxBlockSizeInBytes` | Size of block write | 64 MB |
-  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 2 |
-  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 5000 |
+  | `managedLedgerMinLedgerRolloverTimeMinutes` | Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 10 |
+  | `managedLedgerMaxEntriesPerLedger` | Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment. | 50000 |
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.9.x/tiered-storage-aws.md
+++ b/versioned_docs/version-2.9.x/tiered-storage-aws.md
@@ -99,8 +99,8 @@ You can configure the AWS S3 offloader driver in the configuration file `broker.
   `s3ManagedLedgerOffloadRegion` | Bucket region <br /><br />**Note**: before specifying a value for this parameter, you need to set the following configurations. Otherwise, you might get an error.<br /><br />- Set [`s3ManagedLedgerOffloadServiceEndpoint`](https://docs.aws.amazon.com/general/latest/gr/s3.html).<br /><br />Example<br />`s3ManagedLedgerOffloadServiceEndpoint=https://s3.YOUR_REGION.amazonaws.com`<br /><br />- Grant `GetBucketLocation` permission to a user.<br /><br />For how to grant `GetBucketLocation` permission to a user, see [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-buckets).| eu-west-3
   `s3ManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `s3ManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.9.x/tiered-storage-azure.md
+++ b/versioned_docs/version-2.9.x/tiered-storage-azure.md
@@ -98,8 +98,8 @@ You can configure the Azure BlobStore offloader driver in the configuration file
   |---|---|---
   `managedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `managedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Bucket (required)
 

--- a/versioned_docs/version-2.9.x/tiered-storage-filesystem.md
+++ b/versioned_docs/version-2.9.x/tiered-storage-filesystem.md
@@ -104,8 +104,8 @@ You can configure filesystem offloader driver in the configuration file `broker.
 
   Optional configuration| Description | Example value
   |---|---|---
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|2
-  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|10
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended that you set this configuration in the production environment.|50000
 
 #### Offloader driver (required)
 

--- a/versioned_docs/version-2.9.x/tiered-storage-gcs.md
+++ b/versioned_docs/version-2.9.x/tiered-storage-gcs.md
@@ -101,8 +101,8 @@ You can configure GCS offloader driver in the configuration file `broker.conf` o
   |---|---|---
   `gcsManagedLedgerOffloadReadBufferSizeInBytes`|Size of block read|1 MB
   `gcsManagedLedgerOffloadMaxBlockSizeInBytes`|Size of block write|64 MB
-  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|2
-  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|5000
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic.|10
+  `managedLedgerMaxEntriesPerLedger`|The max number of entries to append to a ledger before triggering a rollover.|50000
 
 #### Bucket (required)
 


### PR DESCRIPTION
### Modifications

Correct the default values of the following two parameters for all types of offloaders:
* `managedLedgerMinLedgerRolloverTimeMinutes`
* `managedLedgerMaxEntriesPerLedger`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
