### PR TITLE
Add `multi-arch docker images support` to 3.0.0 release note

### DIFF
--- a/release-notes/versioned/pulsar-3.0.0.md
+++ b/release-notes/versioned/pulsar-3.0.0.md
@@ -26,6 +26,7 @@ sidebar_label: Apache Pulsar 3.0.0
 - Revert 5895: fix redeliveryCount in [#17060](https://github.com/apache/pulsar/pull/17060)
 - Fix producer/consume permission can’t get v1/schema in [#16018](https://github.com/apache/pulsar/pull/16018)
 - Autorecovery default reppDnsResolverClass to ZkBookieRackAffinityMapping in [#15640](https://github.com/apache/pulsar/pull/15640)
+- Allow to build and push multi-arch Docker images in [#19432](https://github.com/apache/pulsar/pull/19432)
 
 ### PIPs
 - PIP-160 Metrics stats of Transaction buffered writer [#15370](https://github.com/apache/pulsar/issues/15370)


### PR DESCRIPTION
The PR https://github.com/apache/pulsar/pull/19432 wasn't marked with the 3.0.0 milestone. So the 3.0.0 release note didn't include it.
This PR adds it to the 3.0.0 release note.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
