### PR TITLE
[feat][doc] add metrics for extensible load balancer

### DIFF
--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -350,6 +350,12 @@ All the loadbalancing metrics are labeled with the following labels:
 - broker: broker=${broker}. ${broker} is the IP address of the broker
 - metric: metric="loadBalancing".
 
+:::note
+
+Metrics with an asterisk (*) are only available in the **extensible** load balancer.
+
+:::
+
 | Name | Type | Description |
 | --- | --- | --- |
 | pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwidth usage (in percent). |
@@ -357,25 +363,46 @@ All the loadbalancing metrics are labeled with the following labels:
 | pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
 | pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
 | pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
+| pulsar_lb_resource_usage {feature=max}* |Gauge|The max resource usage of the bandwidth, CPU, memory, and direct_memory.|
+| pulsar_lb_resource_usage {feature=max_ema}* | Gauge | The broker load score (WeightedMaxEMA).|
 
 ### BundleUnloading metrics
 All the bundleUnloading metrics are labeled with the following labels:
 - cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name that you have configured in the `broker.conf` file.
+- bundle: bundle=${bundle}. ${bundle} is the bundle range on this broker.
 - metric: metric="bundleUnloading".
+
+:::note
+
+Metrics with an asterisk (*) are only available in the **extensible** load balancer.
+
+:::
 
 | Name                          | Type    | Description                                  |
 |-------------------------------|---------|----------------------------------------------|
 | pulsar_lb_unload_broker_total | Counter | Unload broker count in this bundle unloading |
 | pulsar_lb_unload_bundle_total | Counter | Bundle unload count in this bundle unloading |
+| pulsar_lb_unload_broker_breakdown_total{result, reason}* | Counter | Unload broker breakdown count grouped by result and reason labels.|
+| pulsar_lb_resource_usage_stats{feature=max_ema, stat=avg}* | Gauge | The average of brokers’ load scores.|
+| pulsar_lb_resource_usage_stats{feature=max_ema, stat=std}*   | Gauge | The standard deviation of brokers’ load scores. |
 
 ### BundleSplit metrics
 All the bundleUnloading metrics are labeled with the following labels:
 - cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name that you have configured in the `broker.conf` file.
+- bundle: bundle=${bundle}. ${bundle} is the bundle range on this broker.
 - metric: metric="bundlesSplit".
+
+:::note
+
+Metrics with an asterisk (*) are only available in the **extensible** load balancer.
+
+:::
 
 | Name                          | Type    | Description                                                |
 |-------------------------------|---------|------------------------------------------------------------|
 | pulsar_lb_bundles_split_total | Counter | The total count of bundle split in this leader broker |
+| pulsar_lb_bundles_split_breakdown_total{result, reason}* | Counter | Bundle split breakdown count grouped by the result and reason labels.|
+
 
 ### Bundle metrics
 All the bundle metrics are labeled with the following labels:
@@ -393,6 +420,49 @@ All the bundle metrics are labeled with the following labels:
 | pulsar_bundle_producer_count | Gauge | The producer count of the topics in this bundle. |
 | pulsar_bundle_msg_throughput_in | Gauge | The total throughput coming into the topics in this bundle (byte per second). |
 | pulsar_bundle_msg_throughput_out | Gauge | The total throughput going out from the topics in this bundle (byte per second). |
