### PR TITLE
[Improve][doc] Add missing examples for java client

### DIFF
--- a/docs/client-libraries-clients.md
+++ b/docs/client-libraries-clients.md
@@ -17,8 +17,29 @@ To ensure clients in both internal and external networks can connect to a Pulsar
 
 The following example creates a Python client using multiple advertised listeners:
 
-```python
-import pulsar
 
-client = pulsar.Client('pulsar://localhost:6650', listener_name='external')
-```
+````mdx-code-block
+<Tabs groupId="lang-choice"
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"}]}>
+  <TabItem value="Java">
+
+  ```java
+  PulsarClient client = PulsarClient.builder()
+    .serviceUrl("pulsar://xxxx:6650")
+    .listenerName("external")
+    .build();
+  ```
+
+  </TabItem>
+  <TabItem value="Python">
+
+  ```python
+  import pulsar
+
+  client = pulsar.Client('pulsar://localhost:6650', listener_name='external')
+  ```
+
+  </TabItem>
+</Tabs>
+````

--- a/docs/client-libraries-consumers.md
+++ b/docs/client-libraries-consumers.md
@@ -428,8 +428,16 @@ This example shows how a consumer unsubscribes from a topic.
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"
-  defaultValue="C#"
-  values={[{"label":"C#","value":"C#"}]}>
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"},{"label":"C#","value":"C#"}]}>
+<TabItem value="Java">
+
+   ```java
+   consumer.unsubscribe();
+   ```
+
+  </TabItem>
+
 <TabItem value="C#">
 
    ```csharp
@@ -452,8 +460,16 @@ This example shows how a consumer receives messages from a topic.
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"
-  defaultValue="C#"
-  values={[{"label":"C#","value":"C#"}]}>
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"}, {"label":"C#","value":"C#"}]}>
+<TabItem value="Java">
+
+   ```java
+   Message message = consumer.receive();
+   ```
+
+ </TabItem>
+
 <TabItem value="C#">
 
    ```csharp
@@ -471,8 +487,16 @@ This example shows how a consumer receives messages from a topic.
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"
-  defaultValue="Go"
-  values={[{"label":"Go","value":"Go"}]}>
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"}, {"label":"Go","value":"Go"}]}>
+<TabItem value="Java">
+
+   ```java
+   consumer.receive(10, TimeUnit.SECONDS);
+   ```
+
+ </TabItem>
+
   <TabItem value="Go">
 
 
@@ -599,6 +623,9 @@ Messages can be acknowledged individually or cumulatively. For details about mes
   values={[{"label":"Java","value":"Java"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
+  ```java
+  consumer.acknowledge(msg);
+  ```
 
 
   </TabItem>
@@ -620,6 +647,9 @@ Messages can be acknowledged individually or cumulatively. For details about mes
   values={[{"label":"Java","value":"Java"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
+  ```java
+  consumer.acknowledgeCumulative(msg);
+  ```
 
   </TabItem>
   <TabItem value="C#">
@@ -761,8 +791,27 @@ You can avoid running a loop by blocking calls with an event-based style by usin
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"
-  defaultValue="C++"
-  values={[{"label":"C++","value":"C++"},{"label":"Go","value":"Go"}]}>
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"},{"label":"Go","value":"Go"}]}>
+<TabItem value="Java">
+
+```java
+Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                      .topic("persistent://my-property/my-ns/my-topic")
+                      .subscriptionName("my-subscription")
+                      .messageListener((c, m) -> {
+                          try {
+                              c.acknowledge(m);
+                          } catch (Exception e) {
+                              Assert.fail("Failed to acknowledge", e);
+                          }
+                      })
+                      .subscribe();
+```
+
+</TabItem>
+
+
 <TabItem value="C++">
 
 This example starts a subscription at the earliest offset and consumes 100 messages.

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -11,24 +11,44 @@ import TabItem from '@theme/TabItem';
 
 After setting up your clients, you can explore more to start working with [producers](concepts-clients.md#producers).
 
+## Create the producer
 
-## Configure messages
-
-Pulsar clients provide an interface that you can use to construct and configure messages. Here's an example message:
+This example shows how to create a producer:
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"},{"label":"Go","value":"Go"},{"label":"Node.js","value":"Node.js"}]}>
+  values={[{"label":"Java","value":"Java"}]}>
+
+  <TabItem value="Java">
+
+  ```java
+Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic("my-topic")
+                .create();
+  ```
+
+  </TabItem>
+</Tabs>
+````
+
+## Send messages
+
+This example shows how to send messages using producers.
+
+````mdx-code-block
+<Tabs groupId="lang-choice"
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"},{"label":"Go","value":"Go"},{"label":"Node.js","value":"Node.js"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
    ```java
-   producer.newMessage()
-       .key("my-message-key")
-       .value("my-async-message".getBytes())
-       .property("my-key", "my-value")
-       .property("my-other-key", "my-other-value")
-       .send();
+  producer.newMessage()
+          .key("my-message-key")
+          .value("my-async-message")
+          .property("my-key", "my-value")
+          .property("my-other-key", "my-other-value")
+          .send();
    ```
 
    You can terminate the builder chain with `sendAsync()` and get a future return.
@@ -126,17 +146,7 @@ The following static methods are available for the message id object:
 | `deserialize(Buffer)` | Deserialize a message id object from a Buffer. | `Object` |
 
  </TabItem>
-</Tabs>
-````
 
-## Send messages
-
-This example shows how to send messages using producers.
-
-````mdx-code-block
-<Tabs groupId="lang-choice"
-  defaultValue="C#"
-  values={[{"label":"C#","value":"C#"}]}>
 <TabItem value="C#">
 
 ```csharp

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -13,7 +13,7 @@ After setting up your clients, you can explore more to start working with [produ
 
 ## Create the producer
 
-This example shows how to create a producer:
+This example shows how to create a producer.
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"


### PR DESCRIPTION
### Modification

* Add missing example codes for the java client
* Remove `Configure messages` section in the producer doc because it's already covered in `Send mesasges`

I think we also could delete [Send messages with customized metadata section](https://pulsar.apache.org/docs/next/client-libraries-producers/#send-messages-with-customized-metadata) because it's already covered in `Send mesasges`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
