### PR TITLE
Fix wrong examples of CPP advertised listeners.

### DIFF
--- a/docs/client-libraries-clients.md
+++ b/docs/client-libraries-clients.md
@@ -35,10 +35,9 @@ The following example creates a Python client using multiple advertised listener
   <TabItem value="C++">
 
   ```cpp
-  PulsarClient client = PulsarClient.builder()
-    .serviceUrl("pulsar://xxxx:6650")
-    .listenerName("external")
-    .build();
+  ClientConfiguration clientConfiguration;
+  clientConfiguration.setListenerName("external");
+  Client client("pulsar://xxxx:6650", clientConfiguration);
   ```
 
   </TabItem>


### PR DESCRIPTION
### Preview

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/33416836/234022727-c9ad8303-fba1-4d0e-bbda-97ae2fbc906f.png">


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
