### PR TITLE
[fix] [doc] Added solutions for debezium-source-mysql connection errors

### DIFF
--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -170,6 +170,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -170,7 +170,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+

--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -179,7 +179,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -187,7 +187,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
    # check the plugin of mysql.user.

--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -178,9 +178,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/docs/io-cdc-debezium.md
+++ b/docs/io-cdc-debezium.md
@@ -190,7 +190,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/docs/io-debezium-source.md
+++ b/docs/io-debezium-source.md
@@ -228,9 +228,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/docs/io-debezium-source.md
+++ b/docs/io-debezium-source.md
@@ -220,7 +220,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -229,7 +229,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -237,10 +237,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/docs/io-debezium-source.md
+++ b/docs/io-debezium-source.md
@@ -220,6 +220,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```bash

--- a/versioned_docs/version-2.10.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.10.x/io-cdc-debezium.md
@@ -182,6 +182,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.10.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.10.x/io-cdc-debezium.md
@@ -182,7 +182,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -191,7 +191,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -199,10 +199,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.10.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.10.x/io-cdc-debezium.md
@@ -190,9 +190,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.10.x/io-debezium-source.md
+++ b/versioned_docs/version-2.10.x/io-debezium-source.md
@@ -241,7 +241,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -250,7 +250,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -258,10 +258,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.10.x/io-debezium-source.md
+++ b/versioned_docs/version-2.10.x/io-debezium-source.md
@@ -241,6 +241,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.10.x/io-debezium-source.md
+++ b/versioned_docs/version-2.10.x/io-debezium-source.md
@@ -249,9 +249,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.11.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.11.x/io-cdc-debezium.md
@@ -170,6 +170,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.11.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.11.x/io-cdc-debezium.md
@@ -178,9 +178,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.11.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.11.x/io-cdc-debezium.md
@@ -170,7 +170,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -179,7 +179,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -187,10 +187,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.11.x/io-debezium-source.md
+++ b/versioned_docs/version-2.11.x/io-debezium-source.md
@@ -228,9 +228,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.11.x/io-debezium-source.md
+++ b/versioned_docs/version-2.11.x/io-debezium-source.md
@@ -220,7 +220,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -229,7 +229,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -237,10 +237,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.11.x/io-debezium-source.md
+++ b/versioned_docs/version-2.11.x/io-debezium-source.md
@@ -220,6 +220,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```bash

--- a/versioned_docs/version-2.5.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.0/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.0/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.0/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.5.0/io-debezium-source.md
+++ b/versioned_docs/version-2.5.0/io-debezium-source.md
@@ -180,9 +180,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.0/io-debezium-source.md
+++ b/versioned_docs/version-2.5.0/io-debezium-source.md
@@ -172,6 +172,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```
@@ -305,7 +324,7 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
 
    ```
 
-6. A MySQL client pops out.
+6. A PostgreSQL client pops out.
 
    Use the following commands to change the data of the table _products_.
 

