### PR TITLE
[doc][improve] add popular topics to dev landing page

### DIFF
--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -6,7 +6,7 @@ sidebar_label: "Pulsar for Developers"
 
 ## Popular topics
 
-If you want to read top-viewed docs for developers, check out the following concepts, examples, and tutorials.
+If you want to read top-viewed documents for developers, check out the following concepts, examples, and tutorials.
 
 - [Pulsar concepts](concepts-messaging.md)
 - [Pulsar clients](client-libraries.md)
@@ -17,9 +17,9 @@ If you want to read top-viewed docs for developers, check out the following conc
 
 ## Advanced topics
 
-If you want to learn how to develop Pulsar related components, check out the following guides.
+If you want to learn how to develop Pulsar-related components, check out the following documents.
 
-- [Develop simulation tools](develop-tools.md)
-- [Develop binary protocol](developing-binary-protocol.md)
+- [Create a test environment](develop-tools.md)
+- [Develop with the binary protocol](developing-binary-protocol.md)
 - [Develop load manager](develop-load-manager.md)
-- [Develop Pulsar plugin](develop-plugin.md)
+- [Develop plugins for Pulsar](develop-plugin.md)

--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -10,3 +10,17 @@ Developing applications for Pulsar can be a fun and rewarding experience. With P
 - [Develop binary protocol](developing-binary-protocol.md)
 - [Develop load manager](develop-load-manager.md)
 - [Develop Pulsar plugin](develop-plugin.md)
+
+## Populsar topics
+
+If you want to read top-viewed docs for developers, check out the following concepts, examples, and tutorials.
+
+- [Pulsar concepts](concepts-messaging.md)
+
+- [Pulsar clients](client-libraries.md)
+
+- [Pulsar APIs](pulsar-api-overview.md)
+    - [Pulsar admin APIs](admin-api-overview.md)
+    - [Pulsar REST APIs](reference-rest-api-overview.md)
+
+- [Pulsar contribution guide](../../contribute)

--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -4,15 +4,6 @@ title: Pulsar for Developers
 sidebar_label: "Pulsar for Developers"
 ---
 
-## Advanced topics
-
-If you want to learn how to develop Pulsar related components, check out the following guides.
-
-- [Develop simulation tools](develop-tools.md)
-- [Develop binary protocol](developing-binary-protocol.md)
-- [Develop load manager](develop-load-manager.md)
-- [Develop Pulsar plugin](develop-plugin.md)
-
 ## Popular topics
 
 If you want to read top-viewed docs for developers, check out the following concepts, examples, and tutorials.
@@ -23,3 +14,12 @@ If you want to read top-viewed docs for developers, check out the following conc
     - [Pulsar admin APIs](admin-api-overview.md)
     - [Pulsar REST APIs](reference-rest-api-overview.md)
 - [Pulsar contribution guide](../../contribute)
+
+## Advanced topics
+
+If you want to learn how to develop Pulsar related components, check out the following guides.
+
+- [Develop simulation tools](develop-tools.md)
+- [Develop binary protocol](developing-binary-protocol.md)
+- [Develop load manager](develop-load-manager.md)
+- [Develop Pulsar plugin](develop-plugin.md)

--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -4,14 +4,16 @@ title: Pulsar for Developers
 sidebar_label: "Pulsar for Developers"
 ---
 
-Developing applications for Pulsar can be a fun and rewarding experience. With Pulsar, you can quickly create, deploy, and manage your services using a powerful CLI tool and a comprehensive set of libraries. The topics below will get you started!
+## Advanced topics
+
+If you want to learn how to develop Pulsar related components, check out the following guides.
 
 - [Develop simulation tools](develop-tools.md)
 - [Develop binary protocol](developing-binary-protocol.md)
 - [Develop load manager](develop-load-manager.md)
 - [Develop Pulsar plugin](develop-plugin.md)
 
-## Populsar topics
+## Popular topics
 
 If you want to read top-viewed docs for developers, check out the following concepts, examples, and tutorials.
 

--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -18,11 +18,8 @@ If you want to learn how to develop Pulsar related components, check out the fol
 If you want to read top-viewed docs for developers, check out the following concepts, examples, and tutorials.
 
 - [Pulsar concepts](concepts-messaging.md)
-
 - [Pulsar clients](client-libraries.md)
-
 - [Pulsar APIs](pulsar-api-overview.md)
     - [Pulsar admin APIs](admin-api-overview.md)
     - [Pulsar REST APIs](reference-rest-api-overview.md)
-
 - [Pulsar contribution guide](../../contribute)

--- a/docs/developers-landing.md
+++ b/docs/developers-landing.md
@@ -21,5 +21,5 @@ If you want to learn how to develop Pulsar-related components, check out the fol
 
 - [Create a test environment](develop-tools.md)
 - [Develop with the binary protocol](developing-binary-protocol.md)
-- [Develop load manager](develop-load-manager.md)
+- [Develop broker load balancer](develop-load-manager.md)
 - [Develop plugins for Pulsar](develop-plugin.md)


### PR DESCRIPTION
This PR adds popular topics to the dev landing page to give quick guidance for devs to get familiar with Pulsar.

The popular topics (pages) are based on the data collected from [GA](https://docs.google.com/document/d/1H-wEEfut18M18dle6a4-2EWCnLOqyJ81RVYxkPkTXhk/edit#bookmark=id.8p4o4lxknpyy) and [Matomo](https://matomo.privacy.apache.org/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=32#?idSite=32&period=range&date=2022-11-07,2023-06-13&category=General_Actions&subcategory=General_Pages), which covers from concepts, tasks, and references.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
