### PR TITLE
Improve OIDC client authentication docs

### DIFF
--- a/docs/security-openid-connect.md
+++ b/docs/security-openid-connect.md
@@ -131,4 +131,4 @@ In order to simplify migration from Static JWTs to OIDC Authentication, it is po
 
 ## Configure OIDC authentication in Pulsar Clients and CLI Tools
 
-The Pulsar OAuth2 client plugin can be used to for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.
+The Pulsar OAuth2 client plugin can be used for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.

--- a/docs/security-openid-connect.md
+++ b/docs/security-openid-connect.md
@@ -131,4 +131,4 @@ In order to simplify migration from Static JWTs to OIDC Authentication, it is po
 
 ## Configure OIDC authentication in Pulsar Clients and CLI Tools
 
-See the [OAuth2](security-oauth2.md) documentation for configuring clients to use OAuth2 authentication.
+The Pulsar OAuth2 client plugin can be used to for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.

--- a/versioned_docs/version-3.0.x/security-openid-connect.md
+++ b/versioned_docs/version-3.0.x/security-openid-connect.md
@@ -131,4 +131,4 @@ In order to simplify migration from Static JWTs to OIDC Authentication, it is po
 
 ## Configure OIDC authentication in Pulsar Clients and CLI Tools
 
-The Pulsar OAuth2 client plugin can be used to for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.
+The Pulsar OAuth2 client plugin can be used for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.

--- a/versioned_docs/version-3.0.x/security-openid-connect.md
+++ b/versioned_docs/version-3.0.x/security-openid-connect.md
@@ -131,4 +131,4 @@ In order to simplify migration from Static JWTs to OIDC Authentication, it is po
 
 ## Configure OIDC authentication in Pulsar Clients and CLI Tools
 
-See the [OAuth2](security-oauth2.md) documentation for configuring clients to use OAuth2 authentication.
+The Pulsar OAuth2 client plugin can be used to for clients that rely on the Client Credentials Flow for OIDC. See the [OAuth2 Client](security-oauth2.md#configure-oauth2-authentication-in-pulsar-clients) documentation for configuring clients to integrate with Pulsar Servers running with the OIDC Authentication Provider.


### PR DESCRIPTION
### Documentation

- [x] `doc` 

I received some feedback that the client doc section would be better if it pointed to the correct section in the OAuth2 docs. This PR updates the link and also clarifies why the OAuth2 client plugin is recommended.