### PR TITLE
[improve][doc] Restructure releases docs

### DIFF
--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -147,7 +147,7 @@ If you get error `c++: internal compiler error: Killed (program cc1plus)` when r
 
 :::caution
 
-The C++ client is now developing in a [separated repo](https://github.com/apache/pulsar-client-cpp). You should check its own [release guide](https://github.com/apache/pulsar-client-cpp/wiki/Committer-Release-Guide) if you're releasing version >= 3.0.0.  
+The C++ client is now developing in a [separated repo](https://github.com/apache/pulsar-client-cpp). You should check its own [release guide](https://github.com/apache/pulsar-client-cpp/wiki/Committer-Release-Guide) if you're releasing version >= 3.0.0.
 
 :::
 
@@ -464,7 +464,7 @@ poetry install
 poetry run bin/java-apidoc-generator.py 2.X.0
 ```
 
-Once the docs are generated, you can add them and submit them in a PR. The expected doc output is: 
+Once the docs are generated, you can add them and submit them in a PR. The expected doc output is:
 
 * `static/api/admin`
 * `static/api/client`

--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -3,7 +3,7 @@ id: validate-release-candidate
 title: Verifying release candidates
 ---
 
-The following are manual instructions for reviewing and validating a release candidate.
+This page contains manual instructions for reviewing and verifying a release candidate.
 
 ## Validate the binary distribution
 

--- a/sidebarsDevelopment.js
+++ b/sidebarsDevelopment.js
@@ -48,10 +48,16 @@ const sidebars = {
             type: "category",
             label: "Releases",
             items: [
-                'create-gpg-keys',
+                {
+                    type: "category",
+                    label: 'Release process',
+                    link: {type: 'doc', id: 'release-process'},
+                    items: [
+                        'create-gpg-keys',
+                        'release-note-guide',
+                    ]
+                },
                 'validate-release-candidate',
-                'release-process',
-                'release-note-guide',
                 'version-policy',
             ]
         },


### PR DESCRIPTION
Move "Creating GPG key" and "Release note guide" as subpages of "Release process".

Thanks for @Anonymitaet and @momo-jun's suggestion.

![image](https://user-images.githubusercontent.com/18818196/220382467-4bc5e85c-c016-44f5-a24e-27a25f59ff3b.png)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
