### PR TITLE
Add producer access mode examples for Java and C++ client.

### DIFF
--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -786,11 +786,9 @@ This example shows how to set the `EnforceUnencrypted` encryption policy.
 </Tabs>
 ````
 
-## Configure Access mode
+## Configure access mode
 
-Access mode allow applications to require exclusive producer access on a topic in order to achieve a "single-writer" situation.
-
-More information about access mode can be found [concepts-clients](concepts-clients.md#access-mode).
+[Access mode](concepts-clients.md#access-mode) allows applications to require exclusive producer access on a topic to achieve a "single-writer" situation.
 
 This example shows how to set producer access mode.
 

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -792,7 +792,7 @@ Access mode allow applications to require exclusive producer access on a topic i
 
 More information about access mode can be found [concepts-clients](concepts-clients.md#access-mode).
 
-This example shows how to set producer accessmode.
+This example shows how to set producer access mode.
 
 ````mdx-code-block
 <Tabs groupId="lang-choice"

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -798,7 +798,11 @@ This example shows how to set producer access mode.
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"}]}>
 <TabItem value="Java">
 
-  This feature is supported after Java client version 2.8.0.
+::: note
+
+This feature is supported in Java client 2.8.0 or later versions.
+
+:::
 
    ```java
    Producer<byte[]> producer = client.newProducer()
@@ -811,7 +815,11 @@ This example shows how to set producer access mode.
 
 <TabItem value="C++">
 
-  This feature is supported after CPP client version 3.1.0.
+::: note
+
+This feature is supported in C++ client 3.1.0 or later versions.
+
+:::
 
    ```cpp
     Producer producer;

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -798,6 +798,8 @@ This example shows how to set producer access mode.
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"}]}>
 <TabItem value="Java">
 
+  This feature is supported after Java client version 2.8.0.
+
    ```java
    Producer<byte[]> producer = client.newProducer()
         .topic(topic)
@@ -808,6 +810,8 @@ This example shows how to set producer access mode.
   </TabItem>
 
 <TabItem value="C++">
+
+  This feature is supported after CPP client version 3.1.0.
 
    ```cpp
     Producer producer;

--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -785,3 +785,40 @@ This example shows how to set the `EnforceUnencrypted` encryption policy.
   </TabItem>
 </Tabs>
 ````
+
+## Configure Access mode
+
+Access mode allow applications to require exclusive producer access on a topic in order to achieve a "single-writer" situation.
+
+More information about access mode can be found [concepts-clients](concepts-clients.md#access-mode).
+
+This example shows how to set producer accessmode.
+
+````mdx-code-block
+<Tabs groupId="lang-choice"
+  defaultValue="Java"
+  values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"}]}>
+<TabItem value="Java">
+
+   ```java
+   Producer<byte[]> producer = client.newProducer()
+        .topic(topic)
+        .accessMode(ProducerAccessMode.Exclusive)
+        .create();
+   ```
+
+  </TabItem>
+
+<TabItem value="C++">
+
+   ```cpp
+    Producer producer;
+    ProducerConfiguration producerConfiguration;
+    producerConfiguration.setAccessMode(ProducerConfiguration::Exclusive);
+    client.createProducer(topicName, producerConfiguration, producer);
+   ```
+
+  </TabItem>
+
+</Tabs>
+````


### PR DESCRIPTION
### Preview

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/33416836/234173624-578029f2-357d-493b-84ea-6a0a15cdec22.png">

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/33416836/234173676-0f0514a6-1706-4848-9b38-cd4255f2f726.png">


### Related issue
- https://github.com/apache/pulsar/wiki/PIP-68%3A-Exclusive-Producer
- https://github.com/apache/pulsar-client-cpp/issues/95


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
