### PR TITLE
[doc][improve]--fix typos in get the secret section

### DIFF
--- a/docs/functions-develop-security.md
+++ b/docs/functions-develop-security.md
@@ -61,7 +61,7 @@ public class GetSecretValueFunction implements Function<String, Void> {
         String secretValue = context.getSecret(input);
 
         if (!secretValue.isEmpty()) {
-            LOG.info("The secret {} has value {}", intput, secretValue);
+            LOG.info("The secret {} has value {}", input, secretValue);
         } else {
             LOG.warn("No secret with key {}", input);
         }

--- a/versioned_docs/version-2.11.x/functions-develop-security.md
+++ b/versioned_docs/version-2.11.x/functions-develop-security.md
@@ -61,7 +61,7 @@ public class GetSecretValueFunction implements Function<String, Void> {
         String secretValue = context.getSecret(input);
 
         if (!secretValue.isEmpty()) {
-            LOG.info("The secret {} has value {}", intput, secretValue);
+            LOG.info("The secret {} has value {}", input, secretValue);
         } else {
             LOG.warn("No secret with key {}", input);
         }

--- a/versioned_docs/version-3.0.x/functions-develop-security.md
+++ b/versioned_docs/version-3.0.x/functions-develop-security.md
@@ -61,7 +61,7 @@ public class GetSecretValueFunction implements Function<String, Void> {
         String secretValue = context.getSecret(input);
 
         if (!secretValue.isEmpty()) {
-            LOG.info("The secret {} has value {}", intput, secretValue);
+            LOG.info("The secret {} has value {}", input, secretValue);
         } else {
             LOG.warn("No secret with key {}", input);
         }


### PR DESCRIPTION
### Motivation

A typo is found at the "Get the secret" section in Enable security on Functions doc: https://pulsar.apache.org/docs/next/functions-develop-security/#get-the-secret.

- [ x ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->

Before update, it looks like:
<img width="771" alt="image" src="https://github.com/apache/pulsar-site/assets/48120384/e4d0a34a-213c-43ed-8354-877a19457cab">


After update, the preview looks good：
<img width="852" alt="image" src="https://github.com/apache/pulsar-site/assets/48120384/5a3de003-02d8-4ab0-9fd6-a721b38e29b1">
