### PR TITLE
[fix][doc] Markdown link in reference-terminology.md

### DIFF
--- a/docs/reference-terminology.md
+++ b/docs/reference-terminology.md
@@ -153,7 +153,7 @@ handles all message transfers. Pulsar clusters typically consist of multiple bro
 
 #### Dispatcher
 
-An asynchronous TCP server used for all data transfers in and out of a Pulsar [broker](#broker)](#broker). The Pulsar
+An asynchronous TCP server used for all data transfers in and out of a Pulsar [broker](#broker). The Pulsar
 dispatcher uses a custom binary protocol for all communications.
 
 ### Storage


### PR DESCRIPTION
### Documentation

Before
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/1689822/224256554-621cf381-36a8-4324-a61d-abbf7d2e12e1.png">

After
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/1689822/224256650-a4298990-f128-4cee-a23c-460d44d82b68.png">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
