### PR TITLE
Easier to copy&paste command for Windows

### DIFF
--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -13,21 +13,13 @@ If you have not installed Docker, download the [Community edition](https://www.d
 For macOS, Linux, and Windows, run the following command to start Pulsar within a Docker container.
 
 ```shell
-docker run -it -p 6650:6650 -p 8080:8080 \
-    --mount source=pulsardata,target=/pulsar/data \
-    --mount source=pulsarconf,target=/pulsar/conf \
-    apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
+docker run -it -p 6650:6650 -p 8080:8080 --mount source=pulsardata,target=/pulsar/data --mount source=pulsarconf,target=/pulsar/conf apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
 ```
 
 If you want to change Pulsar configurations and start Pulsar, run the following command by passing environment variables with the `PULSAR_PREFIX_` prefix. See [default configuration file](https://github.com/apache/pulsar/blob/e6b12c64b043903eb5ff2dc5186fe8030f157cfc/conf/standalone.conf) for more details.
 
 ```shell
-docker run -it -e PULSAR_PREFIX_xxx=yyy \
-    -p 6650:6650  -p 8080:8080 \
-    --mount source=pulsardata,target=/pulsar/data \
-    --mount source=pulsarconf,target=/pulsar/conf \
-    apachepulsar/pulsar:2.10.0 \
-    sh -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
+docker run -it -e PULSAR_PREFIX_xxx=yyy -p 6650:6650  -p 8080:8080 --mount source=pulsardata,target=/pulsar/data --mount source=pulsarconf,target=/pulsar/conf apachepulsar/pulsar:2.10.0 sh -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
 ```
 
 :::tip

--- a/versioned_docs/version-2.11.x/getting-started-docker.md
+++ b/versioned_docs/version-2.11.x/getting-started-docker.md
@@ -13,21 +13,13 @@ If you have not installed Docker, download the [Community edition](https://www.d
 For macOS, Linux, and Windows, run the following command to start Pulsar within a Docker container.
 
 ```shell
-docker run -it -p 6650:6650 -p 8080:8080 \
-    --mount source=pulsardata,target=/pulsar/data \
-    --mount source=pulsarconf,target=/pulsar/conf \
-    apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
+docker run -it -p 6650:6650 -p 8080:8080 --mount source=pulsardata,target=/pulsar/data --mount source=pulsarconf,target=/pulsar/conf apachepulsar/pulsar:@pulsar:version@bin/pulsar standalone
 ```
 
 If you want to change Pulsar configurations and start Pulsar, run the following command by passing environment variables with the `PULSAR_PREFIX_` prefix. See [default configuration file](https://github.com/apache/pulsar/blob/e6b12c64b043903eb5ff2dc5186fe8030f157cfc/conf/standalone.conf) for more details.
 
 ```shell
-docker run -it -e PULSAR_PREFIX_xxx=yyy \
-    -p 6650:6650  -p 8080:8080 \
-    --mount source=pulsardata,target=/pulsar/data \
-    --mount source=pulsarconf,target=/pulsar/conf \
-    apachepulsar/pulsar:2.11.0 \
-    sh -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
+docker run -it -e PULSAR_PREFIX_xxx=yyy -p 6650:6650  -p 8080:8080 --mount source=pulsardata,target=/pulsar/data --mount source=pulsarconf,target=/pulsar/conf apachepulsar/pulsar:2.11.0 sh -c "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone"
 ```
 
 :::tip


### PR DESCRIPTION
I know its something small but it really should be able for windows people to simply copy and paste this shell command without needing to do any extra effort like removing the backslashes and making it one line because powershell doesn't support this. If you disagree feel free to decline this.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
