### PR TITLE
HomePage - Make the blurry part not be cut, but slowly become blurry as user scrolls to make it a smooth transition.

### DIFF
--- a/src/components/pages/HomePage/HomePage.tsx
+++ b/src/components/pages/HomePage/HomePage.tsx
@@ -11,6 +11,8 @@ import useScrollPosition from './useScrollPosition';
 const HomePage = () => {
   const scrollPosition = useScrollPosition();
 
+  const blurPx = scrollPosition * 0.1;
+
   return (
     <Layout
       title={"Apache Pulsar"}
@@ -20,7 +22,7 @@ const HomePage = () => {
         <div
           className={s.Background}
           style={{
-            filter: `blur(${scrollPosition * 0.1}px)`,
+            filter: `blur(${blurPx < 24 ? blurPx : blurPx}px)`,
             willChange: 'filter'
           }}
         />

--- a/src/components/pages/HomePage/HomePage.tsx
+++ b/src/components/pages/HomePage/HomePage.tsx
@@ -6,8 +6,10 @@ import ShortInfo from './ShortInfo/ShortInfo';
 import Users from './Users/Users';
 
 import s from './HomePage.module.css';
+import useScrollPosition from './useScrollPosition';
 
 const HomePage = () => {
+  const scrollPosition = useScrollPosition();
 
   return (
     <Layout
@@ -15,7 +17,13 @@ const HomePage = () => {
       description={"Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud."}
     >
       <div className={s.Page}>
-        <div className={s.Background}></div>
+        <div
+          className={s.Background}
+          style={{
+            filter: `blur(${scrollPosition * 0.1}px)`,
+            willChange: 'filter'
+          }}
+        />
         <div className={s.FirstScreen}>
           <ShortInfo />
         </div>

--- a/src/components/pages/HomePage/ShortInfo/Parallax/Parallax.tsx
+++ b/src/components/pages/HomePage/ShortInfo/Parallax/Parallax.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React from "react";
+import useScrollPosition from "../../useScrollPosition";
 
 import s from './Parallax.module.css';
 
@@ -9,24 +10,7 @@ type ParallaxProps = {
 const Parallax = (props: ParallaxProps) => {
   const { children } = props;
   const isBrowser = typeof window !== 'undefined';
-
-  const [scrollPosition, setScrollPosition] = useState(0);
-
-  const handleScroll = useCallback(() => {
-    setScrollPosition(isBrowser ? window.scrollY : 0)
-  }, []);
-
-  useEffect(() => {
-    if (isBrowser) {
-      window.addEventListener("scroll", handleScroll);
-    }
-
-    return () => {
-      if (isBrowser) {
-        window.removeEventListener("scroll", handleScroll);
-      }
-    };
-  }, []);
+  const scrollPosition = useScrollPosition();
 
   return (
     <div className={s.container}>
@@ -34,7 +18,7 @@ const Parallax = (props: ParallaxProps) => {
         className={s.component}
         style={{
           transform: `translateY(-${scrollPosition * 0.5}px) translateZ(0)`,
-          opacity: 1 - scrollPosition / (isBrowser ? window.innerHeight : 1)
+          opacity: 1 - scrollPosition / (isBrowser ? window.innerHeight : 1),
         }}
       >
         {children}

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.module.css
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.module.css
@@ -89,17 +89,6 @@
   margin-right: 1rem;
 }
 
-.blur {
-  backdrop-filter: blur(3rem);
-  backface-visibility: hidden;
-  transform: translateZ(0);
-
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
 @media (max-width: 1280px) {
   .container {
     box-sizing: border-box;

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
@@ -41,8 +41,6 @@ const ShortInfo: React.FC = () => {
       </div>
 
       <div className={s.fullsize_container}>
-        <div className={s.blur} />
-
         <div className={s.container}>
           <div className={s.info_container}>
             <ScreenTitle>

--- a/src/components/pages/HomePage/useScrollPosition.tsx
+++ b/src/components/pages/HomePage/useScrollPosition.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+const useScrollPosition = () => {
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const updatePosition = () => {
+      setScrollPosition(window.pageYOffset);
+    }
+    window.addEventListener("scroll", updatePosition);
+    updatePosition();
+    return () => window.removeEventListener("scroll", updatePosition);
+  }, []);
+
+  return scrollPosition;
+};
+
+export default useScrollPosition;


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


Live demo: https://pulsar-site-pip-249-git-blur-transition-teal-tools.vercel.app/
Feature request: https://apache-pulsar.slack.com/archives/C04UXRZSMHV/p1686493144908659

https://github.com/apache/pulsar-site/assets/9302460/40c8d02b-5809-4e16-bcf2-f375c74f4a10

My only concern for such animations is performance on some devices, especially on mobile.

Please thumb up 👍 if it performs smoothly on your device.
Thumb down 👎 if not.