### PR TITLE
Improve doc

### DIFF
--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -39,7 +39,7 @@ gpg --verify apache-pulsar-<release>-bin.tar.gz.asc
 
 #### Standalone service
 
-Open a terminal to start a standalone service (For 2.11 or later, please `export PULSAR_STANDALONE_USE_ZOOKEEPER=1` before starting the service):
+Open a terminal to start a standalone service (For 2.11.x or later, please `export PULSAR_STANDALONE_USE_ZOOKEEPER=1` before starting the service):
 
 ```shell
 bin/pulsar standalone

--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -39,7 +39,7 @@ gpg --verify apache-pulsar-<release>-bin.tar.gz.asc
 
 #### Standalone service
 
-Open a terminal to start a standalone service:
+Open a terminal to start a standalone service (For 2.11 or later, please `export PULSAR_STANDALONE_USE_ZOOKEEPER=1` before starting the service):
 
 ```shell
 bin/pulsar standalone


### PR DESCRIPTION
### Motivation
When verifying 2.11.x or later, we should suggest adding the below command otherwise, it will fail when `Validate Stateful Functions` with the below error:

```
~/Downloads/release_2.11.1/apache-pulsar-2.11.1 » bin/pulsar-admin
functions querystate --tenant test --namespace test-namespace --name
word_count -k hello -w
# key 'hello' doesn't exist.
# key 'hello' doesn't exist.
# key 'hello' doesn't exist
State storage client is not done initializing. Please try again in a little
while.
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
