### PR TITLE
explain the schema format for REST API & Java Admin API

### DIFF
--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -86,6 +86,26 @@ The post payload is in JSON format.
 }
 ```
 
+The payload includes the following fields:
+
+| Field |  Description | 
+| --- | --- |
+|  `type`  |   The schema type. | 
+|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
+|  `properties`  |  The additional properties associated with the schema. | 
+
+The following is an example of payload for a JSON schema.
+
+**Example**
+
+```json
+{
+    "type": "JSON",
+    "schema": "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.foo\",\"fields\":[{\"name\":\"file1\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file3\",\"type\":[\"string\",\"null\"],\"default\":\"dfdf\"}]}",
+    "properties": {}
+}
+```
+
 </TabItem>
 <TabItem value="Java Admin API">
 
@@ -104,6 +124,9 @@ payload.setSchema("");
 
 admin.createSchema("my-tenant/my-ns/my-topic", payload);
 ```
+
+If the schema is a **primitive** schema, the `schema` field should be blank.
+If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition.
 
 </TabItem>
 </Tabs>

--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -51,26 +51,6 @@ The `schema-definition-file` is in JSON format.
 }
 ```
 
-The `schema-definition-file` includes the following fields:
-
-| Field |  Description | 
-| --- | --- |
-|  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
-|  `properties`  |  The additional properties associated with the schema. | 
-
-The following is an example of the `schema-definition-file` for a JSON schema.
-
-**Example**
-
-```json
-{
-    "type": "JSON",
-    "schema": "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.foo\",\"fields\":[{\"name\":\"file1\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file3\",\"type\":[\"string\",\"null\"],\"default\":\"dfdf\"}]}",
-    "properties": {}
-}
-```
-
 </TabItem>
 <TabItem value="REST API">
 
@@ -83,26 +63,6 @@ The post payload is in JSON format.
     "type": "<schema-type>",
     "schema": "<an-utf8-encoded-string-of-schema-definition-data>",
     "properties": {} // the properties associated with the schema
-}
-```
-
-The payload includes the following fields:
-
-| Field |  Description | 
-| --- | --- |
-|  `type`  |   The schema type. | 
-|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
-|  `properties`  |  The additional properties associated with the schema. | 
-
-The following is an example of payload for a JSON schema.
-
-**Example**
-
-```json
-{
-    "type": "JSON",
-    "schema": "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.foo\",\"fields\":[{\"name\":\"file1\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file3\",\"type\":[\"string\",\"null\"],\"default\":\"dfdf\"}]}",
-    "properties": {}
 }
 ```
 
@@ -125,12 +85,32 @@ payload.setSchema("");
 admin.createSchema("my-tenant/my-ns/my-topic", payload);
 ```
 
-If the schema is a **primitive** schema, the `schema` field should be blank.
-If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition.
+If the schema is a **primitive** schema, the `schema` field must be blank.
+If the schema is a **struct** schema, this field must be a JSON string of the Avro schema definition.
 
 </TabItem>
 </Tabs>
 ````
+
+The payload includes the following fields:
+
+| Field |  Description | 
+| --- | --- |
+|  `type`  |   The schema type. | 
+|  `schema`  |   The schema definition data, which is encoded in UTF 8 charset. <li>If the schema is a **primitive** schema, this field should be blank. </li><li>If the schema is a **struct** schema, this field should be a JSON string of the Avro schema definition. </li> | 
+|  `properties`  |  The additional properties associated with the schema. | 
+
+The following is an example for a JSON schema.
+
+**Example**
+
+```json
+{
+    "type": "JSON",
+    "schema": "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.foo\",\"fields\":[{\"name\":\"file1\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"file3\",\"type\":[\"string\",\"null\"],\"default\":\"dfdf\"}]}",
+    "properties": {}
+}
+```
 
 ### Get the latest schema
 


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

![Screenshot 2023-03-07 at 19 08 01](https://user-images.githubusercontent.com/351773/223510754-94126f9d-dd0a-470f-b9ea-a47192e8c5c5.png)
![Screenshot 2023-03-07 at 19 08 12](https://user-images.githubusercontent.com/351773/223510789-74cc3271-b022-4513-8967-51cf2d1c04b9.png)

The docs explain that the schema format must be a JSON string of the Avro schema definition. However, it is explained only on the Admin CLI tab but not the REST & Java Client tab. 
This pull request fixes that.
However, this PR contains duplicated text. Is there a way to remove this duplication?
