### PR TITLE
[fix] [doc] add plugin name into the demo of debezium-postgres-source

### DIFF
--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -264,7 +264,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --name debezium-postgres-source \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
    * Use the **YAML** configuration file as shown previously.

--- a/docs/io-debezium-source.md
+++ b/docs/io-debezium-source.md
@@ -320,7 +320,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
            --name debezium-postgres-source \
            --tenant public \
            --namespace default \
-           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
      :::note

--- a/versioned_docs/version-2.10.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.10.x/io-cdc-debezium.md
@@ -288,7 +288,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.10.x/io-debezium-source.md
+++ b/versioned_docs/version-2.10.x/io-debezium-source.md
@@ -354,7 +354,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.11.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.11.x/io-cdc-debezium.md
@@ -264,7 +264,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --name debezium-postgres-source \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
    * Use the **YAML** configuration file as shown previously.

--- a/versioned_docs/version-2.11.x/io-debezium-source.md
+++ b/versioned_docs/version-2.11.x/io-debezium-source.md
@@ -320,7 +320,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
            --name debezium-postgres-source \
            --tenant public \
            --namespace default \
-           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
      :::note

--- a/versioned_docs/version-2.5.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.0/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.5.0/io-debezium-source.md
+++ b/versioned_docs/version-2.5.0/io-debezium-source.md
@@ -276,7 +276,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.5.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.1/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.5.1/io-debezium-source.md
+++ b/versioned_docs/version-2.5.1/io-debezium-source.md
@@ -287,7 +287,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.5.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.2/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.5.2/io-debezium-source.md
+++ b/versioned_docs/version-2.5.2/io-debezium-source.md
@@ -287,7 +287,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.0/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.0/io-debezium-source.md
+++ b/versioned_docs/version-2.6.0/io-debezium-source.md
@@ -305,7 +305,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.1/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.1/io-debezium-source.md
+++ b/versioned_docs/version-2.6.1/io-debezium-source.md
@@ -305,7 +305,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.2/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.2/io-debezium-source.md
+++ b/versioned_docs/version-2.6.2/io-debezium-source.md
@@ -305,7 +305,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.3/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.3/io-debezium-source.md
+++ b/versioned_docs/version-2.6.3/io-debezium-source.md
@@ -305,7 +305,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.4/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.6.4/io-debezium-source.md
+++ b/versioned_docs/version-2.6.4/io-debezium-source.md
@@ -305,7 +305,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.0/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.0/io-debezium-source.md
+++ b/versioned_docs/version-2.7.0/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.1/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.1/io-debezium-source.md
+++ b/versioned_docs/version-2.7.1/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.2/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.2/io-debezium-source.md
+++ b/versioned_docs/version-2.7.2/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.3/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.3/io-debezium-source.md
+++ b/versioned_docs/version-2.7.3/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.4/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.4/io-debezium-source.md
+++ b/versioned_docs/version-2.7.4/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.5/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.5/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.7.5/io-debezium-source.md
+++ b/versioned_docs/version-2.7.5/io-debezium-source.md
@@ -314,7 +314,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.8.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.8.x/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.8.x/io-debezium-source.md
+++ b/versioned_docs/version-2.8.x/io-debezium-source.md
@@ -327,7 +327,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.9.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.9.x/io-cdc-debezium.md
@@ -284,7 +284,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-2.9.x/io-debezium-source.md
+++ b/versioned_docs/version-2.9.x/io-debezium-source.md
@@ -352,7 +352,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --destination-topic-name debezium-postgres-topic \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
 
        ```
 

--- a/versioned_docs/version-3.0.x/io-cdc-debezium.md
+++ b/versioned_docs/version-3.0.x/io-cdc-debezium.md
@@ -264,7 +264,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
        --name debezium-postgres-source \
        --tenant public \
        --namespace default \
-       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+       --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
    * Use the **YAML** configuration file as shown previously.

--- a/versioned_docs/version-3.0.x/io-debezium-source.md
+++ b/versioned_docs/version-3.0.x/io-debezium-source.md
@@ -320,7 +320,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
            --name debezium-postgres-source \
            --tenant public \
            --namespace default \
-           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
+           --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "changeme","database.dbname": "postgres","database.server.name": "dbserver1","plugin.name": "pgoutput","schema.whitelist": "public","table.whitelist": "public.users","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
        ```
 
      :::note


### PR DESCRIPTION
The config(`Example of PostgreSQL -> Configuration`) demo of [debezium-postgres-source](https://pulsar.apache.org/docs/3.0.x/io-debezium-source/#configuration-2) contains the prop `plugin.name`

<img width="944" alt="截屏2023-07-20 16 42 53" src="https://github.com/apache/pulsar-site/assets/25195800/d81acb08-c2ac-4c99-bc40-c50639ee4968">

But in the section `Example of PostgreSQL -> Usage -> Start the Pulsar Debezium connector in local run mode using one of the following methods`, the prop `plugin.name` is missing.

<img width="1011" alt="截屏2023-07-20 16 46 18" src="https://github.com/apache/pulsar-site/assets/25195800/5fc321e9-19ff-4f00-92a1-0bb2f8001887">

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
