### PR TITLE
Fix error metric prefix

### DIFF
--- a/docs/deploy-monitoring.md
+++ b/docs/deploy-monitoring.md
@@ -61,11 +61,11 @@ The default port for bookie is `8000`. You can change the port by configuring `p
 The acknowledgment state is persistent to the ledger first. When the acknowledgment state fails to be persistent to the ledger, they are persistent to ZooKeeper. To track the stats of acknowledgment, you can configure the metrics for the managed cursor.
 
 ```
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 ```
 
 Those metrics are added in the Prometheus interface, you can monitor and check the metrics stats in Grafana.

--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -334,14 +334,14 @@ All the cursor acknowledgment state metrics are labeled with the following label
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
-brk_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
-brk_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
+pulsar_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
+pulsar_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
+pulsar_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labeled with the following labels:
@@ -571,17 +571,17 @@ All the offload metrics are labeled with the following labels:
 - *namespace*: `namespace=${pulsar_namespace}`. `${pulsar_namespace}` is the namespace name.
 - *topic*: `topic=${pulsar_topic}`. `${pulsar_topic}` is the topic name.
 
-| Name                                           | Type    | Description                                                                     |
-|------------------------------------------------|---------|---------------------------------------------------------------------------------|
-| brk_ledgeroffloader_offload_error              | Counter | The number of failed operations to offload.                                     |
-| brk_ledgeroffloader_offload_rate               | Gauge   | The rate of offloading(byte per second).                                        |
-| brk_ledgeroffloader_read_offload_error         | Counter | The number of failed operations to read offload ledgers.                        |
-| brk_ledgeroffloader_read_offload_rate          | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
-| brk_ledgeroffloader_write_storage_error        | Counter | The number of failed operations to write to storage.                            |
-| brk_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
-| brk_ledgeroffloader_read_offload_data_latency  | Summary | The latency of reading data from offload ledgers.                               |
-| brk_ledgeroffloader_read_ledger_latency        | Summary | The latency of reading entries from BookKeeper.                                 |
-| brk_ledgeroffloader_delete_offload_ops         | Counter | The total number of successful and failed operations to delete offload ledgers. |
+| Name                                | Type    | Description                                                                     |
+|-------------------------------------|---------|---------------------------------------------------------------------------------|
+| pulsar_ledgeroffloader_offload_error | Counter | The number of failed operations to offload.                                     |
+| pulsar_ledgeroffloader_offload_rate | Gauge   | The rate of offloading(byte per second).                                        |
+| pulsar_ledgeroffloader_read_offload_error | Counter | The number of failed operations to read offload ledgers.                        |
+| pulsar_ledgeroffloader_read_offload_rate | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
+| pulsar_ledgeroffloader_write_storage_error | Counter | The number of failed operations to write to storage.                            |
+| pulsar_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
+| pulsar_ledgeroffloader_read_offload_data_latency | Summary | The latency of reading data from offload ledgers.                               |
+| pulsar_ledgeroffloader_read_ledger_latency | Summary | The latency of reading entries from BookKeeper.                                 |
+| pulsar_ledgeroffloader_delete_offload_ops | Counter | The total number of successful and failed operations to delete offload ledgers. |
 
 
 ### Web service executor metrics

--- a/versioned_docs/version-2.10.x/deploy-monitoring.md
+++ b/versioned_docs/version-2.10.x/deploy-monitoring.md
@@ -73,11 +73,11 @@ The acknowledgment state is persistent to the ledger first. When the acknowledgm
 
 ```
 
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 
 ```
 

--- a/versioned_docs/version-2.10.x/reference-metrics.md
+++ b/versioned_docs/version-2.10.x/reference-metrics.md
@@ -261,14 +261,14 @@ All the cursor acknowledgment state metrics are labelled with the following labe
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
-brk_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
-brk_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
+pulsar_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
+pulsar_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
+pulsar_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labelled with the following labels:

--- a/versioned_docs/version-2.11.x/deploy-monitoring.md
+++ b/versioned_docs/version-2.11.x/deploy-monitoring.md
@@ -61,11 +61,11 @@ The default port for bookie is `8000`. You can change the port by configuring `p
 The acknowledgment state is persistent to the ledger first. When the acknowledgment state fails to be persistent to the ledger, they are persistent to ZooKeeper. To track the stats of acknowledgment, you can configure the metrics for the managed cursor.
 
 ```
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 ```
 
 Those metrics are added in the Prometheus interface, you can monitor and check the metrics stats in Grafana.