--- a/versioned_docs/version-2.5.0/io-debezium-source.md
+++ b/versioned_docs/version-2.5.0/io-debezium-source.md
@@ -172,7 +172,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -181,7 +181,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -189,10 +189,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.1/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.1/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.1/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.5.1/io-debezium-source.md
+++ b/versioned_docs/version-2.5.1/io-debezium-source.md
@@ -191,9 +191,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.1/io-debezium-source.md
+++ b/versioned_docs/version-2.5.1/io-debezium-source.md
@@ -183,7 +183,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -192,7 +192,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -200,10 +200,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.1/io-debezium-source.md
+++ b/versioned_docs/version-2.5.1/io-debezium-source.md
@@ -183,6 +183,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.5.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.2/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.2/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.5.2/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.5.2/io-debezium-source.md
+++ b/versioned_docs/version-2.5.2/io-debezium-source.md
@@ -191,9 +191,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.2/io-debezium-source.md
+++ b/versioned_docs/version-2.5.2/io-debezium-source.md
@@ -183,7 +183,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -192,7 +192,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -200,10 +200,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.5.2/io-debezium-source.md
+++ b/versioned_docs/version-2.5.2/io-debezium-source.md
@@ -183,6 +183,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.0/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.0/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.0/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.0/io-debezium-source.md
+++ b/versioned_docs/version-2.6.0/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.0/io-debezium-source.md
+++ b/versioned_docs/version-2.6.0/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.0/io-debezium-source.md
+++ b/versioned_docs/version-2.6.0/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.1/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.1/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.1/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.1/io-debezium-source.md
+++ b/versioned_docs/version-2.6.1/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.1/io-debezium-source.md
+++ b/versioned_docs/version-2.6.1/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.1/io-debezium-source.md
+++ b/versioned_docs/version-2.6.1/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.2/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.2/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.2/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.2/io-debezium-source.md
+++ b/versioned_docs/version-2.6.2/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.2/io-debezium-source.md
+++ b/versioned_docs/version-2.6.2/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.2/io-debezium-source.md
+++ b/versioned_docs/version-2.6.2/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.3/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.3/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.3/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.3/io-debezium-source.md
+++ b/versioned_docs/version-2.6.3/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.3/io-debezium-source.md
+++ b/versioned_docs/version-2.6.3/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.3/io-debezium-source.md
+++ b/versioned_docs/version-2.6.3/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.4/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.4/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.6.4/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.4/io-debezium-source.md
+++ b/versioned_docs/version-2.6.4/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.6.4/io-debezium-source.md
+++ b/versioned_docs/version-2.6.4/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.6.4/io-debezium-source.md
+++ b/versioned_docs/version-2.6.4/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.0/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.0/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.0/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.0/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.0/io-debezium-source.md
+++ b/versioned_docs/version-2.7.0/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.0/io-debezium-source.md
+++ b/versioned_docs/version-2.7.0/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.0/io-debezium-source.md
+++ b/versioned_docs/version-2.7.0/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.1/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.1/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.1/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.1/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.1/io-debezium-source.md
+++ b/versioned_docs/version-2.7.1/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.1/io-debezium-source.md
+++ b/versioned_docs/version-2.7.1/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.1/io-debezium-source.md
+++ b/versioned_docs/version-2.7.1/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.2/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.2/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.2/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.2/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.2/io-debezium-source.md
+++ b/versioned_docs/version-2.7.2/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.2/io-debezium-source.md
+++ b/versioned_docs/version-2.7.2/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.2/io-debezium-source.md
+++ b/versioned_docs/version-2.7.2/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.3/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.3/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.3/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.3/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.3/io-debezium-source.md
+++ b/versioned_docs/version-2.7.3/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.3/io-debezium-source.md
+++ b/versioned_docs/version-2.7.3/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.3/io-debezium-source.md
+++ b/versioned_docs/version-2.7.3/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.4/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.4/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.4/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.4/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.4/io-debezium-source.md
+++ b/versioned_docs/version-2.7.4/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.4/io-debezium-source.md
+++ b/versioned_docs/version-2.7.4/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.4/io-debezium-source.md
+++ b/versioned_docs/version-2.7.4/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.5/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.5/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.5/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.5/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.5/io-cdc-debezium.md
+++ b/versioned_docs/version-2.7.5/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.5/io-debezium-source.md
+++ b/versioned_docs/version-2.7.5/io-debezium-source.md
@@ -201,7 +201,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -210,7 +210,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -218,10 +218,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.7.5/io-debezium-source.md
+++ b/versioned_docs/version-2.7.5/io-debezium-source.md
@@ -201,6 +201,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.7.5/io-debezium-source.md
+++ b/versioned_docs/version-2.7.5/io-debezium-source.md
@@ -209,9 +209,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.8.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.8.x/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.8.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.8.x/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.8.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.8.x/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.8.x/io-debezium-source.md
+++ b/versioned_docs/version-2.8.x/io-debezium-source.md
@@ -214,6 +214,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.8.x/io-debezium-source.md
+++ b/versioned_docs/version-2.8.x/io-debezium-source.md
@@ -214,7 +214,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -223,7 +223,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -231,10 +231,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.8.x/io-debezium-source.md
+++ b/versioned_docs/version-2.8.x/io-debezium-source.md
@@ -222,9 +222,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.9.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.9.x/io-cdc-debezium.md
@@ -188,9 +188,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.9.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.9.x/io-cdc-debezium.md
@@ -180,7 +180,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -189,7 +189,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -197,10 +197,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.9.x/io-cdc-debezium.md
+++ b/versioned_docs/version-2.9.x/io-cdc-debezium.md
@@ -180,6 +180,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-2.9.x/io-debezium-source.md
+++ b/versioned_docs/version-2.9.x/io-debezium-source.md
@@ -247,9 +247,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.9.x/io-debezium-source.md
+++ b/versioned_docs/version-2.9.x/io-debezium-source.md
@@ -239,7 +239,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -248,7 +248,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -256,10 +256,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-2.9.x/io-debezium-source.md
+++ b/versioned_docs/version-2.9.x/io-debezium-source.md
@@ -239,6 +239,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-3.0.x/io-cdc-debezium.md
+++ b/versioned_docs/version-3.0.x/io-cdc-debezium.md
@@ -170,6 +170,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```

--- a/versioned_docs/version-3.0.x/io-cdc-debezium.md
+++ b/versioned_docs/version-3.0.x/io-cdc-debezium.md
@@ -178,9 +178,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-3.0.x/io-cdc-debezium.md
+++ b/versioned_docs/version-3.0.x/io-cdc-debezium.md
@@ -170,7 +170,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -179,7 +179,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -187,10 +187,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-3.0.x/io-debezium-source.md
+++ b/versioned_docs/version-3.0.x/io-debezium-source.md
@@ -228,9 +228,19 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    +----------------------------------------------+-------+
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | caching_sha2_password |
+   +-----------+------+-----------------------+
+
+   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
-   # check the modified result
+
+   # check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-3.0.x/io-debezium-source.md
+++ b/versioned_docs/version-3.0.x/io-debezium-source.md
@@ -220,7 +220,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
-   Change the connection mode to `mysql_native_password`
+   Change the connection mode to `mysql_native_password`.
    ```
    mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
    +----------------------------------------------+-------+
