### PR TITLE
[improve][doc] Clarify the scope of delayed msg delivery

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -490,7 +490,7 @@ A subscription is a named configuration rule that determines how messages are de
 **Pub-Sub or Queuing**
   In Pulsar, you can use different subscriptions flexibly.
   * If you want to achieve traditional "fan-out pub-sub messaging" among consumers, specify a unique subscription name for each consumer. It is an exclusive subscription type.
-  * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers(shared, failover, key_shared).
+  * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers (shared, failover, key_shared).
   * If you want to achieve both effects simultaneously, combine exclusive subscription types with other subscription types for consumers.
 
 :::
@@ -534,9 +534,7 @@ In the diagram below, **Consumer A**, **Consumer B** and **Consumer C** are all 
 
 :::note
 
-When using Shared type, be aware that:
- * Message ordering is not guaranteed.
- * You cannot use cumulative acknowledgment with Shared type.
+Shared subscriptions do not guarantee message ordering or support cumulative acknowledgment.
 
 :::
 
@@ -745,10 +743,10 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 
 :::note
 
-When you use Key_Shared type, be aware that:
+When you use Key_Shared subscriptions, be aware that:
   * You need to specify a key or ordering key for messages.
-  * You cannot use cumulative acknowledgment with Key_Shared type.
-  * When the position of the newest message in a topic is `X`, a key-shared consumer that is newly attached to the same subscription and connected to the topic will **not** receive any messages until all the messages before `X` have been acknowledged.
+  * You cannot use cumulative acknowledgment.
+  * When the position of the newest message in a topic is `X`, a key_shared consumer that is newly attached to the same subscription and connected to the topic will **not** receive any messages until all the messages before `X` have been acknowledged.
 
 :::
 
@@ -940,7 +938,7 @@ Non-persistent messaging is usually faster than persistent messaging because bro
 
 ### Client API
 