--- a/versioned_docs/version-2.11.x/reference-metrics.md
+++ b/versioned_docs/version-2.11.x/reference-metrics.md
@@ -311,14 +311,14 @@ All the cursor acknowledgment state metrics are labeled with the following label
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
-brk_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
-brk_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
+pulsar_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
+pulsar_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
+pulsar_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labeled with the following labels:
@@ -542,17 +542,17 @@ All the offload metrics are labeled with the following labels:
 - *namespace*: `namespace=${pulsar_namespace}`. `${pulsar_namespace}` is the namespace name.
 - *topic*: `topic=${pulsar_topic}`. `${pulsar_topic}` is the topic name.
 
-| Name                                           | Type    | Description                                                                     |
-|------------------------------------------------|---------|---------------------------------------------------------------------------------|
-| brk_ledgeroffloader_offload_error              | Counter | The number of failed operations to offload.                                     |
-| brk_ledgeroffloader_offload_rate               | Gauge   | The rate of offloading(byte per second).                                        |
-| brk_ledgeroffloader_read_offload_error         | Counter | The number of failed operations to read offload ledgers.                        |
-| brk_ledgeroffloader_read_offload_rate          | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
-| brk_ledgeroffloader_write_storage_error        | Counter | The number of failed operations to write to storage.                            |
-| brk_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
-| brk_ledgeroffloader_read_offload_data_latency  | Summary | The latency of reading data from offload ledgers.                               |
-| brk_ledgeroffloader_read_ledger_latency        | Summary | The latency of reading entries from BookKeeper.                                 |
-| brk_ledgeroffloader_delete_offload_ops         | Counter | The total number of successful and failed operations to delete offload ledgers. |
+| Name                                | Type    | Description                                                                     |
+|-------------------------------------|---------|---------------------------------------------------------------------------------|
+| pulsar_ledgeroffloader_offload_error | Counter | The number of failed operations to offload.                                     |
+| pulsar_ledgeroffloader_offload_rate | Gauge   | The rate of offloading(byte per second).                                        |
+| pulsar_ledgeroffloader_read_offload_error | Counter | The number of failed operations to read offload ledgers.                        |
+| pulsar_ledgeroffloader_read_offload_rate | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
+| pulsar_ledgeroffloader_write_storage_error | Counter | The number of failed operations to write to storage.                            |
+| pulsar_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
+| pulsar_ledgeroffloader_read_offload_data_latency | Summary | The latency of reading data from offload ledgers.                               |
+| pulsar_ledgeroffloader_read_ledger_latency | Summary | The latency of reading entries from BookKeeper.                                 |
+| pulsar_ledgeroffloader_delete_offload_ops | Counter | The total number of successful and failed operations to delete offload ledgers. |
 
 
 ### Web service executor metrics

--- a/versioned_docs/version-2.8.x/deploy-monitoring.md
+++ b/versioned_docs/version-2.8.x/deploy-monitoring.md
@@ -73,11 +73,11 @@ The acknowledgment state is persistent to the ledger first. When the acknowledgm
 
 ```
 
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 
 ```
 

