### PR TITLE
[feat][doc] add migration tutorials for broker load balancing

### DIFF
--- a/docs/concepts-broker-load-balancing-benefits.md
+++ b/docs/concepts-broker-load-balancing-benefits.md
@@ -49,3 +49,5 @@ It helps seamlessly scale up or down broker clusters since it allows you to:
 - To learn essential fundamentals, see [Broker load balancing | Concepts](./concepts-broker-load-balancing-concepts.md).
 
 - To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).
+
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).

--- a/docs/concepts-broker-load-balancing-concepts.md
+++ b/docs/concepts-broker-load-balancing-concepts.md
@@ -563,3 +563,5 @@ For implementation details, see [PIP-220: TransferShedder](https://github.com/ap
 - To understand advantages, see [Broker load balancing | Benefits](./concepts-broker-load-balancing-benefits.md).
 
 - To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).
+
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).

--- a/docs/concepts-broker-load-balancing-features.md
+++ b/docs/concepts-broker-load-balancing-features.md
@@ -23,3 +23,5 @@ In general, the main features of the broker load balancer are:
 - To learn essential fundamentals, see [Broker load balancing | Concepts](./concepts-broker-load-balancing-concepts.md).
 
 - To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).
+
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).

--- a/docs/concepts-broker-load-balancing-migration.md
+++ b/docs/concepts-broker-load-balancing-migration.md
@@ -31,7 +31,7 @@ TransferShedder|Extensible|3.0 and later
 
 You can migrate from the simple to the modular broker load balancer, by manually changing the configuration settings in the broker.conf file or by using the pulsar-admin tool. 
 
-### Manually change broker.conf file 
+### Change broker.conf file 
 
 1. Access to the broker.conf file.
 

--- a/docs/concepts-broker-load-balancing-migration.md
+++ b/docs/concepts-broker-load-balancing-migration.md
@@ -69,7 +69,7 @@ You can migrate from the simple to the modular broker load balancer, by manually
 2. Set `--config` to `loadManagerClassName` and `--value` to `org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl`.
 
     ```bash
-    pulsar-admin update-dynamic-config \
+    pulsar-admin brokers update-dynamic-config \
     --config loadManagerClassName \
     --value org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
     ```
@@ -78,7 +78,7 @@ You can migrate from the simple to the modular broker load balancer, by manually
 
 ## Migrate from modular to extensible broker load balancer
 
-You can migrate from the modular to the extensible broker load balancer, by manually changing settings in the broker.conf file.
+You can migrate from the modular to the extensible broker load balancer, by manually changing settings in the broker.conf file. During the migration, the lookup and assignment will be redirected to the brokers with the extensible load balancer.
 
 :::note
 
@@ -88,7 +88,7 @@ The pulsar-admin tool is not supported for this migration.
 
 ### Change broker.conf file 
 
-1. [Upgrade the Pulsar cluster](./helm-upgrade.md) to 3.0.x.
+1. [Upgrade the Pulsar cluster](./helm-upgrade.md) to 3.0.0 or later versions.
 
 2. Access to the broker.conf file.
 
@@ -119,7 +119,7 @@ The pulsar-admin tool is not supported for this migration.
 
 ## Migrate from extensible to modular broker load balancer
 
-You can migrate from the extensible to the modular broker load balancer, by manually changing the setting in the broker.conf file.
+You can migrate from the extensible to the modular broker load balancer, by manually changing the setting in the broker.conf file. During the migration, the lookup and assignment will be redirected to the brokers with the modular load balancer.
 
 :::note
 

