### PR TITLE
[improve][doc] Subscription replication doesn't replicate the type

### DIFF
--- a/versioned_docs/version-3.0.x/administration-geo.md
+++ b/versioned_docs/version-3.0.x/administration-geo.md
@@ -229,7 +229,7 @@ If you want to use replicated subscriptions in Pulsar:
   ```
 :::note
 
-* Replication type is not replicated between clusters. However, it's determined by the first consumer that connects to the subscription.
+* Subscription type is not replicated between clusters. However, it's determined by the first consumer that connects to the subscription.
 
 :::
 

--- a/versioned_docs/version-3.0.x/administration-geo.md
+++ b/versioned_docs/version-3.0.x/administration-geo.md
@@ -229,7 +229,7 @@ If you want to use replicated subscriptions in Pulsar:
   ```
 :::note
 
-* Replication type is not replicated between clusters but determined by the first consumer that connects to the subscription.
+* Replication type is not replicated between clusters. However, it's determined by the first consumer that connects to the subscription.
 
 :::
 

--- a/versioned_docs/version-3.0.x/administration-geo.md
+++ b/versioned_docs/version-3.0.x/administration-geo.md
@@ -227,6 +227,12 @@ If you want to use replicated subscriptions in Pulsar:
               .replicateSubscriptionState(true)
               .subscribe();
   ```
+:::note
+
+* Replication type is not replicated between clusters but determined by the first consumer that connects to the subscription.
+
+:::
+
 
 ### Advantages
 
@@ -239,6 +245,7 @@ If you want to use replicated subscriptions in Pulsar:
 
 * When you enable replicated subscriptions, you're creating a consistent distributed snapshot to establish an association between message ids from different clusters. The snapshots are taken periodically. The default value is `1 second`. It means that a consumer failing over to a different cluster can potentially receive 1 second of duplicates. You can also configure the frequency of the snapshot in the `broker.conf` file.
 * Only the base line cursor position is synced in replicated subscriptions while the individual acknowledgments are not synced. This means the messages acknowledged out-of-order could end up getting delivered again, in the case of a cluster failover.
+
 
 ## Migrate data between clusters using geo-replication
 


### PR DESCRIPTION
There can be a corner case where 2 consumer subscribe with different type of subscription on each cluster.

The only thing replicated is information about the subscription. Not the type.

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