-Producers and consumers can connect to non-persistent topics in the same way as persistent topics, with the crucial difference that the topic name must start with `non-persistent`. All the subscription types---[exclusive](#exclusive), [shared](#shared), [key-shared](#key_shared) and [failover](#failover)---are supported for non-persistent topics.
+Producers and consumers can connect to non-persistent topics in the same way as persistent topics, with the crucial difference that the topic name must start with `non-persistent`. All the subscription types---[exclusive](#exclusive), [shared](#shared), [key_shared](#key_shared) and [failover](#failover)---are supported for non-persistent topics.
 
 Here's an example [Java consumer](client-libraries-java-use.md#create-a-consumer) for a non-persistent topic:
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -418,7 +418,7 @@ With message chunking enabled, when the size of a message exceeds the allowed ma
 :::note
 
 - Chunking is only available for persistent topics.
-- Chunking cannot be enabled simultaneously with batching.
+- Chunking cannot be enabled simultaneously with batching. Before enabling chunking, you need to disable batching.
 
 :::
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -365,7 +365,7 @@ Message compression can reduce message size by paying some CPU overhead. The Pul
 * [LZ4](https://github.com/lz4/lz4)
 * [ZLIB](https://zlib.net/)
 * [ZSTD](https://facebook.github.io/zstd/)
-* [SNAPPY](https://google.github.io/snappy/).
+* [SNAPPY](https://google.github.io/snappy/)
 
 Compression types are stored in the message metadata, so consumers can adopt different compression types automatically, as needed.
 
@@ -415,9 +415,12 @@ With message chunking enabled, when the size of a message exceeds the allowed ma
 3. The consumer buffers the chunked messages and aggregates them into the receiver queue when it receives all the chunks of a message.
 4. The client consumes the aggregated message from the receiver queue.
 
-**Limitations:**
-- Chunking is only available for persisted topics.
+:::note
+
+- Chunking is only available for persistent topics.
 - Chunking cannot be enabled simultaneously with batching.
+
+:::
 
 #### Handle consecutive chunked messages with one ordered consumer
 
@@ -531,8 +534,7 @@ In the diagram below, **Consumer A**, **Consumer B** and **Consumer C** are all 
 
 :::note
 
-**Limitations of Shared type**
- When using Shared type, be aware that:
+When using Shared type, be aware that:
  * Message ordering is not guaranteed.
  * You cannot use cumulative acknowledgment with Shared type.
 
@@ -742,8 +744,6 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 ````
 
 :::note
-
-**Limitations of Key_Shared type**
 
 When you use Key_Shared type, be aware that:
   * You need to specify a key or ordering key for messages.
@@ -1071,6 +1071,12 @@ The diagram below illustrates the concept of delayed message delivery:
 ![Delayed Message Delivery](/assets/message-delay.svg)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
+
+:::note
+
+Only shared subscription supports delayed message delivery.
+
+:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1049,8 +1049,12 @@ Message deduplication is disabled in the scenario shown at the top. Here, a prod
 
 In the second scenario at the bottom, the producer publishes message 1, which is received by the broker and persisted, as in the first scenario. When the producer attempts to publish the message again, however, the broker knows that it has already seen message 1 and thus does not persist the message.
 
-> Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
-> You can read the design of Message Deduplication in [PIP-6](https://github.com/aahmed-se/pulsar-wiki/blob/master/PIP-6:-Guaranteed-Message-Deduplication.md).
+:::tip
+
+- Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
+- You can read the design of Message Deduplication in [PIP-6](https://github.com/aahmed-se/pulsar-wiki/blob/master/PIP-6:-Guaranteed-Message-Deduplication.md).
+
+:::
 
 ### Producer idempotency
 
@@ -1064,19 +1068,17 @@ Message deduplication makes Pulsar an ideal messaging system to be used in conju
 ## Delayed message delivery
 Delayed message delivery enables you to consume a message later. In this mechanism, a message is stored in BookKeeper. The `DelayedDeliveryTracker` maintains the time index (time -> messageId) in memory after the message is published to a broker. This message will be delivered to a consumer once the specified delay is over.
 
-Delayed message delivery only works in the Shared subscription type. In the Exclusive and Failover subscription types, the delayed message is dispatched immediately.
+:::note
+
+Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+
+:::
 
 The diagram below illustrates the concept of delayed message delivery:
 
 ![Delayed Message Delivery](/assets/message-delay.svg)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
-
-:::note
-
-Only shared subscription supports delayed message delivery.
-
-:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -942,12 +942,15 @@ The following diagram illustrates what happens when message deduplication is dis
 
 ![Pulsar message deduplication](/assets/message-deduplication.png)
 
-
 Message deduplication is disabled in the scenario shown at the top. Here, a producer publishes message 1 on a topic; the message reaches a Pulsar broker and is [persisted](concepts-architecture-overview.md#persistent-storage) to BookKeeper. The producer then sends message 1 again (in this case due to some retry logic), and the message is received by the broker and stored in BookKeeper again, which means that duplication has occurred.
 
 In the second scenario at the bottom, the producer publishes message 1, which is received by the broker and persisted, as in the first scenario. When the producer attempts to publish the message again, however, the broker knows that it has already seen message 1 and thus does not persist the message.
 
-> Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
+:::tip
+
+Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
+
+:::
 
 
 ### Producer idempotency
@@ -963,19 +966,17 @@ Message deduplication makes Pulsar an ideal messaging system to be used in conju
 ## Delayed message delivery
 Delayed message delivery enables you to consume a message later. In this mechanism, a message is stored in BookKeeper. The `DelayedDeliveryTracker` maintains the time index (time -> messageId) in memory after the message is published to a broker. This message will be delivered to a consumer once the specified delay is over.
 
-Delayed message delivery only works in Shared subscription type. In Exclusive and Failover subscription types, the delayed message is dispatched immediately.
+:::note
+
+Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+
+:::
 
 The diagram below illustrates the concept of delayed message delivery:
 
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
-
-:::note
-
-Only shared subscription supports delayed message delivery.
-
-:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -119,10 +119,13 @@ With message chunking enabled, when the size of a message exceeds the allowed ma
 3. The consumer buffers the chunked messages and aggregates them into the receiver queue when it receives all the chunks of a message.
 4. The client consumes the aggregated message from the receiver queue.
 
-**Limitations:**
-- Chunking is only available for persisted topics.
+:::note
+
+- Chunking is only available for persistent topics.
 - Chunking is only available for the exclusive and failover subscription types.
-- Chunking cannot be enabled simultaneously with batching.
+- Chunking cannot be enabled simultaneously with batching. Before enabling chunking, you need to disable batching.
+
+:::
 
 #### Handle consecutive chunked messages with one ordered consumer
 
@@ -572,10 +575,13 @@ In *shared* or *round robin* type, multiple consumers can attach to the same sub
 
 In the diagram below, **Consumer-C-1** and **Consumer-C-2** are able to subscribe to the topic, but **Consumer-C-3** and others could as well.
 
-> **Limitations of Shared type**
-> When using Shared type, be aware that:
-> * Message ordering is not guaranteed.
-> * You cannot use cumulative acknowledgment with Shared type.
+:::note
+
+When using Shared type, be aware that:
+* Message ordering is not guaranteed.
+* You cannot use cumulative acknowledgment with Shared type.
+
+:::
 
 ![Shared subscriptions](/assets/pulsar-shared-subscriptions.png)
 
@@ -634,10 +640,13 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 </Tabs>
 ````
 
-> **Limitations of Key_Shared type**
-> When you use Key_Shared type, be aware that:
-> * You need to specify a key or orderingKey for messages.
-> * You cannot use cumulative acknowledgment with Key_Shared type.
+:::note
+
+When you use Key_Shared type, be aware that:
+* You need to specify a key or orderingKey for messages.
+* You cannot use cumulative acknowledgment with Key_Shared type.
+
+:::
 
 ### Subscription modes
 
@@ -961,6 +970,12 @@ The diagram below illustrates the concept of delayed message delivery:
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
+
+:::note
+
+Only shared subscription supports delayed message delivery.
+
+:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -545,7 +545,7 @@ A subscription is a named configuration rule that determines how messages are de
 **Pub-Sub or Queuing**
   In Pulsar, you can use different subscriptions flexibly.
   * If you want to achieve traditional "fan-out pub-sub messaging" among consumers, specify a unique subscription name for each consumer. It is an exclusive subscription type.
-  * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers(shared, failover, key_shared).
+  * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers (shared, failover, key_shared).
   * If you want to achieve both effects simultaneously, combine exclusive subscription types with other subscription types for consumers.
 
 :::
@@ -589,9 +589,7 @@ In the diagram below, **Consumer A**, **Consumer B** and **Consumer C** are all 
 
 :::note
 
-When using Shared type, be aware that:
- * Message ordering is not guaranteed.
- * You cannot use cumulative acknowledgment with Shared type.
+Shared subscriptions do not guarantee message ordering or support cumulative acknowledgment.
 
 :::
 
@@ -803,7 +801,7 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 When you use Key_Shared type, be aware that:
   * You need to specify a key or ordering key for messages.
   * You cannot use cumulative acknowledgment with Key_Shared type.
-  * When the position of the newest message in a topic is `X`, a key-shared consumer that is newly attached to the same subscription and connected to the topic will **not** receive any messages until all the messages before `X` have been acknowledged.
+  * When the position of the newest message in a topic is `X`, a key_shared consumer that is newly attached to the same subscription and connected to the topic will **not** receive any messages until all the messages before `X` have been acknowledged.
 
 :::
 
@@ -995,7 +993,7 @@ Non-persistent messaging is usually faster than persistent messaging because bro
 
 ### Client API
 
-Producers and consumers can connect to non-persistent topics in the same way as persistent topics, with the crucial difference that the topic name must start with `non-persistent`. All the subscription types---[exclusive](#exclusive), [shared](#shared), [key-shared](#key_shared) and [failover](#failover)---are supported for non-persistent topics.
+Producers and consumers can connect to non-persistent topics in the same way as persistent topics, with the crucial difference that the topic name must start with `non-persistent`. All the subscription types---[exclusive](#exclusive), [shared](#shared), [key_shared](#key_shared) and [failover](#failover)---are supported for non-persistent topics.
 
 Here's an example [Java consumer](client-libraries-java.md#consumer) for a non-persistent topic:
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1104,8 +1104,12 @@ Message deduplication is disabled in the scenario shown at the top. Here, a prod
 
 In the second scenario at the bottom, the producer publishes message 1, which is received by the broker and persisted, as in the first scenario. When the producer attempts to publish the message again, however, the broker knows that it has already seen message 1 and thus does not persist the message.
 
-> Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
-> You can read the design of Message Deduplication in [PIP-6](https://github.com/aahmed-se/pulsar-wiki/blob/master/PIP-6:-Guaranteed-Message-Deduplication.md).
+:::tip
+
+- Message deduplication is handled at the namespace level or the topic level. For more instructions, see the [message deduplication cookbook](cookbooks-deduplication.md).
+- You can read the design of Message Deduplication in [PIP-6](https://github.com/aahmed-se/pulsar-wiki/blob/master/PIP-6:-Guaranteed-Message-Deduplication.md).
+
+:::
 
 ### Producer idempotency
 
@@ -1119,19 +1123,17 @@ Message deduplication makes Pulsar an ideal messaging system to be used in conju
 ## Delayed message delivery
 Delayed message delivery enables you to consume a message later. In this mechanism, a message is stored in BookKeeper. The `DelayedDeliveryTracker` maintains the time index (time -> messageId) in memory after the message is published to a broker. This message will be delivered to a consumer once the specified delay is over.
 
-Delayed message delivery only works in the Shared subscription type. In the Exclusive and Failover subscription types, the delayed message is dispatched immediately.
+:::note
+
+Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+
+:::
 
 The diagram below illustrates the concept of delayed message delivery:
 
 ![Delayed Message Delivery](/assets/message-delay.svg)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
-
-:::note
-
-Only shared subscription supports delayed message delivery.
-
-:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -93,7 +93,7 @@ Message compression can reduce message size by paying some CPU overhead. The Pul
 * [LZ4](https://github.com/lz4/lz4)
 * [ZLIB](https://zlib.net/)
 * [ZSTD](https://facebook.github.io/zstd/)
-* [SNAPPY](https://google.github.io/snappy/).
+* [SNAPPY](https://google.github.io/snappy/)
 
 Compression types are stored in the message metadata, so consumers can adopt different compression types automatically, as needed.
 
@@ -143,9 +143,12 @@ With message chunking enabled, when the size of a message exceeds the allowed ma
 3. The consumer buffers the chunked messages and aggregates them into the receiver queue when it receives all the chunks of a message.
 4. The client consumes the aggregated message from the receiver queue.
 
-**Limitations:**
-- Chunking is only available for persisted topics.
-- Chunking cannot be enabled simultaneously with batching.
+:::note
+
+- Chunking is only available for persistent topics.
+- Chunking cannot be enabled simultaneously with batching. Before enabling chunking, you need to disable batching.
+
+:::
 
 #### Handle consecutive chunked messages with one ordered consumer
 
@@ -586,8 +589,7 @@ In the diagram below, **Consumer A**, **Consumer B** and **Consumer C** are all 
 
 :::note
 
-**Limitations of Shared type**
- When using Shared type, be aware that:
+When using Shared type, be aware that:
  * Message ordering is not guaranteed.
  * You cannot use cumulative acknowledgment with Shared type.
 
@@ -797,8 +799,6 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 ````
 
 :::note
-
-**Limitations of Key_Shared type**
 
 When you use Key_Shared type, be aware that:
   * You need to specify a key or ordering key for messages.
@@ -1126,6 +1126,12 @@ The diagram below illustrates the concept of delayed message delivery:
 ![Delayed Message Delivery](/assets/message-delay.svg)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
+
+:::note
+
+Only shared subscription supports delayed message delivery.
+
+:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -107,10 +107,14 @@ To avoid redelivering acknowledged messages in a batch to the consumer, Pulsar i
 By default, batch index acknowledgement is disabled (`acknowledgmentAtBatchIndexLevelEnabled=false`). You can enable batch index acknowledgement by setting the `acknowledgmentAtBatchIndexLevelEnabled` parameter to `true` at the broker side. Enabling batch index acknowledgement results in more memory overheads.
 
 ### Chunking
-When you enable chunking, read the following instructions.
-- Batching and chunking cannot be enabled simultaneously. To enable chunking, you must disable batching in advance.
-- Chunking is only supported for persisted topics.
-- Chunking is only supported for the exclusive and failover subscription types.
+
+:::note
+
+- Chunking is only available for persistent topics.
+- Chunking is only available for the exclusive and failover subscription types.
+- Chunking cannot be enabled simultaneously with batching. Before enabling chunking, you need to disable batching.
+
+:::
 
 When chunking is enabled (`chunkingEnabled=true`), if the message size is greater than the allowed maximum publish-payload size, the producer splits the original message into chunked messages and publishes them with chunked metadata to the broker separately and in order. At the broker side, the chunked messages are stored in the managed-ledger in the same way as that of ordinary messages. The only difference is that the consumer needs to buffer the chunked messages and combines them into the real message when all chunked messages have been collected. The chunked messages in the managed-ledger can be interwoven with ordinary messages. If producer fails to publish all the chunks of a message, the consumer can expire incomplete chunks if consumer fail to receive all chunks in expire time. By default, the expire time is set to one minute.
 
@@ -345,10 +349,13 @@ In *shared* or *round robin* mode, multiple consumers can attach to the same sub
 
 In the diagram below, **Consumer-C-1** and **Consumer-C-2** are able to subscribe to the topic, but **Consumer-C-3** and others could as well.
 
-> **Limitations of Shared type**
-> When using Shared type, be aware that:
-> * Message ordering is not guaranteed.
-> * You cannot use cumulative acknowledgment with Shared type.
+:::note
+
+When using Shared type, be aware that:
+ * Message ordering is not guaranteed.
+ * You cannot use cumulative acknowledgment with Shared type.
+
+:::
 
 ![Shared subscriptions](/assets/pulsar-shared-subscriptions.png)
 
@@ -356,11 +363,14 @@ In the diagram below, **Consumer-C-1** and **Consumer-C-2** are able to subscrib
 
 In *Key_Shared* type, multiple consumers can attach to the same subscription. Messages are delivered in a distribution across consumers and message with same key or same ordering key are delivered to only one consumer. No matter how many times the message is re-delivered, it is delivered to the same consumer. When a consumer connected or disconnected will cause served consumer change for some key of message.
 
-> **Limitations of Key_Shared type**
-> When you use Key_Shared type, be aware that:
-> * You need to specify a key or orderingKey for messages.
-> * You cannot use cumulative acknowledgment with Key_Shared type.
-> * Your producers should disable batching or use a key-based batch builder.
+:::note
+
+When you use Key_Shared type, be aware that:
+* You need to specify a key or orderingKey for messages.
+* You cannot use cumulative acknowledgment with Key_Shared type.
+* Your producers should disable batching or use a key-based batch builder.
+
+:::
 
 ![Key_Shared subscriptions](/assets/pulsar-key-shared-subscriptions.png)
 
@@ -671,6 +681,12 @@ The diagram below illustrates the concept of delayed message delivery:
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
+
+:::note
+
+Only shared subscription supports delayed message delivery.
+
+:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -674,19 +674,17 @@ Message deduplication makes Pulsar an ideal messaging system to be used in conju
 ## Delayed message delivery
 Delayed message delivery enables you to consume a message later rather than immediately. In this mechanism, a message is stored in BookKeeper, `DelayedDeliveryTracker` maintains the time index(time -> messageId) in memory after published to a broker, and it is delivered to a consumer once the specific delayed time is passed.
 
-Delayed message delivery only works in Shared subscription type. In Exclusive and Failover subscription types, the delayed message is dispatched immediately.
+:::note
+
+Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+
+:::
 
 The diagram below illustrates the concept of delayed message delivery:
 
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
-
-:::note
-
-Only shared subscription supports delayed message delivery.
-
-:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -688,19 +688,17 @@ Message deduplication makes Pulsar an ideal messaging system to be used in conju
 ## Delayed message delivery
 Delayed message delivery enables you to consume a message later rather than immediately. In this mechanism, a message is stored in BookKeeper, `DelayedDeliveryTracker` maintains the time index(time -> messageId) in memory after published to a broker, and it is delivered to a consumer once the specific delayed time is passed.
 
-Delayed message delivery only works in Shared subscription mode. In Exclusive and Failover subscription modes, the delayed message is dispatched immediately.
+:::note
+
+Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+
+:::
 
 The diagram below illustrates the concept of delayed message delivery:
 
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
-
-:::note
-
-Only shared subscription supports delayed message delivery.
-
-:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -109,10 +109,14 @@ To avoid redelivering acknowledged messages in a batch to the consumer, Pulsar i
 By default, batch index acknowledgement is disabled (`acknowledgmentAtBatchIndexLevelEnabled=false`). You can enable batch index acknowledgement by setting the `acknowledgmentAtBatchIndexLevelEnabled` parameter to `true` at the broker side. Enabling batch index acknowledgement results in more memory overheads.
 
 ### Chunking
-Before you enable chunking, read the following instructions.
-- Batching and chunking cannot be enabled simultaneously. To enable chunking, you must disable batching in advance.
-- Chunking is only supported for persisted topics.
-- Chunking is only supported for the exclusive and failover subscription modes.
+
+:::note
+
+- Chunking is only available for persistent topics.
+- Chunking is only available for the exclusive and failover subscription types.
+- Chunking cannot be enabled simultaneously with batching. Before enabling chunking, you need to disable batching.
+
+:::
 
 When chunking is enabled (`chunkingEnabled=true`), if the message size is greater than the allowed maximum publish-payload size, the producer splits the original message into chunked messages and publishes them with chunked metadata to the broker separately and in order. At the broker side, the chunked messages are stored in the managed-ledger in the same way as that of ordinary messages. The only difference is that the consumer needs to buffer the chunked messages and combines them into the real message when all chunked messages have been collected. The chunked messages in the managed-ledger can be interwoven with ordinary messages. If producer fails to publish all the chunks of a message, the consumer can expire incomplete chunks if consumer fail to receive all chunks in expire time. By default, the expire time is set to one minute.
 
@@ -374,10 +378,13 @@ In *shared* or *round robin* mode, multiple consumers can attach to the same sub
 
 In the diagram below, **Consumer-C-1** and **Consumer-C-2** are able to subscribe to the topic, but **Consumer-C-3** and others could as well.
 
-> **Limitations of shared mode**
-> When using shared mode, be aware that:
-> * Message ordering is not guaranteed.
-> * You cannot use cumulative acknowledgment with shared mode.
+:::note
+
+When using shared mode, be aware that:
+* Message ordering is not guaranteed.
+* You cannot use cumulative acknowledgment with shared mode.
+
+:::
 
 ![Shared subscriptions](/assets/pulsar-shared-subscriptions.png)
 
@@ -436,10 +443,13 @@ producer = client.create_producer(topic='my-topic', batching_type=pulsar.Batchin
 </Tabs>
 ````
 
-> **Limitations of Key_Shared mode**
-> When you use Key_Shared mode, be aware that:
-> * You need to specify a key or orderingKey for messages.
-> * You cannot use cumulative acknowledgment with Key_Shared mode.
+:::note
+
+When you use Key_Shared mode, be aware that:
+* You need to specify a key or orderingKey for messages.
+* You cannot use cumulative acknowledgment with Key_Shared mode.
+
+:::
 
 ## Multi-topic subscriptions
 
@@ -685,6 +695,12 @@ The diagram below illustrates the concept of delayed message delivery:
 ![Delayed Message Delivery](/assets/message_delay.png)
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
+
+:::note
+
+Only shared subscription supports delayed message delivery.
+
+:::
 
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:


### PR DESCRIPTION
### Modification

1. Highlight and clarify the scope of delayed msg delivery.
2. Minor fixes and style alignment.

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/60642177/227141439-19dad5f7-9dc1-4cff-81ab-47bbc8d839a2.png">

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
