### PR TITLE
[fix][doc] Remove CPP client lib requirements from Node.js client docs

### DIFF
--- a/docs/client-libraries-cpp-configs.md
+++ b/docs/client-libraries-cpp-configs.md
@@ -6,16 +6,16 @@ sidebar_label: "C++ client"
 
 ## Client configuration
 
-For all available configurations, see [`ClientConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_client_configuration.html)
+For all available configurations, see [`ClientConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_client_configuration.html).
 
 ## Producer configuration
 
-For all available configurations, see [`ProducerConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_producer_configuration.html)
+For all available configurations, see [`ProducerConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_producer_configuration.html).
 
 ## Consumer configuration
 
-For all available configurations, see [`ConsumerConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_consumer_configuration.html)
+For all available configurations, see [`ConsumerConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_consumer_configuration.html).
 
 ## Reader configuration
 
-For all available configurations, see [`ReaderConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_reader_configuration.html)
+For all available configurations, see [`ReaderConfiguration`](@pulsar:apidoc:cpp@/classpulsar_1_1_reader_configuration.html).

--- a/docs/client-libraries-node-setup.md
+++ b/docs/client-libraries-node-setup.md
@@ -6,23 +6,17 @@ sidebar_label: "Set up"
 
 ## Install Node.js client library
 
-:::tip
-
-Pulsar Node.js client library is based on the C++ client library. 
-* You must install the Pulsar C++ client library before installing a Node.js client. For more details, see [instructions](client-libraries-cpp.md).
-* If an incompatible version of the C++ client is installed, you may fail to build or run the Node.js library. For the compatibility between each version of the Node.js client and the C++ client, see [README](https://github.com/apache/pulsar-client-node/blob/master/README.md).
-
-:::
-
 Install the [`pulsar-client`](https://www.npmjs.com/package/pulsar-client) library via [npm](https://www.npmjs.com/):
 
 ```shell
 npm install pulsar-client
 ```
 
+For more information, see [README](https://github.com/apache/pulsar-client-node/blob/master/README.md).
+
 :::note
 
-This library only works in Node.js 10.x or later versions because it uses the [`node-addon-api`](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
+This library only works in Node.js 10.x or later versions because it uses the [`node-addon-api`](https://github.com/nodejs/node-addon-api) module.
 
 :::
 

--- a/versioned_docs/version-2.11.x/client-libraries-node.md
+++ b/versioned_docs/version-2.11.x/client-libraries-node.md
@@ -10,23 +10,17 @@ For 1.3.0 or later versions, [type definitions](https://github.com/apache/pulsar
 
 ## Installation
 
-:::tip
-
-Pulsar Node.js client library is based on the C++ client library. 
-* You must install the Pulsar C++ client library before installing a Node.js client. For more details, see [instructions](client-libraries-cpp.md).
-* If an incompatible version of the C++ client is installed, you may fail to build or run the Node.js library. For the compatibility between each version of the Node.js client and the C++ client, see [README](https://github.com/apache/pulsar-client-node/blob/master/README.md).
-
-:::
-
 Install the [`pulsar-client`](https://www.npmjs.com/package/pulsar-client) library via [npm](https://www.npmjs.com/):
 
 ```shell
 npm install pulsar-client
 ```
 
+For more information, see [README](https://github.com/apache/pulsar-client-node/blob/master/README.md).
+
 :::note
 
-This library only works in Node.js 10.x or later versions because it uses the [`node-addon-api`](https://github.com/nodejs/node-addon-api) module to wrap the C++ library.
+This library only works in Node.js 10.x or later versions because it uses the [`node-addon-api`](https://github.com/nodejs/node-addon-api) module.
 
 :::
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-node/issues/306.

The dependency on the CPP library has been removed for the latest Node.js client library.
The purpose of this fix is to:
1. set up simple and correct expectations for users and eliminate noise.
2. make sure the nitty gritty details are single-sourced in the README of the Node.js client lib.

### Modification

1. remove the out-of-date tips for requiring the CPP client lib.
2. paraphrase the backlink to the README of the Node.js client lib.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
