### PR TITLE
[improve][doc] add instructions of env variables to CLI docs

### DIFF
--- a/static/reference/next/cli.md
+++ b/static/reference/next/cli.md
@@ -1,3 +1,9 @@
-# Welcome
+Pulsar offers several command-line tools that help you manage Pulsar and BookKeeper, produce and consume messages, administer Pulsar entities, test Pulsar, and more.
 
-> Welcome to Pulsar CLI Tools Docs.
+|Goal|Tool
+|---|---
+Manage Pulsar| - `pulsar`  <br/><br/> - [`pulsar-daemon`](/next/pulsar-daemon/pulsar-daemon) <br/><br/> - [`pulsar-shell`](/next/pulsar-shell/pulsar-shell)
+Produce and consume messages | [`pulsar-client`](/next/pulsar-client/pulsar-client)
+Administer Pulsar entities | `pulsar-admin`
+Test Pulsar | [`pulsar-perf`](/next/pulsar-perf/pulsar-perf)
+Manage BookKeeper | [`bookkeper`](/next/bookkeeper/bookkeeper)

--- a/static/reference/next/config/README.md
+++ b/static/reference/next/config/README.md
@@ -1,7 +1,5 @@
 ## Pulsar configurations
 
-Pulsar offers several command-line tools that you can use for managing Pulsar installations, performance testing, using command-line producers and consumers, and more.
-
 You can manage Pulsar configurations through configuration files in the [`conf`](https://github.com/apache/pulsar/tree/master/conf) directory of a Pulsar installation.
 
 - [BookKeeper](/next/config/reference-configuration-bookkeeper)

--- a/static/reference/next/pulsar-admin/README.md
+++ b/static/reference/next/pulsar-admin/README.md
@@ -1,1 +1,16 @@
-> Docs for `pulsar-admin`.
+`pulsar-admin` is a tool used to administer Pulsar entities.
+
+## Environment variables
+
+You can use the following environment variables to configure `pulsar-admin`.
+
+|Variable|Description|Default|
+|---|---|---|
+|`PULSAR_LOG_CONF`|Log4j configuration file|conf/log4j2.yaml|
+|`PULSAR_CLIENT_CONF`|Configuration file for the client|conf/client.conf|
+|`PULSAR_EXTRA_OPTS`|Extra options passed to the JVM|N/A|
+|`PULSAR_EXTRA_CLASSPATH`|Extra paths for Pulsar's classpath|N/A|
+
+## Related topics
+
+- [Pulsar admin API](docs/admin-api-overview)

--- a/static/reference/next/pulsar-client/README.md
+++ b/static/reference/next/pulsar-client/README.md
@@ -1,4 +1,4 @@
-`pulsar-client` is a tool used to produce and consume messages
+`pulsar-client` is a tool used to produce and consume messages.
 
 ## Environment variables
 

--- a/static/reference/next/pulsar-client/README.md
+++ b/static/reference/next/pulsar-client/README.md
@@ -1,1 +1,12 @@
-> Docs for `pulsar-client`.
+`pulsar-client` is a tool used to produce and consume messages
+
+## Environment variables
+
+You can use the following environment variables to configure `pulsar-client`.
+
+|Variable|Description|Default|
+|---|---|---|
+|`PULSAR_LOG_CONF`|Log4j configuration file|conf/log4j2.yaml|
+|`PULSAR_CLIENT_CONF`|Configuration file for the client|conf/client.conf|
+|`PULSAR_EXTRA_OPTS`|Extra options passed to the JVM|N/A|
+|`PULSAR_EXTRA_CLASSPATH`|Extra paths for Pulsar's classpath|N/A|

--- a/static/reference/next/pulsar-perf/README.md
+++ b/static/reference/next/pulsar-perf/README.md
@@ -1,1 +1,12 @@
-> Docs for `pulsar-perf`.
+`pulsar-perf` is a tool used to test the performance of Pulsar brokers.
+
+## Environment variables
+
+You can use the following environment variables to configure `pulsar-perf`.
+
+|Variable|Description|Default|
+|---|---|---|
+|`PULSAR_LOG_CONF`|Log4j configuration file|conf/log4j2.yaml|
+|`PULSAR_CLIENT_CONF`|Configuration file for the client|conf/client.conf|
+|`PULSAR_EXTRA_OPTS`|Extra options passed to the JVM|N/A|
+|`PULSAR_EXTRA_CLASSPATH`|Extra paths for Pulsar's classpath|N/A|


### PR DESCRIPTION
This PR:
- Fixes https://github.com/apache/pulsar/issues/19492
- Adds explanations to the homepages of several CLI tools

All previews look good:

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/50226895/219556615-728e0403-2e04-4ada-93d6-610ff3b08583.png">

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/50226895/219556683-2f1d4a9d-7ed1-47a6-8782-4fee06beda6c.png">

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/50226895/219556754-da61019f-c433-4725-b749-488ab2909643.png">

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/50226895/219556789-873d96c1-51d5-4910-b8a7-4ba87e07c44b.png">

- [x] `doc`

cc @momo-jun @DaveDuggins @D-2-Ed 
