### PR TITLE
[fix][doc] Pulsar client JWT auth example missing commas

### DIFF
--- a/docs/security-jwt.md
+++ b/docs/security-jwt.md
@@ -179,7 +179,7 @@ PulsarClient client = PulsarClient.builder()
 ```python
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 ```
 
@@ -190,7 +190,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 ```
 

--- a/versioned_docs/version-2.10.x/security-jwt.md
+++ b/versioned_docs/version-2.10.x/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.11.x/security-jwt.md
+++ b/versioned_docs/version-2.11.x/security-jwt.md
@@ -173,7 +173,7 @@ PulsarClient client = PulsarClient.builder()
 ```python
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 ```
 
@@ -184,7 +184,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 ```
 

--- a/versioned_docs/version-2.2.1/security-token-client.md
+++ b/versioned_docs/version-2.2.1/security-token-client.md
@@ -86,7 +86,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -99,7 +99,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.3.0/security-token-client.md
+++ b/versioned_docs/version-2.3.0/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.3.1/security-token-client.md
+++ b/versioned_docs/version-2.3.1/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.3.2/security-token-client.md
+++ b/versioned_docs/version-2.3.2/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.0/security-jwt.md
+++ b/versioned_docs/version-2.4.0/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.0/security-token-client.md
+++ b/versioned_docs/version-2.4.0/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.1/security-jwt.md
+++ b/versioned_docs/version-2.4.1/security-jwt.md
@@ -98,7 +98,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -111,7 +111,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.1/security-token-client.md
+++ b/versioned_docs/version-2.4.1/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.2/security-jwt.md
+++ b/versioned_docs/version-2.4.2/security-jwt.md
@@ -98,7 +98,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -111,7 +111,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.4.2/security-token-client.md
+++ b/versioned_docs/version-2.4.2/security-token-client.md
@@ -83,7 +83,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -96,7 +96,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.5.0/security-jwt.md
+++ b/versioned_docs/version-2.5.0/security-jwt.md
@@ -98,7 +98,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -111,7 +111,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.5.1/security-jwt.md
+++ b/versioned_docs/version-2.5.1/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.5.2/security-jwt.md
+++ b/versioned_docs/version-2.5.2/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.6.0/security-jwt.md
+++ b/versioned_docs/version-2.6.0/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.6.1/security-jwt.md
+++ b/versioned_docs/version-2.6.1/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.6.2/security-jwt.md
+++ b/versioned_docs/version-2.6.2/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.6.3/security-jwt.md
+++ b/versioned_docs/version-2.6.3/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.6.4/security-jwt.md
+++ b/versioned_docs/version-2.6.4/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.0/security-jwt.md
+++ b/versioned_docs/version-2.7.0/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.1/security-jwt.md
+++ b/versioned_docs/version-2.7.1/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.2/security-jwt.md
+++ b/versioned_docs/version-2.7.2/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.3/security-jwt.md
+++ b/versioned_docs/version-2.7.3/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.4/security-jwt.md
+++ b/versioned_docs/version-2.7.4/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.7.5/security-jwt.md
+++ b/versioned_docs/version-2.7.5/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.8.x/security-jwt.md
+++ b/versioned_docs/version-2.8.x/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-2.9.x/security-jwt.md
+++ b/versioned_docs/version-2.9.x/security-jwt.md
@@ -99,7 +99,7 @@ PulsarClient client = PulsarClient.builder()
 
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 
 ```
@@ -112,7 +112,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 
 ```

--- a/versioned_docs/version-3.0.x/security-jwt.md
+++ b/versioned_docs/version-3.0.x/security-jwt.md
@@ -179,7 +179,7 @@ PulsarClient client = PulsarClient.builder()
 ```python
 from pulsar import Client, AuthenticationToken
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJKb2UifQ.ipevRNuRP6HflG8cFKnmUPtypruRC4fb1DWtoLL62SY'))
 ```
 
@@ -190,7 +190,7 @@ def read_token():
     with open('/path/to/token.txt') as tf:
         return tf.read().strip()
 
-client = Client('pulsar://broker.example.com:6650/'
+client = Client('pulsar://broker.example.com:6650/',
                 authentication=AuthenticationToken(read_token))
 ```
 


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

Fix the python client JWT auth example problem which is missing the commas. 

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
