### PR TITLE
[feat][doc] Add new configs `skipToLatest` and `compressionType`

### DIFF
--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -91,7 +91,7 @@ The following table outlines the nested fields and related arguments under the `
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
 | batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
+| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>|
 
 ###### Resources
 

--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -63,7 +63,7 @@ You can configure a function by using a predefined YAML file. The following tabl
 | maxPendingAsyncRequests | Int    | `--max-message-retries`    | The max number of pending async requests per instance to avoid a large number of concurrent requests. |
 | exposePulsarAdminClientEnabled | Boolean | N/A                | Whether the Pulsar admin client is exposed to function context or not. By default, it is disabled. |
 | subscriptionPosition | String    | `--subs-position`          | The position of Pulsar source subscription used for consuming messages from a specified location. The default value is `Latest`.|
-| skipToLatest         | Boolean   | `--skip-to-latest`         | Whether the consumer should skip to the latest message upon the function instance restarts. |
+| skipToLatest         | Boolean   | `--skip-to-latest`         | Whether the consumer should skip to the latest message once the function instance restarts. |
 
 ##### ConsumerConfig
 

--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -91,6 +91,7 @@ The following table outlines the nested fields and related arguments under the `
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
 | batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
+compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is `none` (no compression). <br />Available options:<li>[`LZ4`](https://github.com/lz4/lz4)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
 
 ###### Resources
 

--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -91,7 +91,7 @@ The following table outlines the nested fields and related arguments under the `
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
 | batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is `none` (no compression). <br />Available options:<li>[`LZ4`](https://github.com/lz4/lz4)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
+compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`None` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
 
 ###### Resources
 

--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -63,7 +63,7 @@ You can configure a function by using a predefined YAML file. The following tabl
 | maxPendingAsyncRequests | Int    | `--max-message-retries`    | The max number of pending async requests per instance to avoid a large number of concurrent requests. |
 | exposePulsarAdminClientEnabled | Boolean | N/A                | Whether the Pulsar admin client is exposed to function context or not. By default, it is disabled. |
 | subscriptionPosition | String    | `--subs-position`          | The position of Pulsar source subscription used for consuming messages from a specified location. The default value is `Latest`.|
-
+| skipToLatest         | Boolean   | `--skip-to-latest`         | Whether the consumer should skip to the latest message upon the function instance restarts. |
 
 ##### ConsumerConfig
 

--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -91,7 +91,7 @@ The following table outlines the nested fields and related arguments under the `
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
 | batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`None` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
+compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>
 
 ###### Resources
 


### PR DESCRIPTION
### Modifications

1. Add a new config `skipToLatest` to function docs, following https://github.com/apache/pulsar/pull/17214/.
2. Add a new config `compressionType` to function docs, following https://github.com/apache/pulsar/pull/19470.

Local preview:
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/60642177/225183687-2f426a80-a575-45ae-ac49-13603b4f26b0.png">

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/60642177/223952600-efc7a5fa-7113-4cb3-937d-30dc83e2dde5.png">



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