--- a/versioned_docs/version-2.8.x/reference-metrics.md
+++ b/versioned_docs/version-2.8.x/reference-metrics.md
@@ -227,14 +227,14 @@ All the cursor acknowledgment state metrics are labelled with the following labe
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger. **Note:** This metric is only available in 2.8.1 and later versions.
-brk_ml_cursor_writeLedgerLogicalSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger (accounting for without replicas). **Note:** This metric is only available in 2.8.1 and later versions.
-brk_ml_cursor_readLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of read from ledger. **Note:** This metric is only available in 2.8.1 and later versions.
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger. **Note:** This metric is only available in 2.8.1 and later versions.
+pulsar_ml_cursor_writeLedgerLogicalSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger (accounting for without replicas). **Note:** This metric is only available in 2.8.1 and later versions.
+pulsar_ml_cursor_readLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of read from ledger. **Note:** This metric is only available in 2.8.1 and later versions.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labelled with the following labels:

--- a/versioned_docs/version-2.9.x/deploy-monitoring.md
+++ b/versioned_docs/version-2.9.x/deploy-monitoring.md
@@ -73,11 +73,11 @@ The acknowledgment state is persistent to the ledger first. When the acknowledgm
 
 ```
 
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 
 ```
 

--- a/versioned_docs/version-2.9.x/reference-metrics.md
+++ b/versioned_docs/version-2.9.x/reference-metrics.md
@@ -178,8 +178,8 @@ All the replication metrics are also labelled with `remoteCluster=${pulsar_remot
 | pulsar_replication_throughput_in | Gauge | The total throughput of the namespace replicating from remote cluster (bytes/second). |
 | pulsar_replication_throughput_out | Gauge | The total throughput of the namespace replicating to remote cluster (bytes/second). |
 | pulsar_replication_backlog | Gauge | The total backlog of the namespace replicating to remote cluster (messages). |
-| pulsar_replication_rate_expired | Gauge | Total rate of messages expired (messages/second). |	
-| pulsar_replication_connected_count | Gauge | The count of replication-subscriber up and running to replicate to remote cluster. |	
+| pulsar_replication_rate_expired | Gauge | Total rate of messages expired (messages/second). |
+| pulsar_replication_connected_count | Gauge | The count of replication-subscriber up and running to replicate to remote cluster. |
 | pulsar_replication_delay_in_seconds | Gauge | Time in seconds from the time a message was produced to the time when it is about to be replicated. |
 
 ### ManagedLedgerCache metrics
@@ -248,14 +248,14 @@ All the cursor acknowledgment state metrics are labelled with the following labe
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger.
-brk_ml_cursor_writeLedgerLogicalSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger (accounting for without replicas).
-brk_ml_cursor_readLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of read from ledger.
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger.
+pulsar_ml_cursor_writeLedgerLogicalSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of write to ledger (accounting for without replicas).
+pulsar_ml_cursor_readLedgerSize(namespace="", ledger_name="", cursor_name:"")|Gauge|The size of read from ledger.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labelled with the following labels:

--- a/versioned_docs/version-3.0.x/deploy-monitoring.md
+++ b/versioned_docs/version-3.0.x/deploy-monitoring.md
@@ -61,11 +61,11 @@ The default port for bookie is `8000`. You can change the port by configuring `p
 The acknowledgment state is persistent to the ledger first. When the acknowledgment state fails to be persistent to the ledger, they are persistent to ZooKeeper. To track the stats of acknowledgment, you can configure the metrics for the managed cursor.
 
 ```
-brk_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
-brk_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
-brk_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistLedgerSucceed(namespace=", ledger_name="", cursor_name:")
+pulsar_ml_cursor_persistLedgerErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperSucceed(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_persistZookeeperErrors(namespace="", ledger_name="", cursor_name:"")
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange(namespace="", ledger_name="", cursor_name:"")
 ```
 
 Those metrics are added in the Prometheus interface, you can monitor and check the metrics stats in Grafana.

--- a/versioned_docs/version-3.0.x/reference-metrics.md
+++ b/versioned_docs/version-3.0.x/reference-metrics.md
@@ -334,14 +334,14 @@ All the cursor acknowledgment state metrics are labeled with the following label
 
 Name	|Type	|Description
 |---|---|---
