### PR TITLE
revise ambiguous statements

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1068,7 +1068,7 @@ Delayed message delivery enables you to consume a message later. In this mechani
 
 :::note
 
-Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+Only shared and key-shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
 
 :::
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1123,7 +1123,7 @@ Delayed message delivery enables you to consume a message later. In this mechani
 
 :::note
 
-Only shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
+Only shared and key-shared subscriptions support delayed message delivery. In other subscriptions, delayed messages are dispatched immediately.
 
 :::
 


### PR DESCRIPTION
Originally the statement may means shared subscriptions include key-shared subscriptions, but shared and key-shared are totally different subscription types.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
