### PR TITLE
[feat] Add canonical link for SEO

### DIFF
--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  PageMetadata,
+} from '@docusaurus/theme-common';
+import {
+  docVersionSearchTag,
+  DocsSidebarProvider,
+  DocsVersionProvider,
+  useDocRouteMetadata,
+} from '@docusaurus/theme-common/internal';
+import DocPageLayout from '@theme/DocPage/Layout';
+import NotFound from '@theme/NotFound';
+import SearchMetadata from '@theme/SearchMetadata';
+function DocPageMetadata(props) {
+  const {versionMetadata} = props;
+  return (
+    <>
+      <SearchMetadata
+        version={versionMetadata.version}
+        tag={docVersionSearchTag(
+          versionMetadata.pluginId,
+          versionMetadata.version,
+        )}
+      />
+      <PageMetadata>
+        {versionMetadata.noIndex && (
+          <meta name="robots" content="noindex, nofollow" />
+        )}
+      </PageMetadata>
+    </>
+  );
+}
+export default function DocPage(props) {
+  const {versionMetadata} = props;
+  const currentDocRouteMetadata = useDocRouteMetadata(props);
+  if (!currentDocRouteMetadata) {
+    return <NotFound />;
+  }
+  const {docElement, sidebarName, sidebarItems} = currentDocRouteMetadata;
+  return (
+    <>
+      <DocPageMetadata {...props} />
+      <HtmlClassNameProvider
+        className={clsx(
+          // TODO: it should be removed from here
+          ThemeClassNames.wrapper.docsPages,
+          ThemeClassNames.page.docsDocPage,
+          props.versionMetadata.className,
+        )}>
+        <DocsVersionProvider version={versionMetadata}>
+          <DocsSidebarProvider name={sidebarName} items={sidebarItems}>
+            <DocPageLayout>{docElement}</DocPageLayout>
+          </DocsSidebarProvider>
+        </DocsVersionProvider>
+      </HtmlClassNameProvider>
+    </>
+  );
+}

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -14,8 +14,16 @@ import {
 import DocPageLayout from '@theme/DocPage/Layout';
 import NotFound from '@theme/NotFound';
 import SearchMetadata from '@theme/SearchMetadata';
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+function createCanonicalHref(pathname) {
+  const {siteConfig} = useDocusaurusContext();
+  return siteConfig.url + useBaseUrl(pathname) + '/';
+}
+
 function DocPageMetadata(props) {
-  const {versionMetadata} = props;
+  const {versionMetadata, location} = props;
   return (
     <>
       <SearchMetadata
@@ -27,17 +35,19 @@ function DocPageMetadata(props) {
       />
       <PageMetadata>
         {versionMetadata.noIndex && (
-          <meta name="robots" content="noindex, nofollow" />
+          <meta name="robots" content="noindex, nofollow"/>
         )}
+        <link rel="canonical" href={createCanonicalHref(location.pathname)}/>
       </PageMetadata>
     </>
   );
 }
+
 export default function DocPage(props) {
   const {versionMetadata} = props;
   const currentDocRouteMetadata = useDocRouteMetadata(props);
   if (!currentDocRouteMetadata) {
-    return <NotFound />;
+    return <NotFound/>;
   }
   const {docElement, sidebarName, sidebarItems} = currentDocRouteMetadata;
   return (

--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -18,6 +18,8 @@ function createCanonicalHref(props: Props): string {
   const {siteConfig} = useDocusaurusContext();
   const {versionMetadata, location, match} = props;
   if (versionMetadata.version === 'current') {
+    // 1. The NEXT version docs should not forward to the latest stable version
+    // 2. Other plugins-doc instance (contribute, release-note, ...) happens to keep the link
     return siteConfig.url + useBaseUrl(location.pathname);
   }
   const basename = location.pathname.replace(match.path, '');

--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -5,7 +5,7 @@ import {
   DocsSidebarProvider,
   DocsVersionProvider,
   docVersionSearchTag,
-  useDocRouteMetadata, useDocsVersion,
+  useDocRouteMetadata,
 } from '@docusaurus/theme-common/internal';
 import DocPageLayout from '@theme/DocPage/Layout';
 import NotFound from '@theme/NotFound';

--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -5,7 +5,7 @@ import {
   DocsSidebarProvider,
   DocsVersionProvider,
   docVersionSearchTag,
-  useDocRouteMetadata,
+  useDocRouteMetadata, useDocsVersion,
 } from '@docusaurus/theme-common/internal';
 import DocPageLayout from '@theme/DocPage/Layout';
 import NotFound from '@theme/NotFound';
@@ -14,12 +14,19 @@ import type {Props} from '@theme/DocPage';
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-function createCanonicalHref(pathname: string): string {
+function createCanonicalHref(props: Props): string {
   const {siteConfig} = useDocusaurusContext();
-  return siteConfig.url + useBaseUrl(pathname);
+  const {versionMetadata, location, match} = props;
+  if (versionMetadata.version === 'current') {
+    return siteConfig.url + useBaseUrl(location.pathname);
+  }
+  const basename = location.pathname.replace(match.path, '');
+  return siteConfig.url + useBaseUrl(`/docs/${basename}`);
 }
 function DocPageMetadata(props: Props): JSX.Element {
   const {versionMetadata} = props;
+  console.log(`props=${JSON.stringify(props)}`);
+  console.log(`result=${createCanonicalHref(props)}`);
   return (
     <>
       <SearchMetadata
@@ -33,7 +40,7 @@ function DocPageMetadata(props: Props): JSX.Element {
         {versionMetadata.noIndex && (
           <meta name="robots" content="noindex, nofollow" />
         )}
-        <link rel="canonical" href={createCanonicalHref(location.pathname)}/>
+        <link rel="canonical" href={createCanonicalHref(props)}/>
       </PageMetadata>
     </>
   );

--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -25,8 +25,6 @@ function createCanonicalHref(props: Props): string {
 }
 function DocPageMetadata(props: Props): JSX.Element {
   const {versionMetadata} = props;
-  console.log(`props=${JSON.stringify(props)}`);
-  console.log(`result=${createCanonicalHref(props)}`);
   return (
     <>
       <SearchMetadata

--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -1,29 +1,25 @@
 import React from 'react';
 import clsx from 'clsx';
+import {HtmlClassNameProvider, PageMetadata, ThemeClassNames,} from '@docusaurus/theme-common';
 import {
-  HtmlClassNameProvider,
-  ThemeClassNames,
-  PageMetadata,
-} from '@docusaurus/theme-common';
-import {
-  docVersionSearchTag,
   DocsSidebarProvider,
   DocsVersionProvider,
+  docVersionSearchTag,
   useDocRouteMetadata,
 } from '@docusaurus/theme-common/internal';
 import DocPageLayout from '@theme/DocPage/Layout';
 import NotFound from '@theme/NotFound';
 import SearchMetadata from '@theme/SearchMetadata';
-import useBaseUrl from "@docusaurus/useBaseUrl";
+import type {Props} from '@theme/DocPage';
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
-function createCanonicalHref(pathname) {
+function createCanonicalHref(pathname: string): string {
   const {siteConfig} = useDocusaurusContext();
-  return siteConfig.url + useBaseUrl(pathname) + '/';
+  return siteConfig.url + useBaseUrl(pathname);
 }
-
-function DocPageMetadata(props) {
-  const {versionMetadata, location} = props;
+function DocPageMetadata(props: Props): JSX.Element {
+  const {versionMetadata} = props;
   return (
     <>
       <SearchMetadata
@@ -35,7 +31,7 @@ function DocPageMetadata(props) {
       />
       <PageMetadata>
         {versionMetadata.noIndex && (
-          <meta name="robots" content="noindex, nofollow"/>
+          <meta name="robots" content="noindex, nofollow" />
         )}
         <link rel="canonical" href={createCanonicalHref(location.pathname)}/>
       </PageMetadata>
@@ -43,11 +39,11 @@ function DocPageMetadata(props) {
   );
 }
 
-export default function DocPage(props) {
+export default function DocPage(props: Props): JSX.Element {
   const {versionMetadata} = props;
   const currentDocRouteMetadata = useDocRouteMetadata(props);
   if (!currentDocRouteMetadata) {
-    return <NotFound/>;
+    return <NotFound />;
   }
   const {docElement, sidebarName, sidebarItems} = currentDocRouteMetadata;
   return (


### PR DESCRIPTION
This closes https://github.com/apache/pulsar/issues/18190.

Here are some screenshots for the result:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/226602982-231c25fb-f319-44af-a55f-0933e4a4eb22.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/226602991-2df00687-f172-4825-baf5-37ed44ccad15.png">

The "canonical" link are the only element in head metadata, no duplicate or confusion.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
