### PR TITLE
[Fix] Remove unsupported example code for GO mTLS auth

### DIFF
--- a/docs/security-tls-authentication.md
+++ b/docs/security-tls-authentication.md
@@ -91,7 +91,7 @@ When using mTLS authentication, clients connect via TLS transport. You need to c
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"Go","value":"Go"},{"label":"C#","value":"C#"}]}>
+  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
 ```java
@@ -154,17 +154,6 @@ const Pulsar = require('pulsar-client');
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
   });
 })();
-```
-
-</TabItem>
-<TabItem value="Go">
-
-```go
-client, err := pulsar.NewClient(ClientOptions{
-		URL:                   "pulsar+ssl://broker.example.com:6651/",
-		TLSTrustCertsFilePath: "/path/to/ca.cert.pem",
-		Authentication:        pulsar.NewAuthenticationTLS("/path/to/my-role.cert.pem", "/path/to/my-role.key-pk8.pem"),
-	})
 ```
 
 </TabItem>

--- a/versioned_docs/version-2.11.x/security-tls-authentication.md
+++ b/versioned_docs/version-2.11.x/security-tls-authentication.md
@@ -91,7 +91,7 @@ When using mTLS authentication, clients connect via TLS transport. You need to c
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"Go","value":"Go"},{"label":"C#","value":"C#"}]}>
+  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
 ```java
@@ -154,17 +154,6 @@ const Pulsar = require('pulsar-client');
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
   });
 })();
-```
-
-</TabItem>
-<TabItem value="Go">
-
-```go
-client, err := pulsar.NewClient(ClientOptions{
-		URL:                   "pulsar+ssl://broker.example.com:6651/",
-		TLSTrustCertsFilePath: "/path/to/ca.cert.pem",
-		Authentication:        pulsar.NewAuthenticationTLS("/path/to/my-role.cert.pem", "/path/to/my-role.key-pk8.pem"),
-	})
 ```
 
 </TabItem>

--- a/versioned_docs/version-3.0.x/security-tls-authentication.md
+++ b/versioned_docs/version-3.0.x/security-tls-authentication.md
@@ -91,7 +91,7 @@ When using mTLS authentication, clients connect via TLS transport. You need to c
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"Go","value":"Go"},{"label":"C#","value":"C#"}]}>
+  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"C#","value":"C#"}]}>
 <TabItem value="Java">
 
 ```java
@@ -154,17 +154,6 @@ const Pulsar = require('pulsar-client');
     tlsTrustCertsFilePath: '/path/to/ca.cert.pem',
   });
 })();
-```
-
-</TabItem>
-<TabItem value="Go">
-
-```go
-client, err := pulsar.NewClient(ClientOptions{
-		URL:                   "pulsar+ssl://broker.example.com:6651/",
-		TLSTrustCertsFilePath: "/path/to/ca.cert.pem",
-		Authentication:        pulsar.NewAuthenticationTLS("/path/to/my-role.cert.pem", "/path/to/my-role.key-pk8.pem"),
-	})
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

Currently, there is an issue in Go mTLS auth (https://github.com/apache/pulsar-client-go/issues/1018). The example code in Go mTLS auth is not working. We need to remove them to avoid confusion for users. We can add it back once the issue is fixed.

Preview:
<img width="1198" alt="image" src="https://github.com/apache/pulsar-site/assets/16974619/fa2a7022-20a6-426f-816b-d7f89c254174">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