--- a/docs/concepts-broker-load-balancing-migration.md
+++ b/docs/concepts-broker-load-balancing-migration.md
@@ -1,0 +1,130 @@
+---
+id: concepts-broker-load-balancing-migration
+title: Migration
+sidebar_label: "Migration"
+---
+
+Pulsar has 3 types of broker load balancers, that is, simple, modular, and extensible. You can perform the following migrations:
+
+Migrate from simple to modular: ??
+Migrate from modular to extensible: if you want to use the bundle unloading strategy of TransferShedder.
+Migrate from extensible to modular: if you want to use the unloading strategy of OverloadShedder, ThresholdShedder, or UniformLoadShedder
+
+## Considerations
+
+Before migrating from one broker load balancer type to another, review the relationship between [broker load balancer type](./concepts-broker-load-balancing-types.md), Pulsar version, and [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies). You may need to upgrade Pulsar versions or update the [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies). Below are brief summaries.
+
+This broker load balancer type | is available in this Pulsar version
+|---|---
+Simple|All versions
+Modular|1.7 and later
+Extensible|3.0 and later
+
+This bundle unloading strategy|is available for this broker load balancer type|in available this Pulsar version
+|---|---|---
+OverloadShedder|Modular|1.18 and later
+ThresholdShedder|Modular|2.6 and later
+UniformLoadShedder|Modular|2.10 and later
+TransferShedder|Extensible|3.0 and later
+
+## Migrate from simple to modular broker load balancer
+
+You can migrate from the simple to the modular broker load balancer, by manually changing the configuration settings in the broker.conf file or by using the pulsar-admin tool. 
+
+### Manually change broker.conf file 
+
+1. Access to the broker.conf file.
+
+    ```bash
+    vim apache-pulsar-@pulsar:version@/conf/broker.conf
+    ``````
+
+2. Change the broker load balancer by setting [loadManagerClassName](https://github.com/apache/pulsar/blob/69d7a2bf14555f11a716a9545c5cf391d8179a27/conf/broker.conf#L1309C20-L1309C20) to ModularLoadManagerImpl in the broker.conf file.
+
+    ```conf
+    loadManagerClassName=org.apache.pulsar.broker.loadbalance.extensions.ModularLoadManagerImpl
+    ```
+
+3. Restart the Pulsar cluster. The new setting will take effect after the restart.  
+
+### Use pulsar-admin tool
+
+1. Access the [pulsar-admin tool](https://pulsar.apache.org/docs/next/reference-cli-tools/).
+
+    ```bash
+    cd apache-pulsar-@pulsar:version@/bin
+    ```
+
+2. Set `--config` to `loadManagerClassName` and `--value` to `org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl`.
+
+    ```bash
+    pulsar-admin update-dynamic-config \
+    --config loadManagerClassName \
+    --value org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
+    ```
+
+    You do not need to restart the Pulsar cluster. The new settings will take effect after 1 to 2 minutes.
+
+## Migrate from modular to extensible broker load balancer
+
+You can migrate from the modular to the extensible broker load balancer, by manually changing settings in the broker.conf file.
+
+1. [Upgrade the Pulsar cluster](./helm-upgrade.md) to 3.0.x.
+
+2. Access to the broker.conf file.
+
+    ```bash
+    vim apache-pulsar-@pulsar:version@/conf/broker.conf
+    ```
+
+3. Change the following settings in the broker.conf file:
+
+   - Update [broker load balancer](./concepts-broker-load-balancing-overview.md) by setting [loadManagerClassName](https://github.com/apache/pulsar/blob/69d7a2bf14555f11a716a9545c5cf391d8179a27/conf/broker.conf#L1309C20-L1309C20) to `ExtensibleLoadManagerImpl`. 
+
+   - Update [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) by setting `loadBalancerLoadSheddingStrategy` to `TransferShedder`. 
+
+    ```conf
+    loadManagerClassName=org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl 
+
+    loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder
+    ```
+
+4. Restart the Pulsar cluster. The new settings will take effect after the restart.  
+
+## Migrate from extensible to modular broker load balancer
+
+You can migrate from the extensible to the modular broker load balancer, by manually changing the setting in the broker.conf file.
+
+1. Access to the broker.conf file.
+
+    ```bash
+    vim apache-pulsar-@pulsar:version@/conf/broker.conf
+    ```
+
+2. Change the following settings in the broker.conf file:
+   
+   - Update broker load balancer by setting [loadManagerClassName](https://github.com/apache/pulsar/blob/69d7a2bf14555f11a716a9545c5cf391d8179a27/conf/broker.conf#L1309C20-L1309C20) to ModularLoadManagerImpl
+    
+   - Update [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) to OverloadShedder, ThresholdShedder, or UniformLoadShedder based on your needs.
+
+    ```
+    loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
+
+    loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
+    ```
+
+3. Restart the Pulsar cluster. The new settings will take effect after the restart.  
+
+## Related topics
+
+- To get a comprehensive understanding and discover the key insights, see [Broker load balancing | Overview](./concepts-broker-load-balancing-overview.md). 
+
+- To discover different usage scenarios, see [Broker load balancing | Use cases](./concepts-broker-load-balancing-use-cases.md).
+  
+- To explore functionalities, see [Broker load balancing | Features](./concepts-broker-load-balancing-features.md).
+
+- To understand advantages, see [Broker load balancing | Benefits](./concepts-broker-load-balancing-benefits.md).
+
+- To learn essential fundamentals, see [Broker load balancing | Concepts](./concepts-broker-load-balancing-concepts.md).
+
+- To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).

--- a/docs/concepts-broker-load-balancing-migration.md
+++ b/docs/concepts-broker-load-balancing-migration.md
@@ -4,11 +4,22 @@ title: Migration
 sidebar_label: "Migration"
 ---
 
-Pulsar has 3 types of broker load balancers, that is, simple, modular, and extensible. You can perform the following migrations:
+Pulsar has 3 types of broker load balancers, that is, simple, modular, and extensible. 
 
-Migrate from simple to modular: ??
-Migrate from modular to extensible: if you want to use the bundle unloading strategy of TransferShedder.
-Migrate from extensible to modular: if you want to use the unloading strategy of OverloadShedder, ThresholdShedder, or UniformLoadShedder
+You can perform the following migrations.
+
+Migration|When to use
+|---|---
+[Migrate from simple to modular](#migrate-from-simple-to-modular-broker-load-balancer)| If you want to use the [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) of OverloadShedder, ThresholdShedder, or UniformLoadShedder.
+[Migrate from modular to extensible](#migrate-from-modular-to-extensible-broker-load-balancer)| If you want to use the [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) of TransferShedder.
+[Migrate from extensible to modular](#migrate-from-modular-to-extensible-broker-load-balancer)| If you want to use the [bundle unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) of OverloadShedder, ThresholdShedder, or UniformLoadShedder.
+
+:::note
+
+It is not recommended to migrate from the modular or extensible to the simple broker load balancer since the simple broker load balancer is deprecated and no longer in use.
+
+:::
+
 
 ## Considerations
 
@@ -39,7 +50,7 @@ You can migrate from the simple to the modular broker load balancer, by manually
     vim apache-pulsar-@pulsar:version@/conf/broker.conf
     ``````
 
-2. Change the broker load balancer by setting [loadManagerClassName](https://github.com/apache/pulsar/blob/69d7a2bf14555f11a716a9545c5cf391d8179a27/conf/broker.conf#L1309C20-L1309C20) to ModularLoadManagerImpl in the broker.conf file.
+2. Change the broker load balancer by setting [loadManagerClassName](https://github.com/apache/pulsar/blob/69d7a2bf14555f11a716a9545c5cf391d8179a27/conf/broker.conf#L1309C20-L1309C20) to `ModularLoadManagerImpl` in the broker.conf file.
 
     ```conf
     loadManagerClassName=org.apache.pulsar.broker.loadbalance.extensions.ModularLoadManagerImpl
