### PR TITLE
[improve][doc] relocate "Get Started" (pulsar-admin) to admin API and correct inaccurate descriptions

### DIFF
--- a/docs/admin-api-clusters.md
+++ b/docs/admin-api-clusters.md
@@ -21,6 +21,8 @@ Category|Method|If you want to manage clusters...
 [Pulsar admin APIs](admin-api-overview.md)| {@inject: rest:REST API:/}, which lists all parameters, responses, samples, and more.|See the `/admin/v2/clusters` endpoint
 [Pulsar admin APIs](admin-api-overview.md)|[Java admin API](/api/admin/), which lists all classes, methods, descriptions, and more.|See the `clusters` method of the `PulsarAdmin` object
 
+You can perform the following operations on [clusters](reference-terminology.md#cluster).
+
 ## Provision cluster
 
 You can provision new clusters using the admin interface.
@@ -260,33 +262,3 @@ admin.clusters().deleteCluster(clusterName);
 
 </Tabs>
 ````
-
-
-
-:::tip
-
-This page only shows **some frequently used operations**. For the latest and complete information, see the **reference docs** below.
-
- - [Pulsar CLI](reference-cli-tools.md)
-
-   - [pulsar-admin](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/), which lists all commands, flags, descriptions, and more.
-
- - [Pulsar admin APIs](admin-api-overview.md)
-
-   - {@inject: rest:REST API:/}, which lists all parameters, responses, samples, and more.
-
-   - [Java admin API](/api/admin/), which lists all classes, methods, descriptions, and more.
-
-:::
-
-You can manage [clusters](reference-terminology.md#cluster) via one of the following methods:
-
-* [Pulsar CLI](reference-cli-tools.md)
-
-  * [pulsar-admin](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/): the `clusters` command
-
-* [Pulsar admin APIs](admin-api-overview.md)
-
-  * {@inject: rest:REST API:/}: the `/admin/v2/clusters` endpoint
-
-  * [Java admin API](/api/admin/): the `clusters` method of the `PulsarAdmin` object

--- a/docs/admin-api-functions.md
+++ b/docs/admin-api-functions.md
@@ -30,7 +30,7 @@ You can create a Pulsar function in cluster mode (deploy it on a Pulsar cluster)
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`create`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=create) subcommand.
@@ -54,7 +54,7 @@ pulsar-admin functions create \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName|operation/registerFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 FunctionConfig functionConfig = new FunctionConfig();
@@ -84,7 +84,7 @@ You can update a Pulsar function that has been deployed to a Pulsar cluster usin
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`update`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=update) subcommand.
@@ -106,7 +106,7 @@ pulsar-admin functions update \
 {@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName|operation/updateFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 FunctionConfig functionConfig = new FunctionConfig();
@@ -136,7 +136,7 @@ You can start a stopped function instance with `instance-id` using Admin CLI, RE
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`start`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=start) subcommand.
@@ -155,7 +155,7 @@ pulsar-admin functions start \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start|operation/startFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().startFunction(tenant, namespace, functionName, Integer.parseInt(instanceId));
@@ -173,7 +173,7 @@ You can start all stopped function instances using Admin CLI, REST API or Java A
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`start`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=start) subcommand.
@@ -193,7 +193,7 @@ pulsar-admin functions start \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start|operation/startFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().startFunction(tenant, namespace, functionName);
@@ -215,7 +215,7 @@ You can stop a function instance with `instance-id` using Admin CLI, REST API or
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`stop`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=stop) subcommand.
@@ -236,7 +236,7 @@ pulsar-admin functions stop \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop|operation/stopFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().stopFunction(tenant, namespace, functionName, Integer.parseInt(instanceId));
@@ -254,7 +254,7 @@ You can stop all function instances using Admin CLI, REST API or Java Admin API.
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`stop`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=stop) subcommand.
@@ -274,7 +274,7 @@ pulsar-admin functions stop \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop|operation/stopFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().stopFunction(tenant, namespace, functionName);
@@ -296,7 +296,7 @@ Restart a function instance with `instance-id` using Admin CLI, REST API or Java
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`restart`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=restart) subcommand.
@@ -317,7 +317,7 @@ pulsar-admin functions restart \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart|operation/restartFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().restartFunction(tenant, namespace, functionName, Integer.parseInt(instanceId));
@@ -335,7 +335,7 @@ You can restart all function instances using Admin CLI, REST API or Java admin A
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`restart`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=restart) subcommand.
@@ -355,7 +355,7 @@ pulsar-admin functions restart \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart|operation/restartFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().restartFunction(tenant, namespace, functionName);
@@ -373,7 +373,7 @@ You can list all Pulsar functions running under a specific tenant and namespace 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`list`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=list) subcommand.
@@ -392,7 +392,7 @@ pulsar-admin functions list \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace|operation/listFunctions?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctions(tenant, namespace);
@@ -410,7 +410,7 @@ You can delete a Pulsar function that is running on a Pulsar cluster using Admin
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`delete`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=delete) subcommand.
@@ -430,7 +430,7 @@ pulsar-admin functions delete \
 {@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName|operation/deregisterFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().deleteFunction(tenant, namespace, functionName);
@@ -448,7 +448,7 @@ You can get information about a Pulsar function currently running in cluster mod
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`get`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=get) subcommand.
@@ -468,7 +468,7 @@ pulsar-admin functions get \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName|operation/getFunctionInfo?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunction(tenant, namespace, functionName);
@@ -489,7 +489,7 @@ You can get the current status of a Pulsar function instance with `instance-id` 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`status`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=status) subcommand.
@@ -510,7 +510,7 @@ pulsar-admin functions status \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status|operation/getFunctionInstanceStatus?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctionStatus(tenant, namespace, functionName, Integer.parseInt(instanceId));
@@ -528,7 +528,7 @@ You can get the current status of a Pulsar function instance using Admin CLI, RE
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`status`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=status) subcommand.
@@ -548,7 +548,7 @@ pulsar-admin functions status \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status|operation/getFunctionStatus?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctionStatus(tenant, namespace, functionName);
@@ -569,7 +569,7 @@ You can get the current stats of a Pulsar Function instance with `instance-id` u
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`stats`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=stats) subcommand.
@@ -590,7 +590,7 @@ pulsar-admin functions stats \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats|operation/getFunctionInstanceStats?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctionStats(tenant, namespace, functionName, Integer.parseInt(instanceId));
@@ -608,7 +608,7 @@ You can get the current stats of a Pulsar function using Admin CLI, REST API or 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`stats`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=stats) subcommand.
@@ -628,7 +628,7 @@ pulsar-admin functions stats \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats|operation/getFunctionStats?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctionStats(tenant, namespace, functionName);
@@ -646,7 +646,7 @@ You can trigger a specified Pulsar function with a supplied value using Admin CL
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`trigger`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=trigger) subcommand.
@@ -669,7 +669,7 @@ pulsar-admin functions trigger \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger|operation/triggerFunction?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().triggerFunction(tenant, namespace, functionName, topic, triggerValue, triggerFile);
@@ -689,7 +689,7 @@ You can put the state associated with a Pulsar function using Admin CLI, REST AP
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`putstate`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=putstate) subcommand.
@@ -710,7 +710,7 @@ pulsar-admin functions putstate \
 {@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/putFunctionState?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 TypeReference<FunctionState> typeRef = new TypeReference<FunctionState>() {};
@@ -730,7 +730,7 @@ You can fetch the current state associated with a Pulsar function using Admin CL
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="Admin CLI">
 
 Use the [`querystate`](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/functions?id=querystate) subcommand.
@@ -751,7 +751,7 @@ pulsar-admin functions querystate \
 {@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/getFunctionState?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 admin.functions().getFunctionState(tenant, namespace, functionName, key);

--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -31,7 +31,7 @@ To upload (register) a new schema for a topic, you can use one of the following 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -67,7 +67,7 @@ The post payload is in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 void createSchema(String topic, PostSchemaPayload schemaPayload)
@@ -119,7 +119,7 @@ To get the latest schema for a topic, you can use one of the following methods.
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -162,7 +162,7 @@ Here is an example of a response, which is returned in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 SchemaInfo createSchema(String topic)
@@ -187,7 +187,7 @@ To get a specific version of a schema, you can use one of the following methods.
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -215,7 +215,7 @@ Here is an example of a response, which is returned in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 SchemaInfo createSchema(String topic, long version)
@@ -267,7 +267,7 @@ To delete a schema for a topic, you can use one of the following methods.
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -291,7 +291,7 @@ Here is an example of a response returned in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 void deleteSchema(String topic)
@@ -318,7 +318,7 @@ To enable/enforce schema auto-update at the namespace level, you can use one of 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -342,7 +342,7 @@ The post payload is in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Here is an example to enable schema auto-update for a tenant/namespace.
 
@@ -367,7 +367,7 @@ To disable schema auto-update at the **namespace** level, you can use one of the
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -391,7 +391,7 @@ The post payload is in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Here is an example to enable schema auto-unpdate of a tenant/namespace.
 
@@ -414,7 +414,7 @@ To enable schema validation enforcement at the **namespace** level, you can use 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -438,7 +438,7 @@ The post payload is in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Here is an example to enable schema validation enforcement for a tenant/namespace.
 
@@ -457,7 +457,7 @@ To disable schema validation enforcement at the **namespace** level, you can use
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -481,7 +481,7 @@ The post payload is in JSON format.
 ```
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Here is an example to enable schema validation enforcement for a tenant/namespace.
 
@@ -508,7 +508,7 @@ To set a schema compatibility check strategy at the topic level, you can use one
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -524,7 +524,7 @@ pulsar-admin topicPolicies set-schema-compatibility-strategy <strategy> <topicNa
 Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 void setSchemaCompatibilityStrategy(String topic, SchemaCompatibilityStrategy strategy)
@@ -549,7 +549,7 @@ To set schema compatibility check strategy at the namespace level, you can use o
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -565,7 +565,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Use the [`setSchemaCompatibilityStrategy`](/api/admin/) method.
 
@@ -596,7 +596,7 @@ To get the topic-level schema compatibility check strategy, you can use one of t
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -612,7 +612,7 @@ pulsar-admin topicPolicies get-schema-compatibility-strategy <topicName>
 Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 ```java
 SchemaCompatibilityStrategy getSchemaCompatibilityStrategy(String topic, boolean applied)
@@ -641,7 +641,7 @@ You can get schema compatibility check strategy at namespace level using one of 
 ````mdx-code-block
 <Tabs groupId="api-choice"
   defaultValue="Admin CLI"
-  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java Admin API","value":"Java Admin API"}]}>
+  values={[{"label":"Admin CLI","value":"Admin CLI"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 
 <TabItem value="Admin CLI">
 
@@ -657,7 +657,7 @@ pulsar-admin namespaces get-schema-compatibility-strategy options
 Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
 
 </TabItem>
-<TabItem value="Java Admin API">
+<TabItem value="Java">
 
 Use the [`getSchemaCompatibilityStrategy`](/api/admin/) method.
 

--- a/docs/admin-get-started.md
+++ b/docs/admin-get-started.md
@@ -9,25 +9,44 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ````
 
-This guide walks you through the quickest way to get started with the following Pulsar admin APIs to manage topics:
-
-- Java admin API
-
-- Go admin API (coming soon)
-
-- REST API
+This guide walks you through the quickest way to get started with the following methods to manage topics.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"
-  defaultValue="Java admin API"
-  values={[{"label":"Java admin API","value":"Java admin API"},{"label":"REST API","value":"REST API"}]}>
-<TabItem value="Java admin API">
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
 
-This tutorial guides you through every step of using Java admin API to manage topics. It includes the following steps:
+[pulsar-admin CLI](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/): it’s a command-line tool and is available in the bin folder of your Pulsar installation.
 
-1. Initiate a Pulsar Java client.
+</TabItem>
+<TabItem value="REST API">
 
-2. Create a partitioned topic
+[REST API](pathname:///admin-rest-api/?version=@pulsar:version_number@): HTTP calls, which are made against the admin APIs provided by brokers. In addition, both the Java admin API and pulsar-admin CLI use the REST API.
+
+</TabItem>
+<TabItem value="Java">
+
+[Java admin API](/api/admin/): it’s a programmable interface written in Java.
+
+</TabItem>
+
+</Tabs>
+````
+
+Check the detailed steps below.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+This tutorial guides you through every step of using pulsar-admin CLI to manage topics. It includes the following steps:
+
+1. Set the service URL.
+
+2. Create a partitioned topic.
 
 3. Update the number of a partition.
 
@@ -39,72 +58,196 @@ This tutorial guides you through every step of using Java admin API to manage to
 
 **Prerequisites**
 
-- Prepare a Java project. You can download one from [Apache Pulsar examples and demos](https://github.com/streamnative/examples).
+- [Install and start Pulsar standalone](getting-started-standalone.md). This tutorial runs Pulsar 2.11 as an example.
 
 **Steps**
 
-1. Initiate a Pulsar Java client in your Java project.
+1. Set the service URLs to point to the broker service in [client.conf](https://github.com/apache/pulsar/blob/master/conf/client.conf).
 
-    **Input**
-
-    ```java
-    String url = "http://localhost:8080";
-    PulsarAdmin admin = PulsarAdmin.builder()
-        .serviceHttpUrl(url)
-        .build();
+    ```bash
+    webServiceUrl=http://localhost:8080/
+    brokerServiceUrl=pulsar://localhost:6650/
     ```
 
-2. Create a partitioned topic _test-topic-1_ with 4 partitions.
+2. Create a persistent topic named test-topic-1 with 6 partitions.
 
     **Input**
 
-    ```java
-    admin.topics().createPartitionedTopic("persistent://public/default/test-topic-1", 4);
+    ```bash
+    bin/pulsar-admin topics create-partitioned-topic \
+    persistent://public/default/test-topic-1 \
+    --partitions 6
     ```
 
-3. Update the number of the partition to 5.
+    **Output**
+
+    There is no output. You can check the status of the topic in Step 5.
+
+3. Update the number of the partition to 8.
 
     **Input**
 
-    ```java
-    admin.topics().updatePartitionedTopic("test-topic-1", 5);
+    ```bash
+    bin/pulsar-admin topics update-partitioned-topic \
+    persistent://public/default/test-topic-1 \
+    --partitions 8
     ```
 
-4. Produce some messages to the topic _test-topic-1_.
+    **Output**
+
+    There is no output. You can check the number of partitions in Step 5.
+
+4. Produce some messages to the partitioned topic test-topic-1.
 
     **Input**
 
-    ```java
-    PulsarClient client = PulsarClient.builder()
-        .serviceUrl("pulsar://localhost:6650")
-        .build();
-
-    Producer<String> producer = client.newProducer(Schema.STRING)
-        .topic(topic)
-        .blockIfQueueFull(true)
-        .create();
-
-    for (int i = 0; i < 100; ++i) {
-        producer.newMessage().value("test").send();
-    }
-    producer.close();
-    client.close();
+    ```bash
+    bin/pulsar-perf produce -u pulsar://localhost:6650 -r 1000 -i 1000 persistent://public/default/test-topic-1
     ```
 
-5. Check the stats of the topic _test-topic-1_.
+    **Output**
 
-    **Input**
+    ```bash
+    2023-03-07T15:33:56,832+0800 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Starting Pulsar perf producer with config: {
+      "confFile" : "/Users/yu/apache-pulsar-2.11.0/conf/client.conf",
+      "serviceURL" : "pulsar://localhost:6650",
+      "authPluginClassName" : "",
+      "authParams" : "",
+      "tlsTrustCertsFilePath" : "",
+      "tlsAllowInsecureConnection" : false,
+      "tlsHostnameVerificationEnable" : false,
+      "maxConnections" : 1,
+      "statsIntervalSeconds" : 1000,
+      "ioThreads" : 1,
+      "enableBusyWait" : false,
+      "listenerName" : null,
+      "listenerThreads" : 1,
+      "maxLookupRequest" : 50000,
+      "topics" : [ "persistent://public/default/test-topic-1" ],
+      "numTestThreads" : 1,
+      "msgRate" : 1000,
+      "msgSize" : 1024,
+      "numTopics" : 1,
+    "numProducers" : 1,
+      "separator" : "-",
+      "sendTimeout" : 0,
+      "producerName" : null,
+      "adminURL" : "http://localhost:8080/",
 
+    ...
+
+    2023-03-07T15:35:03,769+0800 [Thread-0] INFO  org.apache.pulsar.testclient.PerformanceProducer - Aggregated latency stats --- Latency: mean:   8.931 ms - med:   3.775 - 95pct:  32.144 - 99pct:  98.432 - 99.9pct: 216.088 - 99.99pct: 304.807 - 99.999pct: 349.391 - Max: 351.235
     ```
-    admin.topics().getPartitionedStats("persistent://public/default/test-topic-1", false)
-    ````
 
-5. Delete the topic _test-topic-1_.
+5. Check the internal stats of the partitioned topic _test-topic-1_.
 
     **Input**
 
-    ```java
-    admin.topics().deletePartitionedTopic("test-topic-1");
+    ```bash
+    bin/pulsar-admin topics partitioned-stats-internal \
+    persistent://public/default/test-topic-1
+    ```
+
+    **Output**
+
+    Below is a part of the output. For detailed explanations of topic stats, see [Pulsar statistics](administration-stats.md).
+
+    ```bash
+    {
+      "metadata" : {
+        "partitions" : 8
+      },
+      "partitions" : {
+        "persistent://public/default/test-topic-1-partition-1" : {
+          "entriesAddedCounter" : 4213,
+          "numberOfEntries" : 4213,
+          "totalSize" : 8817693,
+          "currentLedgerEntries" : 4212,
+          "currentLedgerSize" : 8806289,
+          "lastLedgerCreatedTimestamp" : "2023-03-07T15:33:59.367+08:00",
+          "waitingCursorsCount" : 0,
+          "pendingAddEntriesCount" : 0,
+          "lastConfirmedEntry" : "65:4211",
+          "state" : "LedgerOpened",
+          "ledgers" : [ {
+            "ledgerId" : 49,
+            "entries" : 1,
+            "size" : 11404,
+            "offloaded" : false,
+            "underReplicated" : false
+          }, {
+            "ledgerId" : 65,
+            "entries" : 0,
+            "size" : 0,
+            "offloaded" : false,
+            "underReplicated" : false
+          } ],
+          "cursors" : {
+            "test-subscriptio-1" : {
+              "markDeletePosition" : "49:-1",
+              "readPosition" : "49:0",
+              "waitingReadOp" : false,
+              "pendingReadOps" : 0,
+              "messagesConsumedCounter" : 0,
+              "cursorLedger" : -1,
+              "cursorLedgerLastEntry" : -1,
+      "individuallyDeletedMessages" : "[]",
+              "lastLedgerSwitchTimestamp" : "2023-03-06T16:41:32.801+08:00",
+              "state" : "NoLedger",
+              "numberOfEntriesSinceFirstNotAckedMessage" : 1,
+              "totalNonContiguousDeletedMessagesRange" : 0,
+              "subscriptionHavePendingRead" : false,
+              "subscriptionHavePendingReplayRead" : false,
+              "properties" : { }
+            },
+            "test-subscription-1" : {
+              "markDeletePosition" : "49:-1",
+              "readPosition" : "49:0",
+              "waitingReadOp" : false,
+              "pendingReadOps" : 0,
+              "messagesConsumedCounter" : 0,
+              "cursorLedger" : -1,
+              "cursorLedgerLastEntry" : -1,
+              "individuallyDeletedMessages" : "[]",
+              "lastLedgerSwitchTimestamp" : "2023-03-06T16:41:32.801+08:00",
+              "state" : "NoLedger",
+              "numberOfEntriesSinceFirstNotAckedMessage" : 1,
+              "totalNonContiguousDeletedMessagesRange" : 0,
+              "subscriptionHavePendingRead" : false,
+              "subscriptionHavePendingReplayRead" : false,
+              "properties" : { }
+            }
+          },
+          "schemaLedgers" : [ ],
+          "compactedLedger" : {
+            "ledgerId" : -1,
+            "entries" : -1,
+            "size" : -1,
+            "offloaded" : false,
+            "underReplicated" : false
+          }
+        },
+    ...
+    ```
+
+6. Delete the topic _test-topic-1_.
+
+    **Input**
+
+    ```bash
+    bin/pulsar-admin topics delete-partitioned-topic persistent://public/default/test-topic-1
+    ```
+
+    **Output**
+
+    There is no output. You can verify whether the _test-topic-1_ exists or not using the following command.
+
+    **Input**
+
+    List topics in `public/default` namespace.
+
+    ```bash
+    bin/pulsar-admin topics list public/default
     ```
 
 </TabItem>
@@ -259,6 +402,93 @@ This tutorial guides you through every step of using REST API to manage topics. 
     ```
 
 </TabItem>
+<TabItem value="Java">
+
+This tutorial guides you through every step of using Java admin API to manage topics. It includes the following steps:
+
+1. Initiate a Pulsar Java client.
+
+2. Create a partitioned topic
+
+3. Update the number of a partition.
+
+4. Produce messages to the topic.
+
+5. Check the stats of the topic.
+
+6. Delete the topic.
+
+**Prerequisites**
+
+- Prepare a Java project. You can download one from [Apache Pulsar examples and demos](https://github.com/streamnative/examples).
+
+**Steps**
+
+1. Initiate a Pulsar Java client in your Java project.
+
+    **Input**
+
+    ```java
+    String url = "http://localhost:8080";
+    PulsarAdmin admin = PulsarAdmin.builder()
+        .serviceHttpUrl(url)
+        .build();
+    ```
+
+2. Create a partitioned topic _test-topic-1_ with 4 partitions.
+
+    **Input**
+
+    ```java
+    admin.topics().createPartitionedTopic("persistent://public/default/test-topic-1", 4);
+    ```
+
+3. Update the number of the partition to 5.
+
+    **Input**
+
+    ```java
+    admin.topics().updatePartitionedTopic("test-topic-1", 5);
+    ```
+
+4. Produce some messages to the topic _test-topic-1_.
+
+    **Input**
+
+    ```java
+    PulsarClient client = PulsarClient.builder()
+        .serviceUrl("pulsar://localhost:6650")
+        .build();
+
+    Producer<String> producer = client.newProducer(Schema.STRING)
+        .topic(topic)
+        .blockIfQueueFull(true)
+        .create();
+
+    for (int i = 0; i < 100; ++i) {
+        producer.newMessage().value("test").send();
+    }
+    producer.close();
+    client.close();
+    ```
+
+5. Check the stats of the topic _test-topic-1_.
+
+    **Input**
+
+    ```
+    admin.topics().getPartitionedStats("persistent://public/default/test-topic-1", false)
+    ````
+
+6. Delete the topic _test-topic-1_.
+
+    **Input**
+
+    ```java
+    admin.topics().deletePartitionedTopic("test-topic-1");
+    ```
+
+</TabItem>
 
 </Tabs>
 
@@ -272,8 +502,12 @@ This tutorial guides you through every step of using REST API to manage topics. 
 
 - To perform administrative operations, see [Pulsar admin API - Tools](admin-api-tools.md).
 
-- To check the detailed usage, see the API references below.
+- To check the detailed usage, see the references below.
 
-  - [Java admin API](/api/admin/)
+  - [pulsar-admin CLI](pathname:///reference/#/@pulsar:version_reference@/pulsar-admin/)
 
-  - [REST API](reference-rest-api-overview.md)
+  - Pulsar admin APIs
+
+    - [REST API](reference-rest-api-overview.md)
+
+    - [Java admin API](/api/admin/)

--- a/docs/admin-get-started.md
+++ b/docs/admin-get-started.md
@@ -150,7 +150,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
 
     **Output**
 
-    Below is a part of the output. For detailed explanations of topic stats, see Pulsar statistics).
+    Below is a part of the output. For detailed explanations of topic stats, see Pulsar statistics.
 
     ```bash
     {

--- a/docs/admin-get-started.md
+++ b/docs/admin-get-started.md
@@ -69,7 +69,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
     brokerServiceUrl=pulsar://localhost:6650/
     ```
 
-2. Create a persistent topic named test-topic-1 with 6 partitions.
+2. Create a persistent topic named _test-topic-1_ with 6 partitions.
 
     **Input**
 
@@ -97,7 +97,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
 
     There is no output. You can check the number of partitions in Step 5.
 
-4. Produce some messages to the partitioned topic test-topic-1.
+4. Produce some messages to the partitioned topic _test-topic-1_.
 
     **Input**
 
@@ -420,7 +420,15 @@ This tutorial guides you through every step of using Java admin API to manage to
 
 **Prerequisites**
 
-- Prepare a Java project. You can download one from [Apache Pulsar examples and demos](https://github.com/streamnative/examples).
+- Prepare a Java project and add the following dependency to your POM file.
+
+  ```java
+  <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-client-admin</artifactId>
+        <version>2.11.0</version>
+    </dependency>
+  ```
 
 **Steps**
 

--- a/docs/admin-get-started.md
+++ b/docs/admin-get-started.md
@@ -58,7 +58,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
 
 **Prerequisites**
 
-- [Install and start Pulsar standalone](getting-started-standalone.md). This tutorial runs Pulsar 2.11 as an example.
+- Install and start Pulsar standalone. This tutorial runs Pulsar 2.11 as an example.
 
 **Steps**
 
@@ -150,7 +150,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
 
     **Output**
 
-    Below is a part of the output. For detailed explanations of topic stats, see [Pulsar statistics](administration-stats.md).
+    Below is a part of the output. For detailed explanations of topic stats, see Pulsar statistics).
 
     ```bash
     {
@@ -267,7 +267,7 @@ This tutorial guides you through every step of using REST API to manage topics. 
 
 **Prerequisites**
 
-- [Install and start Pulsar standalone](getting-started-standalone.md). This tutorial runs Pulsar 2.11 as an example.
+- Install and start Pulsar standalone. This tutorial runs Pulsar 2.11 as an example.
 
 **Steps**
 
@@ -375,7 +375,7 @@ This tutorial guides you through every step of using REST API to manage topics. 
 
     **Output**
 
-    For detailed explanations of topic stats, see [Pulsar statistics](administration-stats.md).
+    For detailed explanations of topic stats, see Pulsar statistics.
 
     ```bash
     {"metadata":{"partitions":5},"partitions":{"persistent://public/default/test-topic-2-partition-3":{"entriesAddedCounter":47087,"numberOfEntries":47087,"totalSize":80406959,"currentLedgerEntries":47087,"currentLedgerSize":80406959,"lastLedgerCreatedTimestamp":"2023-03-08T15:47:07.273+08:00","waitingCursorsCount":0,"pendingAddEntriesCount":0,"lastConfirmedEntry":"117:47086","state":"LedgerOpened","ledgers":[{"ledgerId":117,"entries":0,"size":0,"offloaded":false,"underReplicated":false}],"cursors":{},"schemaLedgers":[],"compactedLedger":{"ledgerId":-1,"entries":-1,"size":-1,"offloaded":false,"underReplicated":false}},"persistent://public/default/test-topic-2-partition-2":{"entriesAddedCounter":46995,"numberOfEntries":46995,"totalSize":80445417,"currentLedgerEntries":46995,"currentLedgerSize":80445417,"lastLedgerCreatedTimestamp":"2023-03-08T15:47:07.43+08:00","waitingCursorsCount":0,"pendingAddEntriesCount":0,"lastConfirmedEntry":"118:46994","state":"LedgerOpened","ledgers":[{"ledgerId":118,"entries":0,"size":0,"offloaded":false,"underReplicated":false}],...

--- a/docs/admin-get-started.md
+++ b/docs/admin-get-started.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ````
 
-This guide walks you through the quickest way to get started with the following methods to manage topics.
+This guide walks you through the quickest way to get started with the following methods to manage topics. 
 
 ````mdx-code-block
 <Tabs groupId="api-choice"
@@ -54,7 +54,7 @@ This tutorial guides you through every step of using pulsar-admin CLI to manage 
 
 5. Check the stats of the topic.
 
-6. Delete the topic.
+6. Delete the topic. 
 
 **Prerequisites**
 
@@ -461,7 +461,7 @@ This tutorial guides you through every step of using Java admin API to manage to
         .build();
 
     Producer<String> producer = client.newProducer(Schema.STRING)
-        .topic(topic)
+        .topic("test-topic-1")
         .blockIfQueueFull(true)
         .create();
 
@@ -476,9 +476,16 @@ This tutorial guides you through every step of using Java admin API to manage to
 
     **Input**
 
+    ```java
+    PartitionedTopicStats stats = admin.topics().getPartitionedStats("persistent://public/default/test-topic-1",false);
+    System.out.println(stats.getMsgInCounter());
     ```
-    admin.topics().getPartitionedStats("persistent://public/default/test-topic-1", false)
-    ````
+    
+    **Output**
+
+    ```java
+    100
+    ```
 
 6. Delete the topic _test-topic-1_.
 

--- a/docs/how-to-landing.md
+++ b/docs/how-to-landing.md
@@ -11,4 +11,3 @@ Learning new software can be an overwhelming task, but relax – most aspects of
 - [How to create a namespace](tutorials-namespace.md)
 - [How to create a topic](tutorials-topic.md)
 - [How to produce and consume messages](tutorials-produce-consume.md)
-- [Get started with pulsar-admin CLI tool](get-started-pulsar-admin.md)

--- a/sidebars.json
+++ b/sidebars.json
@@ -466,8 +466,7 @@
         "cookbooks-non-persistent",
         "cookbooks-retention-expiry",
         "cookbooks-message-queue",
-        "cookbooks-bookkeepermetadata",
-        "get-started-pulsar-admin"
+        "cookbooks-bookkeepermetadata"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes https://github.com/apache/pulsar/issues/20024

I’ve summarized all issues with the corresponding solutions below. 

Issues | Solutions
-- | --
[Get Started of pulsar-admin ](https://pulsar.apache.org/docs/next/get-started-pulsar-admin/)is shown in [Tutorials](https://pulsar.apache.org/docs/next/how-to-landing/). | Relocate it to [Admin API - Get Started](https://pulsar.apache.org/docs/next/admin-api-get-started/) to improve the ease of use.
The wordings "Java admin API" in [Admin API > Features > Functions](https://pulsar.apache.org/docs/next/admin-api-functions/) and [Admin API > Features > Schemas](https://pulsar.apache.org/docs/next/admin-api-schemas/) are inaccurate. | Correct it to "Java".

- [x] `doc` 

@labuladong @asafm @jak78 thanks for your technical guidance!

Ping @D-2-Ed to review. Thank you!