+
+### Bundle assign metrics
+
+All the bundle assign metrics are labeled with the following labels:
+
+- cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name you have configured in the `broker.conf` file.
+- broker: broker=${broker}. ${broker} is the IP address of the broker.
+- bundle: bundle=${bundle}. ${bundle} is the bundle range on this broker.
+- metric: metric="assign".
+
+:::note
+
+Metrics with an asterisk (*) are only available in the **extensible** load balancer.
+
+:::
+
+Name | Type | Description
+|---|---|---
+pulsar_lb_assign_broker_breakdown_total{result, reason}*|Counter| Assign broker breakdown count grouped by result and reason labels.|
+
+### Service unit state channel metrics
+
+All the service unit state channel metrics are labeled with the following labels:
+
+- cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name you have configured in the `broker.conf` file.
+- metric: metric="sunitStateChn".
+
+:::note
+
+Metrics with an asterisk (*) are only available in the **extensible** load balancer.
+
+:::
+
+Name | Type | Description
+|---|---|---
+pulsar_sunit_state_chn_owner_lookup_total{result, state}*|Counter|The owner broker lookup counts grouped by the result and state labels.
+pulsar_sunit_state_chn_event_publish_ops_total{result, event}*|Counter|The published message count of service unit (e.g., bundle) state changes grouped by the result and event labels
+pulsar_sunit_state_chn_subscribe_ops_total{result, event}*|Counter|The subscribed message count of service unit (e.g., bundle) state changes grouped by the result and event labels.
+pulsar_sunit_state_chn_inactive_broker_cleanup_ops_total{result}*|Counter|The counts of inactive broker cleanup operations grouped by the result label.
+pulsar_sunit_state_chn_orphan_su_cleanup_ops_total*|Counter|The total count of orphan service unit (e.g., bundle) cleanup operations.
+pulsar_sunit_state_chn_owned_su_total*|Gauge|The number of owned bundles.
+pulsar_sunit_state_chn_su_tombstone_cleanup_ops_total*|Counter|The total count of deleted service units (e.g., bundles) tombstone operations.
+pulsar_sunit_state_chn_cleanup_ops_total{result=Failure}*|Counter|The total count of cleanup operation failures.
 
 ### Subscription metrics
 

--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -383,8 +383,8 @@ Metrics with an asterisk (*) are only available in the **extensible** load balan
 | pulsar_lb_unload_broker_total | Counter | Unload broker count in this bundle unloading |
 | pulsar_lb_unload_bundle_total | Counter | Bundle unload count in this bundle unloading |
 | pulsar_lb_unload_broker_breakdown_total{result, reason}* | Counter | Unload broker breakdown count grouped by result and reason labels.|
-| pulsar_lb_resource_usage_stats{feature=max_ema, stat=avg}* | Gauge | The average of brokers’ load scores.|
-| pulsar_lb_resource_usage_stats{feature=max_ema, stat=std}*   | Gauge | The standard deviation of brokers’ load scores. |
+| pulsar_lb_resource_usage_stats{feature=max_ema, stat=avg}* | Gauge | The average of brokers' load scores.|
+| pulsar_lb_resource_usage_stats{feature=max_ema, stat=std}*   | Gauge | The standard deviation of brokers' load scores. |
 
 ### BundleSplit metrics
 All the bundleUnloading metrics are labeled with the following labels:


### PR DESCRIPTION
## What change does this PR introduce?

This PR adds metrics for the extensible load balancer (topics in the red box below)

<img width="1360" alt="image" src="https://github.com/apache/pulsar-site/assets/50226895/2109a561-88cb-44b0-b6f5-feca12adbf02">

## Doc development plan - Read before review

For the current doc of Broker Load Balancer, we want to tackle the following challenges:
- Create new documentation to cover all aspects of the feature (especially for the new extensible load balancer).
- Fill in any content gaps that may exist.
- Consolidate existing documentation into the new IA, as it is currently scattered and disorganized.
- Organize the documentation in a cohesive manner, ensuring it flows logically.

Consequently, we’ve created the following content development plans:
- [Broker Load Balancing | Information Architecture](https://xmind.works/share/dzbyKsnS)  
  This document presents a high-level architecture overview, including how we address content gaps and reconcile existing documentation.

- [Broker Load Balancing | Doc Outline](https://docs.google.com/document/d/1zshyn93XJp8Y-uvYLTnFCrcUWaHxeiTjPqdaUrR6zf0/edit#heading=h.6iz0wf853c5u)
  This document delves into the specifics of the content development plan, providing purpose and context for each section.

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
