### PR TITLE
[fix][doc]: add the primary auth config on cluster failover example 

### DIFF
--- a/docs/client-libraries-cluster-level-failover.md
+++ b/docs/client-libraries-cluster-level-failover.md
@@ -38,7 +38,12 @@ This is an example of how to construct a Java Pulsar client to use automatic clu
 private PulsarClient getAutoFailoverClient() throws PulsarClientException {
     String primaryUrl = "pulsar+ssl://localhost:6651";
     String secondaryUrl = "pulsar+ssl://localhost:6661";
+    String primaryTlsTrustCertsFilePath = "primary/path";
     String secondaryTlsTrustCertsFilePath = "secondary/path";
+    Authentication primaryAuthentication = AuthenticationFactory.create(
+        "org.apache.pulsar.client.impl.auth.AuthenticationTls",
+        "tlsCertFile:/path/to/primary-my-role.cert.pem,"
+                + "tlsKeyFile:/path/to/primary-role.key-pk8.pem");
     Authentication secondaryAuthentication = AuthenticationFactory.create(
         "org.apache.pulsar.client.impl.auth.AuthenticationTls",
         "tlsCertFile:/path/to/secondary-my-role.cert.pem,"
@@ -76,6 +81,8 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
+`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
+`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|Path to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|Authentication of the backup cluster.
 

--- a/docs/client-libraries-cluster-level-failover.md
+++ b/docs/client-libraries-cluster-level-failover.md
@@ -83,8 +83,6 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
-`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
-`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|Path to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|Authentication of the backup cluster.
 

--- a/docs/client-libraries-cluster-level-failover.md
+++ b/docs/client-libraries-cluster-level-failover.md
@@ -65,6 +65,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
+        .authentication(primaryAuthentication) 
+        .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
     failover.initialize(pulsarClient);

--- a/versioned_docs/version-2.10.x/client-libraries-java.md
+++ b/versioned_docs/version-2.10.x/client-libraries-java.md
@@ -376,6 +376,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
+        .authentication(primaryAuthentication) 
+        .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
     failover.initialize(pulsarClient);

--- a/versioned_docs/version-2.10.x/client-libraries-java.md
+++ b/versioned_docs/version-2.10.x/client-libraries-java.md
@@ -394,8 +394,6 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
-`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
-`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|A map of certificate file. Keys are service urls of backup cluster. Values are paths to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|A map of Authentication config. Keys are service urls of backup cluster. Values are Authentication object of the backup cluster.
 

--- a/versioned_docs/version-2.10.x/client-libraries-java.md
+++ b/versioned_docs/version-2.10.x/client-libraries-java.md
@@ -346,6 +346,12 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
     String primaryUrl = "pulsar+ssl://localhost:6651";
     String secondaryUrl = "pulsar+ssl://localhost:6661";
 
+    String primaryTlsTrustCertsFilePath = "primary/path";
+    Authentication primaryAuthentication = AuthenticationFactory.create(
+        "org.apache.pulsar.client.impl.auth.AuthenticationTls",
+        "tlsCertFile:/path/to/primary-my-role.cert.pem,"
+                + "tlsKeyFile:/path/to/primary-role.key-pk8.pem");
+
     String secondaryTlsTrustCertsFilePath = "secondary/path";
     Authentication secondaryAuthentication = AuthenticationFactory.create(
         "org.apache.pulsar.client.impl.auth.AuthenticationTls",
@@ -386,6 +392,8 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
+`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
+`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|A map of certificate file. Keys are service urls of backup cluster. Values are paths to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|A map of Authentication config. Keys are service urls of backup cluster. Values are Authentication object of the backup cluster.
 

--- a/versioned_docs/version-2.11.x/client-libraries-java.md
+++ b/versioned_docs/version-2.11.x/client-libraries-java.md
@@ -1238,6 +1238,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
+        .authentication(primaryAuthentication) 
+        .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
     failover.initialize(pulsarClient);

--- a/versioned_docs/version-2.11.x/client-libraries-java.md
+++ b/versioned_docs/version-2.11.x/client-libraries-java.md
@@ -1208,6 +1208,12 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
     String primaryUrl = "pulsar+ssl://localhost:6651";
     String secondaryUrl = "pulsar+ssl://localhost:6661";
 
+    String primaryTlsTrustCertsFilePath = "primary/path";
+    Authentication primaryAuthentication = AuthenticationFactory.create(
+        "org.apache.pulsar.client.impl.auth.AuthenticationTls",
+        "tlsCertFile:/path/to/primary-my-role.cert.pem,"
+                + "tlsKeyFile:/path/to/primary-role.key-pk8.pem");
+
     String secondaryTlsTrustCertsFilePath = "secondary/path";
     Authentication secondaryAuthentication = AuthenticationFactory.create(
         "org.apache.pulsar.client.impl.auth.AuthenticationTls",
@@ -1248,6 +1254,8 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
+`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
+`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|A map of certificate file. Keys are service urls of backup cluster. Values are paths to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|A map of Authentication config. Keys are service urls of backup cluster. Values are Authentication object of the backup cluster.
 

--- a/versioned_docs/version-2.11.x/client-libraries-java.md
+++ b/versioned_docs/version-2.11.x/client-libraries-java.md
@@ -1256,8 +1256,6 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
-`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
-`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|A map of certificate file. Keys are service urls of backup cluster. Values are paths to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|A map of Authentication config. Keys are service urls of backup cluster. Values are Authentication object of the backup cluster.
 

--- a/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
@@ -38,7 +38,12 @@ This is an example of how to construct a Java Pulsar client to use automatic clu
 private PulsarClient getAutoFailoverClient() throws PulsarClientException {
     String primaryUrl = "pulsar+ssl://localhost:6651";
     String secondaryUrl = "pulsar+ssl://localhost:6661";
+    String primaryTlsTrustCertsFilePath = "primary/path";
     String secondaryTlsTrustCertsFilePath = "secondary/path";
+    Authentication primaryAuthentication = AuthenticationFactory.create(
+        "org.apache.pulsar.client.impl.auth.AuthenticationTls",
+        "tlsCertFile:/path/to/primary-my-role.cert.pem,"
+                + "tlsKeyFile:/path/to/primary-role.key-pk8.pem");
     Authentication secondaryAuthentication = AuthenticationFactory.create(
         "org.apache.pulsar.client.impl.auth.AuthenticationTls",
         "tlsCertFile:/path/to/secondary-my-role.cert.pem,"
@@ -76,6 +81,8 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
+`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
+`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|Path to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|Authentication of the backup cluster.
 

--- a/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
@@ -83,8 +83,6 @@ Parameter|Default value|Required?|Description
 `failoverDelay`|N/A|Yes|The delay before the Pulsar client switches from the primary cluster to the backup cluster.<br /><br />Automatic failover is controlled by a probe task: <br />1) The probe task first checks the health status of the primary cluster. <br /> 2) If the probe task finds the continuous failure time of the primary cluster exceeds `failoverDelayMs`, it switches the Pulsar client to the backup cluster.
 `switchBackDelay`|N/A|Yes|The delay before the Pulsar client switches from the backup cluster to the primary cluster.<br /><br />Automatic failover switchover is controlled by a probe task: <br /> 1) After the Pulsar client switches from the primary cluster to the backup cluster, the probe task continues to check the status of the primary cluster. <br /> 2) If the primary cluster functions well and continuously remains active longer than `switchBackDelay`, the Pulsar client switches back to the primary cluster.
 `checkInterval`|30s|No|Frequency of performing a probe task (in seconds).
-`primaryTlsTrustCertsFilePath` |N/A|No|Path to the trusted TLS certificate file of the primary cluster.
-`primaryAuthentication`|N/A|No|Authentication of the primary cluster.
 `secondaryTlsTrustCertsFilePath`|N/A|No|Path to the trusted TLS certificate file of the backup cluster.
 `secondaryAuthentication`|N/A|No|Authentication of the backup cluster.
 

--- a/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
@@ -65,6 +65,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
+        .authentication(primaryAuthentication) 
+        .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
     failover.initialize(pulsarClient);


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

### Motivation

It's quite weird that on the https://pulsar.apache.org/docs/3.0.x/client-libraries-cluster-level-failover/#automatic-failover code example only includes the secondary cluster auth config without the primary cluster auth. 

And as my check on test code https://github.com/apache/pulsar/blob/2b01f83ea4f3ab7b22f4ea2b0290cc183e79bbb8/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java#L73 it has the `primaryAuthentication` config creation. 

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
