### PR TITLE
[improve][doc] Add sample code to use Copper Argos in Golang

### DIFF
--- a/docs/security-athenz.md
+++ b/docs/security-athenz.md
@@ -159,18 +159,19 @@ const client = new Pulsar.Client({
 <TabItem value="Go">
 
 ```go
-provider := pulsar.NewAuthenticationAthenz(
-		"pulsar",
-		"shopping",
-		"some_app",
-		"file:///path/to/private.pem",
-		"v1",
-		"",
-		"http://localhost:9998")
-client, err := pulsarNewClient(ClientOptions{
-		URL:                   "pulsar://my-broker.com:6650",
-		Authentication:        basicAuth,
-	})
+authParams := map[string]string{
+	"ztsUrl":         "http://localhost:9998",
+	"providerDomain": "pulsar",
+	"tenantDomain":   "shopping",
+	"tenantService":  "some_app",
+	"privateKey":     "file:///path/to/private.pem",
+	"keyId":          "v1",
+}
+
+client, err := pulsar.NewClient(ClientOptions{
+	URL:            "pulsar://my-broker.com:6650",
+	Authentication: pulsar.NewAuthenticationAthenz(authParams),
+})
 ```
 
 </TabItem>
@@ -181,7 +182,7 @@ client, err := pulsarNewClient(ClientOptions{
 
 Athenz has a mechanism called [Copper Argos](https://github.com/AthenZ/athenz/blob/master/docs/copper_argos.md). This means that ZTS distributes an X.509 certificate and private key pair to each service, which it can use to identify itself to other services within the organization.
 
-Pulsar currently supports Copper Argos only in the Java client. When using Copper Argos, you need to provide at least the following four parameters:
+Pulsar currently supports Copper Argos only in Java and Go. When using Copper Argos, you need to provide at least the following four parameters:
 * `providerDomain`
 * `x509CertChain`
 * `privateKey`
@@ -192,7 +193,7 @@ In this case, `tenantDomain`, `tenantService` and `keyId` are ignored.
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"}]}>
+  values={[{"label":"Java","value":"Java"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
 
 ```java
@@ -210,6 +211,24 @@ PulsarClient client = PulsarClient.builder()
         .serviceUrl("pulsar://my-broker.com:6650")
         .authentication(athenzAuth)
         .build();
+```
+
+</TabItem>
+<TabItem value="Go">
+
+```go
+authParams := map[string]string{
+	"ztsUrl":         "http://localhost:9998",
+	"providerDomain": "pulsar",
+	"x509CertChain":  "file:///path/to/x509cert.pem",
+	"privateKey":     "file:///path/to/private.pem",
+	"caCert":         "file:///path/to/cacert.pem",
+}
+
+client, err := pulsar.NewClient(ClientOptions{
+	URL:            "pulsar://my-broker.com:6650",
+	Authentication: pulsar.NewAuthenticationAthenz(authParams),
+})
 ```
 
 </TabItem>

--- a/docs/security-athenz.md
+++ b/docs/security-athenz.md
@@ -159,18 +159,18 @@ const client = new Pulsar.Client({
 <TabItem value="Go">
 
 ```go
-authParams := map[string]string{
+provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
 	"providerDomain": "pulsar",
 	"tenantDomain":   "shopping",
 	"tenantService":  "some_app",
 	"privateKey":     "file:///path/to/private.pem",
 	"keyId":          "v1",
-}
+})
 
-client, err := pulsar.NewClient(ClientOptions{
+client, err := pulsar.NewClient(pulsar.ClientOptions{
 	URL:            "pulsar://my-broker.com:6650",
-	Authentication: pulsar.NewAuthenticationAthenz(authParams),
+	Authentication: provider,
 })
 ```
 
@@ -217,17 +217,17 @@ PulsarClient client = PulsarClient.builder()
 <TabItem value="Go">
 
 ```go
-authParams := map[string]string{
+provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
 	"providerDomain": "pulsar",
 	"x509CertChain":  "file:///path/to/x509cert.pem",
 	"privateKey":     "file:///path/to/private.pem",
 	"caCert":         "file:///path/to/cacert.pem",
-}
+})
 
-client, err := pulsar.NewClient(ClientOptions{
+client, err := pulsar.NewClient(pulsar.ClientOptions{
 	URL:            "pulsar://my-broker.com:6650",
-	Authentication: pulsar.NewAuthenticationAthenz(authParams),
+	Authentication: provider,
 })
 ```
 


### PR DESCRIPTION
### Documentation

This is a continuation of https://github.com/apache/pulsar-site/pull/410. I've also added some parameters to the Athenz authentication provider for Golang to support Copper Argos (cf. https://github.com/apache/pulsar-client-go/pull/960), so I'll add sample code for Golang. Also, the existing sample code was wrong, so I fixed it.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
