### PR TITLE
Fix wrong C++ client download page

### DIFF
--- a/data/release-cpp.js
+++ b/data/release-cpp.js
@@ -1,7 +1,7 @@
 module.exports = [
-{tagName: "v3.1.2",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.2/",doc:"/docs/client-libraries-cpp",version:"v3.1.x"},
-{tagName: "v3.1.1",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.1/",doc:"/docs/client-libraries-cpp",version:""},
-{tagName: "v3.1.0",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.0/",doc:"/docs/client-libraries-cpp",version:""},
+{tagName: "v3.1.2",vtag:"3.1.2",releaseNotes:"/release-notes/versioned/client-cpp-3.1.2/",doc:"/docs/client-libraries-cpp",version:"v3.1.x"},
+{tagName: "v3.1.1",vtag:"3.1.1",releaseNotes:"/release-notes/versioned/client-cpp-3.1.1/",doc:"/docs/client-libraries-cpp",version:""},
+{tagName: "v3.1.0",vtag:"3.1.0",releaseNotes:"/release-notes/versioned/client-cpp-3.1.0/",doc:"/docs/client-libraries-cpp",version:""},
 {tagName: "v3.0.0",vtag:"3.0.0",releaseNotes:"/release-notes/versioned/client-cpp-3.0.0/",doc:"/docs/client-libraries-cpp",version:"v3.0.x"},
 {tagName: "v2.10.3",vtag:"2.10.x",releaseNotes:"/release-notes/versioned/client-cpp-2.10.3/",doc:"/docs/2.10.x/client-libraries-cpp",version:"v2.10.x"},
 {tagName: "v2.10.2",vtag:"2.10.x",releaseNotes:"/release-notes/versioned/client-cpp-2.10.2/",doc:"/docs/2.10.x/client-libraries-cpp",version:""},

--- a/data/release-cpp.js
+++ b/data/release-cpp.js
@@ -1,7 +1,7 @@
 module.exports = [
-{tagName: "v3.1.2",vtag:"3.1.2",releaseNotes:"/release-notes/versioned/client-cpp-3.1.2/",doc:"/docs/client-libraries-cpp",version:"v3.1.x"},
-{tagName: "v3.1.1",vtag:"3.1.1",releaseNotes:"/release-notes/versioned/client-cpp-3.1.1/",doc:"/docs/client-libraries-cpp",version:""},
-{tagName: "v3.1.0",vtag:"3.1.0",releaseNotes:"/release-notes/versioned/client-cpp-3.1.0/",doc:"/docs/client-libraries-cpp",version:""},
+{tagName: "v3.1.2",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.2/",doc:"/docs/client-libraries-cpp",version:"v3.1.x"},
+{tagName: "v3.1.1",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.1/",doc:"/docs/client-libraries-cpp",version:""},
+{tagName: "v3.1.0",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.0/",doc:"/docs/client-libraries-cpp",version:""},
 {tagName: "v3.0.0",vtag:"3.0.0",releaseNotes:"/release-notes/versioned/client-cpp-3.0.0/",doc:"/docs/client-libraries-cpp",version:"v3.0.x"},
 {tagName: "v2.10.3",vtag:"2.10.x",releaseNotes:"/release-notes/versioned/client-cpp-2.10.3/",doc:"/docs/2.10.x/client-libraries-cpp",version:"v2.10.x"},
 {tagName: "v2.10.2",vtag:"2.10.x",releaseNotes:"/release-notes/versioned/client-cpp-2.10.2/",doc:"/docs/2.10.x/client-libraries-cpp",version:""},

--- a/src/components/downloads.tsx
+++ b/src/components/downloads.tsx
@@ -174,7 +174,7 @@ export function ArchivedPulsarDownloadTable(): JSX.Element {
 
 export function CppReleasesDownloadTable(): JSX.Element {
     const data = cppReleases
-        .map(item => item.vtag)
+        .map(item => item.tagName.substring(1))
         .filter(version => Number(version.split('.')[0]) >= 3)
         .map(version => {
             const url = `https://archive.apache.org/dist/pulsar/pulsar-client-cpp-${version}/`


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

The current C++ client download page is wrong, see:

![20230217142511](https://user-images.githubusercontent.com/18204803/219566198-a99c106f-8730-4910-89da-936ed821f2d2.jpg)

It's because the table uses the `vtag` field to generate the **Release** and **Link** columns. 

https://github.com/apache/pulsar-site/blob/679b203bf481c552dde9d7dd4a932e7309e81d52/src/components/downloads.tsx#L177-L181

However, #419 set them as `3.1.x`. This PR uses the sub string of the `tagName` field instead of the `vtag` field, after the change the download page looks like:

![20230217142459](https://user-images.githubusercontent.com/18204803/219567083-0ef8eb8a-5c60-465f-982a-95130914706a.jpg)