-brk_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
-brk_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
-brk_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
-brk_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
-brk_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
-brk_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
-brk_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
-brk_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
+pulsar_ml_cursor_persistLedgerSucceed|Gauge|The number of acknowledgment states that is persistent to a ledger.|
+pulsar_ml_cursor_persistLedgerErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to the ledger.|
+pulsar_ml_cursor_persistZookeeperSucceed|Gauge|The number of acknowledgment states that is persistent to ZooKeeper.
+pulsar_ml_cursor_persistZookeeperErrors|Gauge|The number of ledger errors occurred when acknowledgment states fail to be persistent to ZooKeeper.
+pulsar_ml_cursor_nonContiguousDeletedMessagesRange|Gauge|The number of non-contiguous deleted messages ranges.
+pulsar_ml_cursor_writeLedgerSize|Gauge|The size of write to ledger.
+pulsar_ml_cursor_writeLedgerLogicalSize|Gauge|The size of write to ledger (accounting for without replicas).
+pulsar_ml_cursor_readLedgerSize|Gauge|The size of read from ledger.
 
 ### LoadBalancing metrics
 All the loadbalancing metrics are labeled with the following labels:
@@ -571,17 +571,17 @@ All the offload metrics are labeled with the following labels:
 - *namespace*: `namespace=${pulsar_namespace}`. `${pulsar_namespace}` is the namespace name.
 - *topic*: `topic=${pulsar_topic}`. `${pulsar_topic}` is the topic name.
 
-| Name                                           | Type    | Description                                                                     |
-|------------------------------------------------|---------|---------------------------------------------------------------------------------|
-| brk_ledgeroffloader_offload_error              | Counter | The number of failed operations to offload.                                     |
-| brk_ledgeroffloader_offload_rate               | Gauge   | The rate of offloading(byte per second).                                        |
-| brk_ledgeroffloader_read_offload_error         | Counter | The number of failed operations to read offload ledgers.                        |
-| brk_ledgeroffloader_read_offload_rate          | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
-| brk_ledgeroffloader_write_storage_error        | Counter | The number of failed operations to write to storage.                            |
-| brk_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
-| brk_ledgeroffloader_read_offload_data_latency  | Summary | The latency of reading data from offload ledgers.                               |
-| brk_ledgeroffloader_read_ledger_latency        | Summary | The latency of reading entries from BookKeeper.                                 |
-| brk_ledgeroffloader_delete_offload_ops         | Counter | The total number of successful and failed operations to delete offload ledgers. |
+| Name                                | Type    | Description                                                                     |
+|-------------------------------------|---------|---------------------------------------------------------------------------------|
+| pulsar_ledgeroffloader_offload_error | Counter | The number of failed operations to offload.                                     |
+| pulsar_ledgeroffloader_offload_rate | Gauge   | The rate of offloading(byte per second).                                        |
+| pulsar_ledgeroffloader_read_offload_error | Counter | The number of failed operations to read offload ledgers.                        |
+| pulsar_ledgeroffloader_read_offload_rate | Gauge   | The rate of reading entries from offload ledgers(byte per second).              |
+| pulsar_ledgeroffloader_write_storage_error | Counter | The number of failed operations to write to storage.                            |
+| pulsar_ledgeroffloader_read_offload_index_latency | Summary | The latency of reading index from offload ledgers.                              |
+| pulsar_ledgeroffloader_read_offload_data_latency | Summary | The latency of reading data from offload ledgers.                               |
+| pulsar_ledgeroffloader_read_ledger_latency | Summary | The latency of reading entries from BookKeeper.                                 |
+| pulsar_ledgeroffloader_delete_offload_ops | Counter | The total number of successful and failed operations to delete offload ledgers. |
 
 
 ### Web service executor metrics


### PR DESCRIPTION
### Motivation

We will convert the metric prefix `brk_` to `pulsar_` when generating the metrics.
So we don't have `brk_` related metrics.

As most of the users are using Pulsar-2.8 at least, so I just modify the error metrics from 2.8~now


- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