@@ -69,6 +80,14 @@ You can migrate from the simple to the modular broker load balancer, by manually
 
 You can migrate from the modular to the extensible broker load balancer, by manually changing settings in the broker.conf file.
 
+:::note
+
+The pulsar-admin tool is not supported for this migration.
+
+:::
+
+### Change broker.conf file 
+
 1. [Upgrade the Pulsar cluster](./helm-upgrade.md) to 3.0.x.
 
 2. Access to the broker.conf file.
@@ -89,11 +108,26 @@ You can migrate from the modular to the extensible broker load balancer, by manu
     loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder
     ```
 
+    :::note
+
+      - The [extensible broker load balancer](./concepts-broker-load-balancing-types.md) is **available in Pulsar 3.0.0** or later.
+      - The [TransferShedder unloading strategy](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) is **only available** in the [extensible load balancer](./concepts-broker-load-balancing-types.md).
+  
+    :::
+
 4. Restart the Pulsar cluster. The new settings will take effect after the restart.  
 
 ## Migrate from extensible to modular broker load balancer
 
 You can migrate from the extensible to the modular broker load balancer, by manually changing the setting in the broker.conf file.
+
+:::note
+
+The pulsar-admin tool is not supported for this migration.
+
+:::
+
+### Change broker.conf file 
 
 1. Access to the broker.conf file.
 
@@ -112,6 +146,12 @@ You can migrate from the extensible to the modular broker load balancer, by manu
 
     loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
     ```
