### PR TITLE
[fix][doc] Misleading tip about retention, not mentioned topics policies.

### DIFF
--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1073,7 +1073,7 @@ Pulsar has two features, however, that enable you to override this default behav
 
 :::tip
 
-All message retention and expiry are managed at the [namespace](#namespaces) level or at [topic]($topic) level from Pulsar `2.6.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
+All message retention and expiry are managed at the [namespace](#namespaces) level or at topic level from Pulsar `2.6.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
 
 :::
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1073,7 +1073,7 @@ Pulsar has two features, however, that enable you to override this default behav
 
 :::tip
 
-All message retention and expiry are managed at the [namespace](#namespaces) level. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
+All message retention and expiry are managed at the [namespace](#namespaces) level or at [topic]($topic) level from Pulsar `2.6.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
 
 :::
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1073,7 +1073,11 @@ Pulsar has two features, however, that enable you to override this default behav
 
 :::tip
 
-All message retention and expiry are managed at the [namespace](#namespaces) level or at topic level from Pulsar `2.7.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
+Since Pulsar 2.7.0, all message retention and expiry can be managed at the [namespace](#namespaces) level or at the topic level. For example, you can set `topicLevelPoliciesEnabled=true` at `broker.conf`. 
+
+Since Pulsaer 2.11.0, the default value of  `topicLevelPoliciesEnabled` is `true`. 
+
+For how to set policies for message retention and expiry, see [message retention and expiry](cookbooks-retention-expiry.md).
 
 :::
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1073,7 +1073,7 @@ Pulsar has two features, however, that enable you to override this default behav
 
 :::tip
 
-All message retention and expiry are managed at the [namespace](#namespaces) level or at topic level from Pulsar `2.6.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
+All message retention and expiry are managed at the [namespace](#namespaces) level or at topic level from Pulsar `2.7.0` activating `topicLevelPoliciesEnabled=true` at broker.conf. Since `2.11` that default value is `true`. For a how-to, see the [Message retention and expiry](cookbooks-retention-expiry.md) cookbook.
 
 :::
 


### PR DESCRIPTION
Added information about topic retention policies on the tip. 

It forgets to mention that there are actions that can be performed at `topic` level for retention and mislead that it can only be done at namespace level

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
