### PR TITLE
Add doc for available-functions and functions reload

### DIFF
--- a/docs/functions-deploy-cluster-builtin.md
+++ b/docs/functions-deploy-cluster-builtin.md
@@ -21,7 +21,7 @@ To get the list of available built-in Functions, use the `available-functions` c
 bin/pulsar-admin functions available-functions
 ```
 
-If you add or delete a nar file in a `functions` folder, reload the available built-in functions before using it.
+If you add or delete a NAR file in a `functions` folder, reload the available built-in functions before using it.
 
 ```bash
 bin/pulsar-admin functions reload

--- a/docs/functions-deploy-cluster-builtin.md
+++ b/docs/functions-deploy-cluster-builtin.md
@@ -14,3 +14,15 @@ bin/pulsar-admin functions create \
   --inputs persistent://public/default/input-1 \
   --output persistent://public/default/output-1
 ```
+
+To get the list of available built-in Functions, use the `available-functions` command:
+
+```bash
+bin/pulsar-admin functions available-functions
+```
+
+If you add or delete a nar file in a `functions` folder, reload the available built-in functions before using it.
+
+```bash
+bin/pulsar-admin functions reload
+```

--- a/versioned_docs/version-3.0.x/functions-deploy-cluster-builtin.md
+++ b/versioned_docs/version-3.0.x/functions-deploy-cluster-builtin.md
@@ -14,3 +14,15 @@ bin/pulsar-admin functions create \
   --inputs persistent://public/default/input-1 \
   --output persistent://public/default/output-1
 ```
+
+To get the list of available built-in Functions, use the `available-functions` command:
+
+```bash
+bin/pulsar-admin functions available-functions
+```
+
+If you add or delete a NAR file in a `functions` folder, reload the available built-in functions before using it.
+
+```bash
+bin/pulsar-admin functions reload
+```


### PR DESCRIPTION
Those commands are available starting Pulsar 3.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