@@ -229,7 +229,7 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | caching_sha2_password_auto_generate_rsa_keys | ON    |
    +----------------------------------------------+-------+
 
-   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
+   # If the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, ensure the plugin of mysql.user is "mysql_native_password".
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |
@@ -237,10 +237,10 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
    | localhost | root | caching_sha2_password |
    +-----------+------+-----------------------+
 
-   # if the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
+   # If the plugin of mysql.user is is "caching_sha2_password", set it to "mysql_native_password".
    alter user '{user}'@'{host}' identified with mysql_native_password by {password};
 
-   # check the plugin of mysql.user.
+   # Check the plugin of mysql.user.
    mysql> SELECT Host, User, plugin from mysql.user where user={user};
    +-----------+------+-----------------------+
    | Host      | User | plugin                |

--- a/versioned_docs/version-3.0.x/io-debezium-source.md
+++ b/versioned_docs/version-3.0.x/io-debezium-source.md
@@ -220,6 +220,25 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
 
 6. A MySQL client pops out.
 
+   Change the connection mode to `mysql_native_password`
+   ```
+   mysql> show variables like "caching_sha2_password_auto_generate_rsa_keys";
+   +----------------------------------------------+-------+
+   | Variable_name                                | Value |
+   +----------------------------------------------+-------+
+   | caching_sha2_password_auto_generate_rsa_keys | ON    |
+   +----------------------------------------------+-------+
+   # if the value of "caching_sha2_password_auto_generate_rsa_keys" is ON, set connection mode to "mysql_native_password".
+   alter user '{user}'@'{host}' identified with mysql_native_password by {password};
+   # check the modified result
+   mysql> SELECT Host, User, plugin from mysql.user where user={user};
+   +-----------+------+-----------------------+
+   | Host      | User | plugin                |
+   +-----------+------+-----------------------+
+   | localhost | root | mysql_native_password |
+   +-----------+------+-----------------------+
+   ```
+
    Use the following commands to change the data of the table _products_.
 
    ```bash


### PR DESCRIPTION
When MySQL enabled `caching_sha2_password_auto_generate_rsa_keys `, the debezium will get an error: `Public Key Retrieval is not allowed`

```
2023-07-20T18:28:41,740+0800 [function-timer-thread-34-1] ERROR org.apache.pulsar.functions.runtime.RuntimeSpawner - public/default/debezium-mysql-source Function Container is dead with following exception. Restarting.
io.debezium.DebeziumException: Unexpected error while connecting to MySQL and looking at BINLOG_FORMAT mode: 
	at io.debezium.connector.mysql.MySqlConnection.isBinlogFormatRow(MySqlConnection.java:385) ~[?:?]
	at io.debezium.connector.mysql.MySqlConnectorTask.validateBinlogConfiguration(MySqlConnectorTask.java:240) ~[?:?]
	at io.debezium.connector.mysql.MySqlConnectorTask.start(MySqlConnectorTask.java:85) ~[?:?]
	at io.debezium.connector.common.BaseSourceTask.start(BaseSourceTask.java:133) ~[?:?]
	at org.apache.pulsar.io.kafka.connect.AbstractKafkaConnectSource.open(AbstractKafkaConnectSource.java:162) ~[?:?]
	at org.apache.pulsar.io.kafka.connect.KafkaConnectSource.open(KafkaConnectSource.java:63) ~[?:?]
	at org.apache.pulsar.io.debezium.DebeziumSource.open(DebeziumSource.java:114) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupInput(JavaInstanceRunnable.java:858) ~[org.apache.pulsar-pulsar-functions-instance-3.0.0.jar:3.0.0]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:253) ~[org.apache.pulsar-pulsar-functions-instance-3.0.0.jar:3.0.0]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:290) ~[org.apache.pulsar-pulsar-functions-instance-3.0.0.jar:3.0.0]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.sql.SQLNonTransientConnectionException: Public Key Retrieval is not allowed
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:110) ~[?:?]
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:828) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:448) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:241) ~[?:?]
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:198) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.lambda$patternBasedFactory$1(JdbcConnection.java:244) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.connection(JdbcConnection.java:888) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.connection(JdbcConnection.java:883) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.queryAndMap(JdbcConnection.java:636) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.queryAndMap(JdbcConnection.java:510) ~[?:?]
	at io.debezium.connector.mysql.MySqlConnection.isBinlogFormatRow(MySqlConnection.java:380) ~[?:?]
	... 10 more
