### PR TITLE
[feat] noIndex unmaintained pages for SEO

### DIFF
--- a/src/theme/DocPage/index.tsx
+++ b/src/theme/DocPage/index.tsx
@@ -13,6 +13,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 import type {Props} from '@theme/DocPage';
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import semver from "semver/preload";
 
 function createCanonicalHref(props: Props): string {
   const {siteConfig} = useDocusaurusContext();
@@ -25,6 +26,16 @@ function createCanonicalHref(props: Props): string {
   const basename = location.pathname.replace(match.path, '');
   return siteConfig.url + useBaseUrl(`/docs/${basename}`);
 }
+
+function shouldNotIndex(props: Props): boolean {
+  const {versionMetadata} = props;
+  if (versionMetadata.version == 'current') {
+    return false;
+  }
+  let version = semver.coerce(versionMetadata.version);
+  return version.compareMain('2.10.0') < 0;
+}
+
 function DocPageMetadata(props: Props): JSX.Element {
   const {versionMetadata} = props;
   return (
@@ -37,7 +48,7 @@ function DocPageMetadata(props: Props): JSX.Element {
         )}
       />
       <PageMetadata>
-        {versionMetadata.noIndex && (
+        {(versionMetadata.noIndex || shouldNotIndex(props)) && (
           <meta name="robots" content="noindex, nofollow" />
         )}
         <link rel="canonical" href={createCanonicalHref(props)}/>


### PR DESCRIPTION
I still searched some ancient versions on Google. Perhaps the canonical link trick doesn't work or it needs more time to propagate. But let's add more meta to help the search engine not index unmaintained pages.

2.9.x (unmaintained):

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/230335961-9fb81f16-66b9-4b37-943b-422fc5632445.png">

2.10.x, 2.11.x, and NEXT don't have this meta tag.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
