### PR TITLE
[fix][doc] Add 3.0.x reference docs in sidebar

### DIFF
--- a/static/reference/index.html
+++ b/static/reference/index.html
@@ -201,6 +201,7 @@
           '<option value="2.9.x">2.9.x</value>' +
           '<option value="2.10.x">2.10.x</value>' +
           '<option value="2.11.x">2.11.x</value>' +
+          '<option value="3.0.x">3.0.x</value>' +
           '<option value="next">next</value>' +
           "</select>",
         repo: "apache/pulsar",
@@ -213,7 +214,7 @@
         namespaces: [
           {
             id: "version",
-            values: ["2.6.x", "2.7.x", "2.8.x", "2.9.x", "2.10.x", "2.11.x", "next"],
+            values: ["2.6.x", "2.7.x", "2.8.x", "2.9.x", "2.10.x", "2.11.x", "3.0.x", "next"],
             optional: true,
             selector: "#ver-selector",
             default: "next",


### PR DESCRIPTION
Found when answering https://github.com/apache/pulsar/issues/20324.

<img width="1727" alt="image" src="https://github.com/apache/pulsar-site/assets/18818196/35a9187d-d3f5-4f9e-a12a-0bc1dc7f59d6">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
