### PR TITLE
feat: js doc generator

### DIFF
--- a/tools/pytools/README.md
+++ b/tools/pytools/README.md
@@ -59,6 +59,16 @@ poetry run bin/cpp-apidoc-generator.py <VERSION>
 
 ... where the `VERSION` is released semantic version like `2.10.2` or `3.0.0`.
 
+### [js-apidoc-generator](bin/js-apidoc-generator.py)
+
+This executable generates API docs for Pulsar Node.js Client using [`typedoc`](https://typedoc.org/):
+
+```bash
+poetry run bin/js-apidoc-generator.py <VERSION>
+```
+
+... where the `VERSION` is released semantic version like `1.8.2`.
+
 ### [py-apidoc-generator](bin/py-apidoc-generator.py)
 
 This executable generates API docs for Pulsar Python Client:

--- a/tools/pytools/bin/js-apidoc-generator.py
+++ b/tools/pytools/bin/js-apidoc-generator.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+
+from execute import typedoc_generator
+
+if __name__ == '__main__':
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.set_defaults(func=typedoc_generator.execute)
+    parser.add_argument('version', metavar='VERSION', help='version of Pulsar Node.js Client')
+
+    args = parser.parse_args()
+    fn = args.func
+    args = dict(vars(args))
+    del args['func']
+    fn(**args)

--- a/tools/pytools/lib/execute/typedoc_generator.py
+++ b/tools/pytools/lib/execute/typedoc_generator.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import semver
+
+from command import find_command, run
+from constant import site_path
+
+
+def execute(version: str):
+    git = find_command('git', msg="git is required")
+    npm = find_command('npm', msg="npm is required")
+    npx = find_command('npx', msg="npx is required")
+
+    ver = semver.VersionInfo.parse(version)
+    assert ver.compare('1.8.1') > 0
+
+    with tempfile.TemporaryDirectory() as cwd:
+        tag = f"v{ver}"
+        remote = 'https://github.com/apache/pulsar-client-node'
+        run(git, 'clone', '--depth=1', '--single-branch', f'--branch={tag}', remote, cwd=cwd)
+
+        d = (Path(cwd) / 'pulsar-client-node').absolute()
+        run(npm, 'i', '-D', '@types/node', cwd=d)
+        run(npx, 'typedoc', cwd=d)
+
+        v = f"{ver.major}.{ver.minor}.x"
+        dst = site_path() / 'static' / 'api' / 'js' / v
+        shutil.copytree(d / 'apidocs', dst)


### PR DESCRIPTION
cc @shibd 

This refers to https://github.com/apache/pulsar/issues/19876.

You can test with:

```shell
cd tools/pytools
poetry run bin/js-apidoc-generator.py 1.8.2-rc.1
```

Then, preview on http://localhost:3000/api/js/1.8.x/.

The release process can be updated later.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
