### PR TITLE
OIDC docs fixes

### DIFF
--- a/docs/security-openid-connect.md
+++ b/docs/security-openid-connect.md
@@ -91,8 +91,7 @@ authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.Authenti
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"
-  # Only include when using a custom trust store
-  openIDTokenIssuerTrustCertsFilePath: "/my/custom/trust/store"
+  openIDTokenIssuerTrustCertsFilePath: ""
   openIDRoleClaim: "sub"
   openIDAcceptedTimeLeewaySeconds: 0
   openIDCacheSize: 5

--- a/docs/security-openid-connect.md
+++ b/docs/security-openid-connect.md
@@ -91,7 +91,8 @@ authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.Authenti
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"
-  openIDTokenIssuerTrustCertsFilePath: ""
+  # Only include when using a custom trust store
+  openIDTokenIssuerTrustCertsFilePath: "/my/custom/trust/store"
   openIDRoleClaim: "sub"
   openIDAcceptedTimeLeewaySeconds: 0
   openIDCacheSize: 5

--- a/docs/security-openid-connect.md
+++ b/docs/security-openid-connect.md
@@ -87,7 +87,7 @@ To configure the Pulsar Function Worker to authenticate clients using OpenID Con
 ```yaml
 # Configuration to enable authentication
 authenticationEnabled: true
-authenticationProviders: "org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenID"
+authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenID"]
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"

--- a/versioned_docs/version-3.0.x/security-openid-connect.md
+++ b/versioned_docs/version-3.0.x/security-openid-connect.md
@@ -102,7 +102,7 @@ authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.Authenti
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"
-  # Only include when using a custom trust store
+  # Note: for 3.0.0, only include when using a custom trust store
   openIDTokenIssuerTrustCertsFilePath: "/my/custom/trust/store"
   openIDRoleClaim: "sub"
   openIDAcceptedTimeLeewaySeconds: 0

--- a/versioned_docs/version-3.0.x/security-openid-connect.md
+++ b/versioned_docs/version-3.0.x/security-openid-connect.md
@@ -43,7 +43,8 @@ PULSAR_PREFIX_openIDAllowedAudiences=audience-1,audience-2
 
 # Optional settings (values shown are the defaults)
 # The path to the file containing the trusted certificate(s) of the token issuer(s). If not set, uses the default
-# trust store of the JVM.
+# trust store of the JVM. Note: in version 3.0.0, the default only applies when this setting is not an environment
+# variable and is not in the configuration file.
 PULSAR_PREFIX_openIDTokenIssuerTrustCertsFilePath=
 # The JWT's claim to use for the role/principal during authorization.
 PULSAR_PREFIX_openIDRoleClaim=sub
@@ -97,7 +98,7 @@ To configure the Pulsar Function Worker to authenticate clients using OpenID Con
 ```yaml
 # Configuration to enable authentication
 authenticationEnabled: true
-authenticationProviders: "org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenID"
+authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenID"]
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"

--- a/versioned_docs/version-3.0.x/security-openid-connect.md
+++ b/versioned_docs/version-3.0.x/security-openid-connect.md
@@ -102,7 +102,8 @@ authenticationProviders: ["org.apache.pulsar.broker.authentication.oidc.Authenti
 properties:
   openIDAllowedTokenIssuers: "https://my-issuer-1.com,https://my-issuer-2.com"
   openIDAllowedAudiences: "audience-1,audience-2"
-  openIDTokenIssuerTrustCertsFilePath: ""
+  # Only include when using a custom trust store
+  openIDTokenIssuerTrustCertsFilePath: "/my/custom/trust/store"
   openIDRoleClaim: "sub"
   openIDAcceptedTimeLeewaySeconds: 0
   openIDCacheSize: 5


### PR DESCRIPTION
This PR fixes the issues raised in https://stackoverflow.com/questions/76633061/apache-pulsar-fails-to-enable-openid-authentication-in-function-worker-when-conf and https://stackoverflow.com/questions/76631732/apache-pulsar-unable-to-validate-issuer-certificate-when-attempting-to-load-open

- [x] `doc`

Fixes:
* The Function worker's `authenticationProviders` takes a list, not a string
* The `openIDTokenIssuerTrustCertsFilePath` config should not be the empty string. This is fixed by https://github.com/apache/pulsar/pull/20745.