### PR TITLE
[improve][docs] Upgrade nifi-nar-maven-plugin version shown in docs

### DIFF
--- a/docs/develop-plugin.md
+++ b/docs/develop-plugin.md
@@ -74,7 +74,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
          <plugin>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-nar-maven-plugin</artifactId>
-            <version>1.2.0</version>
+            <version>1.5.0</version>
             <extensions>true</extensions>
             <configuration>
                <finalName>${project.artifactId}-${project.version}</finalName>
@@ -192,7 +192,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
                <plugin>
                    <groupId>org.apache.nifi</groupId>
                    <artifactId>nifi-nar-maven-plugin</artifactId>
-                   <version>1.2.0</version>
+                   <version>1.5.0</version>
                    <extensions>true</extensions>
                    <configuration>
                        <finalName>${project.artifactId}-${project.version}</finalName>

--- a/docs/functions-package-java.md
+++ b/docs/functions-package-java.md
@@ -150,7 +150,7 @@ To package a Java function as NAR, complete the following steps.
                 <plugin>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-nar-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.5.0</version>
                     </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/docs/io-develop.md
+++ b/docs/io-develop.md
@@ -296,7 +296,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 ```

--- a/versioned_docs/version-2.10.x/develop-plugin.md
+++ b/versioned_docs/version-2.10.x/develop-plugin.md
@@ -75,7 +75,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
          <plugin>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-nar-maven-plugin</artifactId>
-            <version>1.2.0</version>
+            <version>1.5.0</version>
             <extensions>true</extensions>
             <configuration>
                <finalName>${project.artifactId}-${project.version}</finalName>
@@ -198,7 +198,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
                <plugin>
                    <groupId>org.apache.nifi</groupId>
                    <artifactId>nifi-nar-maven-plugin</artifactId>
-                   <version>1.2.0</version>
+                   <version>1.5.0</version>
                    <extensions>true</extensions>
                    <configuration>
                        <finalName>${project.artifactId}-${project.version}</finalName>

--- a/versioned_docs/version-2.10.x/io-develop.md
+++ b/versioned_docs/version-2.10.x/io-develop.md
@@ -316,7 +316,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 

--- a/versioned_docs/version-2.11.x/develop-plugin.md
+++ b/versioned_docs/version-2.11.x/develop-plugin.md
@@ -74,7 +74,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
          <plugin>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-nar-maven-plugin</artifactId>
-            <version>1.2.0</version>
+            <version>1.5.0</version>
             <extensions>true</extensions>
             <configuration>
                <finalName>${project.artifactId}-${project.version}</finalName>
@@ -192,7 +192,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
                <plugin>
                    <groupId>org.apache.nifi</groupId>
                    <artifactId>nifi-nar-maven-plugin</artifactId>
-                   <version>1.2.0</version>
+                   <version>1.5.0</version>
                    <extensions>true</extensions>
                    <configuration>
                        <finalName>${project.artifactId}-${project.version}</finalName>

--- a/versioned_docs/version-2.11.x/functions-package-java.md
+++ b/versioned_docs/version-2.11.x/functions-package-java.md
@@ -150,7 +150,7 @@ To package a Java function as NAR, complete the following steps.
                 <plugin>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-nar-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.5.0</version>
                     </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/versioned_docs/version-2.11.x/io-develop.md
+++ b/versioned_docs/version-2.11.x/io-develop.md
@@ -296,7 +296,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 ```

--- a/versioned_docs/version-2.8.x/io-develop.md
+++ b/versioned_docs/version-2.8.x/io-develop.md
@@ -316,7 +316,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 

--- a/versioned_docs/version-2.9.x/io-develop.md
+++ b/versioned_docs/version-2.9.x/io-develop.md
@@ -315,7 +315,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 

--- a/versioned_docs/version-3.0.x/develop-plugin.md
+++ b/versioned_docs/version-3.0.x/develop-plugin.md
@@ -74,7 +74,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
          <plugin>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-nar-maven-plugin</artifactId>
-            <version>1.2.0</version>
+            <version>1.5.0</version>
             <extensions>true</extensions>
             <configuration>
                <finalName>${project.artifactId}-${project.version}</finalName>
@@ -192,7 +192,7 @@ For how to create a Maven project, see [here](https://maven.apache.org/guides/ge
                <plugin>
                    <groupId>org.apache.nifi</groupId>
                    <artifactId>nifi-nar-maven-plugin</artifactId>
-                   <version>1.2.0</version>
+                   <version>1.5.0</version>
                    <extensions>true</extensions>
                    <configuration>
                        <finalName>${project.artifactId}-${project.version}</finalName>

--- a/versioned_docs/version-3.0.x/functions-package-java.md
+++ b/versioned_docs/version-3.0.x/functions-package-java.md
@@ -150,7 +150,7 @@ To package a Java function as NAR, complete the following steps.
                 <plugin>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-nar-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.5.0</version>
                     </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/versioned_docs/version-3.0.x/io-develop.md
+++ b/versioned_docs/version-3.0.x/io-develop.md
@@ -296,7 +296,7 @@ Include this [nifi-nar-maven-plugin](https://mvnrepository.com/artifact/org.apac
   <plugin>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-maven-plugin</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.0</version>
   </plugin>
 </plugins>
 ```


### PR DESCRIPTION
Update nar maven plugin to 1.5.0

Contains fixes such as
https://issues.apache.org/jira/browse/NIFI-10599
https://issues.apache.org/jira/browse/NIFI-11217

With older nifi-nar-maven-plugin versions, the nar file generation "downloads the internet" and is extremely slow together with other updated maven plugins.

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
