### PR TITLE
[fix][doc] k8s function runtime uses deprecated config key

### DIFF
--- a/versioned_docs/version-3.0.x/functions-runtime-kubernetes.md
+++ b/versioned_docs/version-3.0.x/functions-runtime-kubernetes.md
@@ -79,7 +79,7 @@ Here is an example configuration for the function worker to utilize this feature
 
 ```yaml
 functionAuthProviderClassName: "org.apache.pulsar.functions.auth.KubernetesServiceAccountTokenAuthProvider"
-kubernetesContainerFactory:
+functionRuntimeFactoryConfigs:
   kubernetesFunctionAuthProviderConfig:
     # Required
     serviceAccountTokenExpirationSeconds: "600"


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

(detailed history: https://github.com/apache/pulsar/discussions/20708)

this PR address these two issues

1. according to the source code, the document uses a deprecated config key.
2. the key is not working on apache pulsar 3.0.0 (while the updated key works)

https://github.com/apache/pulsar/blob/17ea4b8f968d8862cb2c781eaeefc83ff4b25686/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java#L884-L887

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
