### PR TITLE
Fix note annotation to correct rendering

### DIFF
--- a/docs/client-libraries-producers.md
+++ b/docs/client-libraries-producers.md
@@ -796,7 +796,7 @@ This example shows how to set producer access mode.
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"}]}>
 <TabItem value="Java">
 
-::: note
+:::note
 
 This feature is supported in Java client 2.8.0 or later versions.
 
@@ -813,7 +813,7 @@ This feature is supported in Java client 2.8.0 or later versions.
 
 <TabItem value="C++">
 
-::: note
+:::note
 
 This feature is supported in C++ client 3.1.0 or later versions.
 

--- a/versioned_docs/version-3.0.x/client-libraries-producers.md
+++ b/versioned_docs/version-3.0.x/client-libraries-producers.md
@@ -796,7 +796,7 @@ This example shows how to set producer access mode.
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"}]}>
 <TabItem value="Java">
 
-::: note
+:::note
 
 This feature is supported in Java client 2.8.0 or later versions.
 
@@ -813,7 +813,7 @@ This feature is supported in Java client 2.8.0 or later versions.
 
 <TabItem value="C++">
 
-::: note
+:::note
 
 This feature is supported in C++ client 3.1.0 or later versions.
 


### PR DESCRIPTION
### Documentation

- [x] `doc`

The current notes look like:

<img width="523" alt="Screen Shot 2023-05-05 at 10 19 42 AM" src="https://user-images.githubusercontent.com/47911938/236499390-eb7648cd-2f3f-4677-b423-c3eef54cf43e.png">

That is because they have an extra space `::: note`. By removing the space, the note will render correctly. Here is my preview:

<img width="543" alt="Screen Shot 2023-05-05 at 10 21 00 AM" src="https://user-images.githubusercontent.com/47911938/236499709-82a596c7-9326-4e0a-88ae-c260dee25ed3.png">
