### PR TITLE
[improve][doc] Add configurations doc for the python client

### DIFF
--- a/docs/client-libraries-python-configs.md
+++ b/docs/client-libraries-python-configs.md
@@ -10,12 +10,12 @@ For all available configurations, see [`the constructor of the pulsar client`](@
 
 ## Producer configuration
 
-For all available configurations, see [`client.create_producer`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producer).
+For all available configurations, see [`client.create_producer`](@pulsar:apidoc:python@/pulsar.Client.html#create_producer).
 
 ## Consumer configuration
 
-For all available configurations, see [`client.subscribe`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producerl).
+For all available configurations, see [`client.subscribe`](@pulsar:apidoc:python@/pulsar.Client.html#subscribe).
 
 ## Reader configuration
 
-For all available configurations, see [`client.create_reader`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producer).
+For all available configurations, see [`client.create_reader`](@pulsar:apidoc:python@/pulsar.Client.html#create_reader).

--- a/docs/client-libraries-python-configs.md
+++ b/docs/client-libraries-python-configs.md
@@ -4,4 +4,18 @@ title: Pulsar Python client configurations
 sidebar_label: "Python client"
 ---
 
-Coming soon...
+## Client configuration
+
+For all available configurations, see [`the constructor of the pulsar client`](@pulsar:apidoc:python@/pulsar.Client.html#__init__).
+
+## Producer configuration
+
+For all available configurations, see [`client.create_producer`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producer).
+
+## Consumer configuration
+
+For all available configurations, see [`client.subscribe`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producerl).
+
+## Reader configuration
+
+For all available configurations, see [`client.create_reader`](@pulsar:apidoc:cpp@/pulsar.Client.html#create_producer).


### PR DESCRIPTION
Here are specific links for these configuration doc:
* Client: https://pulsar.apache.org/api/python/3.1.x/pulsar.Client.html#__init__
* Producer: https://pulsar.apache.org/api/python/3.1.x/pulsar.Client.html#create_producer
* Consumer: https://pulsar.apache.org/api/python/3.1.x/pulsar.Client.html#subscribe
* Reader: https://pulsar.apache.org/api/python/3.1.x/pulsar.Client.html#create_reader 



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
