### PR TITLE
Fix highlight Quickstart and Concepts menu items at the same time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const linkifyRegex = require("./plugins/remark-linkify-regex");
 const { renderAnnouncementBar } = require("./src/components/ui/renderAnnouncementBar");
 const versions = require("./versions.json");
+const latestStableVersion = versions[0];
 const versionsMap = {
     ..._.keyBy(
         versions.map((item) => {
@@ -172,14 +173,14 @@ module.exports = {
           label: "Get Started",
           position: "left",
           items: [
-            {
-              type: 'doc',
-              docId: 'concepts-overview',
+               {
+              to: `/docs/${latestStableVersion}/concepts-overview/`,
+              activeBaseRegex: `docs/(${versions.join('|')})/concepts-overview/$`,
               label: "Concepts",
             },
             {
-              type: 'doc',
-              docId: 'about',
+              to: `/docs/${latestStableVersion}/`,
+              activeBaseRegex: `docs/(${versions.join('|')})/$`,
               label: "Quickstart",
             },
             {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ const _ = require("lodash");
 const linkifyRegex = require("./plugins/remark-linkify-regex");
 const { renderAnnouncementBar } = require("./src/components/ui/renderAnnouncementBar");
 const versions = require("./versions.json");
-const latestStableVersion = versions[0];
+const latestVersion = versions[0];
 const versionsMap = {
     ..._.keyBy(
         versions.map((item) => {
@@ -174,12 +174,12 @@ module.exports = {
           position: "left",
           items: [
                {
-              to: `/docs/${latestStableVersion}/concepts-overview/`,
+              to: `/docs/${latestVersion}/concepts-overview/`,
               activeBaseRegex: `docs/(${versions.join('|')})/concepts-overview/$`,
               label: "Concepts",
             },
             {
-              to: `/docs/${latestStableVersion}/`,
+              to: `/docs/${latestVersion}/`,
               activeBaseRegex: `docs/(${versions.join('|')})/$`,
               label: "Quickstart",
             },


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

After https://github.com/apache/pulsar-site/commit/b30efcce68ceeda50f960cec2a22fe0f1194d233, the Concepts, and Quickstart menu items are both highlighted at the same time.

Looks not good. 🙂

<img width="512" alt="Screenshot 2023-05-26 at 9 15 16 AM" src="https://github.com/apache/pulsar-site/assets/9302460/19f83095-4d1c-4ed2-9868-b8fee69d9806">

This PR fixes it.
Also, this PR fixes the reason behind https://github.com/apache/pulsar-site/commit/b30efcce68ceeda50f960cec2a22fe0f1194d233.
The Concepts and Quickstart menu items refer to the latest version now instead of `next`.

<img width="450" alt="Screenshot 2023-05-26 at 9 26 30 AM" src="https://github.com/apache/pulsar-site/assets/9302460/7b89cab8-ef09-4093-881f-2b3d7df72f74">
