### PR TITLE
[fix] [doc] Fix the Pulsar Shell directory name in the example

### DIFF
--- a/docs/administration-pulsar-shell.md
+++ b/docs/administration-pulsar-shell.md
@@ -25,7 +25,7 @@ Download the tarball from the [download page](pathname:///download) and extract 
 ```shell
 wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
-cd apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+cd apache-pulsar-shell-@pulsar:version@/
 ```
 
 Now you can enter Pulsar shell's interactive mode:


### PR DESCRIPTION
This PR fixes the Pulsar Shell directory name in the example.

Copy-pasting the example into a bash shell and running it didn't work because of the invalid directory name in the last line. This PR fixes this problem.

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->


<!-- or fixes a doc issue -->


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