+
+    :::note
+
+    [TransferShedder](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies) is **only supported** in the extensible broker load balancer, so you need to change TransferShedder to other [bundle unloading strategies](./concepts-broker-load-balancing-concepts.md#bundle-unloading-strategies).
+
+    :::
 
 3. Restart the Pulsar cluster. The new settings will take effect after the restart.  
 

--- a/docs/concepts-broker-load-balancing-overview.md
+++ b/docs/concepts-broker-load-balancing-overview.md
@@ -39,3 +39,5 @@ Pulsar uses automatic broker load balancing to monitor the brokers' load interna
 
 - To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).
 
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).
+

--- a/docs/concepts-broker-load-balancing-types.md
+++ b/docs/concepts-broker-load-balancing-types.md
@@ -44,3 +44,4 @@ However, for bundle ownership and load data stores, the modular load balancer us
 
 - To learn essential fundamentals, see [Broker load balancing | Concepts](./concepts-broker-load-balancing-concepts.md).
 
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).

--- a/docs/concepts-broker-load-balancing-use-case.md
+++ b/docs/concepts-broker-load-balancing-use-case.md
@@ -27,3 +27,5 @@ The broker load balancer can increase cluster availability by re-routing data lo
 - To learn essential fundamentals, see [Broker load balancing | Concepts](./concepts-broker-load-balancing-concepts.md).
 
 - To review various versions of broker load balancers, see [Broker load balancing | Types](./concepts-broker-load-balancing-types.md).
+
+- To migrate one broker load balancer type to another, see [Broker load balancing | Migration](./concepts-broker-load-balancing-migration.md).

--- a/sidebars.json
+++ b/sidebars.json
@@ -35,7 +35,8 @@
             "concepts-broker-load-balancing-features",
             "concepts-broker-load-balancing-benefits",
             "concepts-broker-load-balancing-concepts",
-            "concepts-broker-load-balancing-types"
+            "concepts-broker-load-balancing-types",
+            "concepts-broker-load-balancing-migration"
           ]
         },
         "concepts-replication",


### PR DESCRIPTION
## What change does this PR introduce?

This PR adds migration tutorials for broker load balancing (topics in the red box below)

<img width="1571" alt="image" src="https://github.com/apache/pulsar-site/assets/50226895/f2505100-183e-4b8c-b863-3ba7cc50e733">

## Doc development plan - Read before review

For the current doc of Broker Load Balancer, we want to tackle the following challenges:
- Create new documentation to cover all aspects of the feature (especially for the new extensible load balancer).
- Fill in any content gaps that may exist.
- Consolidate existing documentation into the new IA, as it is currently scattered and disorganized.
- Organize the documentation in a cohesive manner, ensuring it flows logically.

Consequently, we’ve created the following content development plans:
- [Broker Load Balancing | Information Architecture](https://xmind.works/share/dzbyKsnS)  
  This document presents a high-level architecture overview, including how we address content gaps and reconcile existing documentation.

- [Broker Load Balancing | Doc Outline](https://docs.google.com/document/d/1zshyn93XJp8Y-uvYLTnFCrcUWaHxeiTjPqdaUrR6zf0/edit#heading=h.6iz0wf853c5u)
  This document delves into the specifics of the content development plan, providing purpose and context for each section.

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->

## Ackowledgements

@Demogorgon314  @D-2-Ed many thanks for your technical guidance and great support! 