### PR TITLE
[fix][doc] Replace master version with a variable for specific versions in REST API links

### DIFF
--- a/versioned_docs/version-2.10.x/administration-isolation.md
+++ b/versioned_docs/version-2.10.x/administration-isolation.md
@@ -51,7 +51,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/createNamespace)
+[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">
@@ -111,7 +111,7 @@ For the bookie rack name restrictions, see [pulsar-admin bookies set-bookie-rack
 </TabItem>
 <TabItem value="REST API">
 
-[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/setBookieAffinityGroup)
+[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-2.10.x/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.10.x/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.11.x/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.11.x/reference-rest-api-overview.md
@@ -10,11 +10,11 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
-| [Transactions](/transactions-rest-api/?version=master) | REST APIs for transaction-specific operations.|
-| [Lookup](/lookup-rest-api/?version=master) | REST APIs for lookup-specific operations, such as getting the owner broker of a topic, getting the namespace bundle that a topic belongs to, and so on.|
+| [Admin](/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Transactions](/transactions-rest-api/?version=@pulsar:version_number@) | REST APIs for transaction-specific operations.|
+| [Lookup](/lookup-rest-api/?version=@pulsar:version_number@) | REST APIs for lookup-specific operations, such as getting the owner broker of a topic, getting the namespace bundle that a topic belongs to, and so on.|
 

--- a/versioned_docs/version-2.2.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.2.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.2.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.2.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.3.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.3.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.3.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.3.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.3.2/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.3.2/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.4.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.4.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.4.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.4.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.4.2/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.4.2/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.5.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.5.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.5.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.5.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.5.2/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.5.2/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.6.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.6.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.6.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.6.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.6.2/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.6.2/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.6.3/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.6.3/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.6.4/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.6.4/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.0/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.0/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.1/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.1/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.2/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.2/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.3/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.3/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.4/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.4/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.7.5/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.7.5/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.8.x/administration-isolation.md
+++ b/versioned_docs/version-2.8.x/administration-isolation.md
@@ -51,7 +51,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/createNamespace)
+[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">
@@ -102,7 +102,7 @@ bin/pulsar-admin namespaces set-bookie-affinity-group public/default \
 </TabItem>
 <TabItem value="REST API">
 
-[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/setBookieAffinityGroup)
+[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-2.8.x/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.8.x/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 

--- a/versioned_docs/version-2.9.x/administration-isolation.md
+++ b/versioned_docs/version-2.9.x/administration-isolation.md
@@ -51,7 +51,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/createNamespace)
+[PUT /admin/v2/namespaces/{tenant}/{namespace}](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">
@@ -102,7 +102,7 @@ bin/pulsar-admin namespaces set-bookie-affinity-group public/default \
 </TabItem>
 <TabItem value="REST API">
 
-[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=master&apiversion=v2#operation/setBookieAffinityGroup)
+[POST /admin/v2/namespaces/{tenant}/{namespace}/persistence/bookieAffinity](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@&apiversion=v2#operation/setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-2.9.x/reference-rest-api-overview.md
+++ b/versioned_docs/version-2.9.x/reference-rest-api-overview.md
@@ -10,9 +10,9 @@ Pulsar provides a variety of REST APIs that enable you to interact with Pulsar t
 
 | REST API category | Description |
 | --- | --- |
-| [Admin](https://pulsar.apache.org/admin-rest-api/?version=master) | REST APIs for administrative operations.|
-| [Functions](https://pulsar.apache.org/functions-rest-api/?version=master) | REST APIs for function-specific operations.|
-| [Sources](https://pulsar.apache.org/source-rest-api/?version=master) | REST APIs for source-specific operations.|
-| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=master) | REST APIs for sink-specific operations.|
-| [Packages](https://pulsar.apache.org/packages-rest-api/?version=master) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
+| [Admin](https://pulsar.apache.org/admin-rest-api/?version=@pulsar:version_number@) | REST APIs for administrative operations.|
+| [Functions](https://pulsar.apache.org/functions-rest-api/?version=@pulsar:version_number@) | REST APIs for function-specific operations.|
+| [Sources](https://pulsar.apache.org/source-rest-api/?version=@pulsar:version_number@) | REST APIs for source-specific operations.|
+| [Sinks](https://pulsar.apache.org/sink-rest-api/?version=@pulsar:version_number@) | REST APIs for sink-specific operations.|
+| [Packages](https://pulsar.apache.org/packages-rest-api/?version=@pulsar:version_number@) | REST APIs for package-specific operations. A package can be a group of functions, sources, and sinks.|
 


### PR DESCRIPTION
### Modifications

Replace the master version (`version=master`) with a variable for specific versions (`version=@pulsar:version_number@`) of REST API docs.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