Caused by: com.mysql.cj.exceptions.UnableToConnectException: Public Key Retrieval is not allowed
	at jdk.internal.reflect.GeneratedConstructorAccessor33.newInstance(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61) ~[?:?]
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:85) ~[?:?]
	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:130) ~[?:?]
	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:49) ~[?:?]
	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.proceedHandshakeWithPluggableAuthentication(NativeAuthenticationProvider.java:447) ~[?:?]
	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.connect(NativeAuthenticationProvider.java:212) ~[?:?]
	at com.mysql.cj.protocol.a.NativeProtocol.connect(NativeProtocol.java:1433) ~[?:?]
	at com.mysql.cj.NativeSession.connect(NativeSession.java:133) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:948) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:818) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:448) ~[?:?]
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:241) ~[?:?]
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:198) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.lambda$patternBasedFactory$1(JdbcConnection.java:244) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.connection(JdbcConnection.java:888) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.connection(JdbcConnection.java:883) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.queryAndMap(JdbcConnection.java:636) ~[?:?]
	at io.debezium.jdbc.JdbcConnection.queryAndMap(JdbcConnection.java:510) ~[?:?]
	at io.debezium.connector.mysql.MySqlConnection.isBinlogFormatRow(MySqlConnection.java:380) ~[?:?]
	... 10 more
```

Add a solution to solve the issue

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
