### PR TITLE
[improve] [doc] Add compatibility reminders for retry queues

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -244,12 +244,9 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
+- It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -328,13 +325,9 @@ The default dead letter topic uses this format:
 ```
 <topicname>-<subscriptionname>-DLQ
 ```
-
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -247,7 +247,9 @@ The default retry letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`.
+original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -330,7 +332,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -247,6 +247,7 @@ The default retry letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
 - It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -328,6 +329,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -244,6 +244,11 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-RETRY`.
+
 Use the Java client to specify the name of the retry letter topic.
 
 ```java
@@ -321,6 +326,11 @@ The default dead letter topic uses this format:
 ```
 <topicname>-<subscriptionname>-DLQ
 ```
+
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -380,6 +380,7 @@ The default retry letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
 - It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -473,6 +474,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -380,7 +380,9 @@ The default retry letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`.
+original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -474,7 +476,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -377,6 +377,11 @@ The default retry letter topic uses this format:
 
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-RETRY`.
+
 Use the Java client to specify the name of the retry letter topic.
 
 ```java
@@ -465,6 +470,11 @@ The default dead letter topic uses this format:
 <topicname>-<subscriptionname>-DLQ
 
 ```
+
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -377,12 +377,9 @@ The default retry letter topic uses this format:
 
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
+- It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -473,12 +470,9 @@ The default dead letter topic uses this format:
 
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -396,7 +396,9 @@ The default retry letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`.
+original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -479,7 +481,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -393,6 +393,11 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-RETRY`.
+
 Use the Java client to specify the name of the retry letter topic.
 
 ```java
@@ -470,6 +475,11 @@ The default dead letter topic uses this format:
 ```
 <topicname>-<subscriptionname>-DLQ
 ```
+
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -396,6 +396,7 @@ The default retry letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
 - It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -478,6 +479,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -393,12 +393,9 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
+- It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -478,12 +475,9 @@ The default dead letter topic uses this format:
 <topicname>-<subscriptionname>-DLQ
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -231,6 +231,10 @@ The default dead letter topic uses this format:
 
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -234,6 +234,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -231,12 +231,9 @@ The default dead letter topic uses this format:
 
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.8.x/concepts-messaging.md
+++ b/versioned_docs/version-2.8.x/concepts-messaging.md
@@ -234,7 +234,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -256,6 +256,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -253,12 +253,9 @@ The default dead letter topic uses this format:
 
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -256,7 +256,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 If you want to specify the name of the dead letter topic, use this Java client example:
 

--- a/versioned_docs/version-2.9.x/concepts-messaging.md
+++ b/versioned_docs/version-2.9.x/concepts-messaging.md
@@ -253,6 +253,11 @@ The default dead letter topic uses this format:
 
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
+
 If you want to specify the name of the dead letter topic, use this Java client example:
 
 ```java

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -247,6 +247,7 @@ The default retry letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
 - It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -329,6 +330,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+:::
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -244,12 +244,9 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default retry letter topic uses the format of `<subscriptionname>-RETRY`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-RETRY`.
+- It is not recommended to use `<subscriptionname>-RETRY` because if multiple topics under the same namespace have the same subscription, then retry message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -329,12 +326,9 @@ The default dead letter topic uses this format:
 <topicname>-<subscriptionname>-DLQ
 ```
 
-Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
-If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
-the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
-to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
-for multiple topics will be the same, resulting in mutual consumption.
+:::note
+- For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
+- It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -247,7 +247,9 @@ The default retry letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-RETRY`.
+original topics, which were formatted with `<subscriptionname>-RETRY`. Rule `<subscriptionname>-RETRY` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the retry message topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the retry letter topic.
 
@@ -330,7 +332,9 @@ The default dead letter topic uses this format:
 Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
 If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
 the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
-original topics, which were formatted with `<subscriptionname>-DLQ`.
+original topics, which were formatted with `<subscriptionname>-DLQ`. Rule `<subscriptionname>-DLQ` should be avoided
+to use, because if multiple topics under the same namespace have the same subscription, the dead letter topic names
+for multiple topics will be the same, resulting in mutual consumption.
 
 Use the Java client to specify the name of the dead letter topic.
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -244,6 +244,11 @@ The default retry letter topic uses this format:
 <topicname>-<subscriptionname>-RETRY
 ```
 
+Note: In versions `2.6.x` and `2.7.x`, the default retry letter topic uses this format is `<subscriptionname>-RETRY`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical retry letter topics and retry letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-RETRY`.
+
 Use the Java client to specify the name of the retry letter topic.
 
 ```java
@@ -321,6 +326,11 @@ The default dead letter topic uses this format:
 ```
 <topicname>-<subscriptionname>-DLQ
 ```
+
+Note: In versions `2.6.x` and `2.7.x`, the default dead letter topic uses this format is `<subscriptionname>-DLQ`.
+If you are upgrading from version `2.6.x~2.7.x` to version `2.8.x` or greater, then you need to manually delete
+the historical dead letter topics and dead letter partitioned topics. Otherwise, Pulsar will continue to use the
+original topics, which were formatted with `<subscriptionname>-DLQ`.
 
 Use the Java client to specify the name of the dead letter topic.
 


### PR DESCRIPTION
This PR fixes https://github.com/apache/pulsar/issues/20612

The default naming rule of Retry topic is `{tenant}/{namespaces}/{topic}-{sub}-RETRY`, see: https://pulsar.apache.org/docs/3.0.x/concepts-messaging/#retry-letter-topic

The rule before version `2.8` was `{tenant}/{namespaces}/{sub}-RETRY`, and if there is a ZK node `/admin/partitioned-topics/{namespace}-RETRY`, Pulsar will still use the rule `{tenant}/{namespaces}/{sub}-RETRY` even if the version of Pulsar is larger than `2.8`.  This part of the explanation is not reflected in the documentation.


**Related PR**
- [#6449 Support Consumers Set Custom Retry Delay](https://github.com/apache/pulsar/pull/6449)
- [#10129 fix the default retry letter and dead letter topic name](https://github.com/apache/pulsar/pull/10129)

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
