### PR TITLE
[fix][doc] resolve doc issues in schema, client, and reference

### DIFF
--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -52,6 +52,7 @@ The `schema-definition-file` is in JSON format.
 ```
 
 The `schema-definition-file` includes the following fields:
+
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 

--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -51,6 +51,13 @@ The `schema-definition-file` is in JSON format.
 }
 ```
 
+The `schema-definition-file` includes the following fields:
+| Field |  Description | 
+| --- | --- |
+|  `type`  |   The schema type. | 
+|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
+|  `properties`  |  The additional properties associated with the schema. | 
+
 The following is an example of the `schema-definition-file` for a JSON schema.
 
 **Example**

--- a/docs/client-libraries-cpp.md
+++ b/docs/client-libraries-cpp.md
@@ -21,7 +21,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 ## Reference doc
 
-- [API docs](@pulsar:apidoc:cpp@)
+- [API docs](pathname:///api/cpp)
 - [Release notes](/release-notes/client-cpp)
 - [C++ client configurations](client-libraries-cpp-configs.md)
 - [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples)

--- a/docs/client-libraries-cpp.md
+++ b/docs/client-libraries-cpp.md
@@ -21,7 +21,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 ## Reference doc
 
-- [API docs](pathname:///api/cpp)
+- [API docs](https://pulsar.apache.org/api/cpp/)
 - [Release notes](/release-notes/client-cpp)
 - [C++ client configurations](client-libraries-cpp-configs.md)
 - [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples)

--- a/docs/client-libraries-cpp.md
+++ b/docs/client-libraries-cpp.md
@@ -21,7 +21,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 ## Reference doc
 
-- [API docs](https://pulsar.apache.org/api/cpp/)
+- [API docs](@pulsar:apidoc:cpp@)
 - [Release notes](/release-notes/client-cpp)
 - [C++ client configurations](client-libraries-cpp-configs.md)
 - [C++ client examples](https://github.com/apache/pulsar-client-cpp/tree/main/examples)

--- a/static/reference/next/pulsar-daemon/pulsar-daemon.md
+++ b/static/reference/next/pulsar-daemon/pulsar-daemon.md
@@ -7,11 +7,9 @@ pulsar-daemon has a similar interface to the pulsar command but adds start and s
 ### `start`
 Start a service in the background using nohup.
 
-:::tip
+**Tip**
 
-You can use flags to perform more tasks. For example, `pulsar-daemon start standalone -nfw -nss` can start Pulsar faster in the background (without function workers and stream storage). `pulsar-daemon start standalone` flags are the same as `pulsar standalone` flags. For the complete flag list, see flags of the `pulsar standalone` command on the [Pulsar Reference Site](https://pulsar.apache.org/reference).
-
-:::
+> You can use flags to perform more tasks. For example, `pulsar-daemon start standalone -nfw -nss` can start Pulsar faster in the background (without function workers and stream storage). `pulsar-daemon start standalone` flags are the same as `pulsar standalone` flags. For the complete flag list, see flags of the `pulsar standalone` command on the [Pulsar Reference Site](https://pulsar.apache.org/reference).
 
 Usage
 

--- a/versioned_docs/version-2.10.x/schema-manage.md
+++ b/versioned_docs/version-2.10.x/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.11.x/admin-api-schemas.md
+++ b/versioned_docs/version-2.11.x/admin-api-schemas.md
@@ -52,6 +52,7 @@ The `schema-definition-file` is in JSON format.
 ```
 
 The `schema-definition-file` includes the following fields:
+
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 

--- a/versioned_docs/version-2.11.x/admin-api-schemas.md
+++ b/versioned_docs/version-2.11.x/admin-api-schemas.md
@@ -51,6 +51,13 @@ The `schema-definition-file` is in JSON format.
 }
 ```
 
+The `schema-definition-file` includes the following fields:
+| Field |  Description | 
+| --- | --- |
+|  `type`  |   The schema type. | 
+|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
+|  `properties`  |  The additional properties associated with the schema. | 
+
 The following is an example of the `schema-definition-file` for a JSON schema.
 
 **Example**

--- a/versioned_docs/version-2.2.0/schema-manage.md
+++ b/versioned_docs/version-2.2.0/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.2.1/schema-manage.md
+++ b/versioned_docs/version-2.2.1/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.3.0/schema-manage.md
+++ b/versioned_docs/version-2.3.0/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.3.1/schema-manage.md
+++ b/versioned_docs/version-2.3.1/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.3.2/schema-manage.md
+++ b/versioned_docs/version-2.3.2/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.4.0/schema-manage.md
+++ b/versioned_docs/version-2.4.0/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.4.1/schema-manage.md
+++ b/versioned_docs/version-2.4.1/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.4.2/schema-manage.md
+++ b/versioned_docs/version-2.4.2/schema-manage.md
@@ -175,7 +175,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -228,7 +228,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -245,7 +245,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.5.0/schema-manage.md
+++ b/versioned_docs/version-2.5.0/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.5.1/schema-manage.md
+++ b/versioned_docs/version-2.5.1/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.5.2/schema-manage.md
+++ b/versioned_docs/version-2.5.2/schema-manage.md
@@ -199,7 +199,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -252,7 +252,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -269,7 +269,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.6.0/schema-manage.md
+++ b/versioned_docs/version-2.6.0/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.6.1/schema-manage.md
+++ b/versioned_docs/version-2.6.1/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.6.2/schema-manage.md
+++ b/versioned_docs/version-2.6.2/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.6.3/schema-manage.md
+++ b/versioned_docs/version-2.6.3/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.6.4/schema-manage.md
+++ b/versioned_docs/version-2.6.4/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.0/schema-manage.md
+++ b/versioned_docs/version-2.7.0/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.1/schema-manage.md
+++ b/versioned_docs/version-2.7.1/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.2/schema-manage.md
+++ b/versioned_docs/version-2.7.2/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.3/schema-manage.md
+++ b/versioned_docs/version-2.7.3/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.4/schema-manage.md
+++ b/versioned_docs/version-2.7.4/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.7.5/schema-manage.md
+++ b/versioned_docs/version-2.7.5/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.8.x/schema-manage.md
+++ b/versioned_docs/version-2.8.x/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:

--- a/versioned_docs/version-2.9.x/schema-manage.md
+++ b/versioned_docs/version-2.9.x/schema-manage.md
@@ -200,7 +200,7 @@ The `schema-definition-file` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here are examples of the `schema-definition-file` for a JSON schema.
@@ -253,7 +253,7 @@ The post payload includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. |
 
 </TabItem>
@@ -270,7 +270,7 @@ The `PostSchemaPayload` includes the following fields:
 | Field |  Description | 
 | --- | --- |
 |  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a </li>**primitive**<li>schema, this field should be blank. </li><li>If the schema is a </li>**struct**<li>schema, this field should be a JSON string of the Avro schema definition. </li> | 
+| `schema` | The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> |
 |  `properties`  |  The additional properties associated with the schema. | 
 
 Here is an example of `PostSchemaPayload`:


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/19697 and https://github.com/apache/pulsar/issues/19675

- [x] `doc`

Preview looks good:

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/50226895/222603720-df466edc-281a-4847-be64-fe0aa74c8722.png">

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/50226895/222603739-ec658030-26f3-4e99-98a8-d216b82d194e.png">

Previews of other versioned docs are not attached. They will be in the correct formats since those contents are written in the same way (markdown).
