### PR TITLE
[feat][doc] add configurations for broker load balancing

### DIFF
--- a/static/reference/next/config/README.md
+++ b/static/reference/next/config/README.md
@@ -32,3 +32,72 @@ You can set specific configurations through Java properties.
 | **Property**       | **Description**                                              |
 | ------------------ | ------------------------------------------------------------ |
 | pulsar.enableUring | Use `io_uring` instead of `epoll` as network IO mode. `-Dpulsar.enableUring=1` means this feature is enabled. |
+
+## Broker load balancing configurations
+
+Below is a brief summary of configurations for broker load balancing. 
+
+For detailed descriptions of each configuration, see [Broker load balancing | Configurations](pathname:///reference/#/@pulsar:version_reference@/config/reference-configuration-broker).
+
+> Note
+> Configurations with an asterisk (*) are only available in the extensible load balancer.
+
+### Broker load data
+
+- loadBalancerReportUpdateMinIntervalMillis
+- loadBalancerReportUpdateThresholdPercentage
+- loadBalancerReportUpdateMaxIntervalMinutes
+- loadBalancerBandwithInResourceWeight
+- loadBalancerBandwithOutResourceWeight
+- loadBalancerCPUResourceWeight
+- loadBalancerMemoryResourceWeight
+- loadBalancerDirectMemoryResourceWeight
+- loadBalancerHistoryResourcePercentage
+  
+### TopK bundle load data
+
+- loadBalancerReportUpdateMinIntervalMillis
+- statsUpdateFrequencyInSecs
+- loadBalancerMaxNumberOfBundlesInBundleLoadReport*
+
+
+### Bundle-broker assignment
+
+- loadBalancerAverageResourceUsageDifferenceThresholdPercentage
+
+### Bundle ownership system topic (ServiceUnitStateChannel)
+
+- loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds*
+
+### Bundle unloading
+
+- loadBalancerEnabled
+- loadBalancerSheddingEnabled
+- loadBalancerSheddingIntervalMinutes
+- loadBalancerSheddingGracePeriodMinutes
+- loadBalancerBrokerOverloadedThresholdPercentage
+- loadBalancerLoadSheddingStrategy. The default value is [org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder](https://github.com/apache/pulsar/blob/782e91fe327efe2c9c9107d6c679c2837d43935b/conf/broker.conf#L1324). Available values are:
+  -  `org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder`
+  -  `org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder`
+  -  `org.apache.pulsar.broker.loadbalance.impl.OverloadShedder`
+  -  `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder`
+- loadBalancerTransferEnabled*
+- loadBalancerBrokerLoadTargetStd*
+- loadBalancerSheddingConditionHitCountThreshold*
+- loadBalancerMaxNumberOfBrokerSheddingPerCycle*
+- loadBalanceSheddingDelayInSeconds*
+- loadBalancerBrokerLoadDataTTLInSeconds*
+
+### Bundle splitting
+
+- loadBalancerEnabled
+- loadBalancerAutoBundleSplitEnabled
+- defaultNamespaceBundleSplitAlgorithm
+- loadBalancerNamespaceBundleMaxTopics
+- loadBalancerNamespaceBundleMaxSessions
+- loadBalancerNamespaceBundleMaxMsgRate
+- loadBalancerNamespaceBundleMaxBandwidthMbytes
+- loadBalancerNamespaceMaximumBundles
+- loadBalancerSplitIntervalMinutes*
+- loadBalancerNamespaceBundleSplitConditionHitCountThreshold*
+- loadBalancerMaxNumberOfBundlesToSplitPerCycle*


### PR DESCRIPTION
## What change does this PR introduce?

This PR adds configurations for broker load balancing (topics in the red box below)

<img width="1953" alt="image" src="https://github.com/apache/pulsar-site/assets/50226895/1b68b721-3902-44fb-97e1-4102214fecbc">

## Doc development plan - Read before review

For the current doc of Broker Load Balancer, we want to tackle the following challenges:
- Create new documentation to cover all aspects of the feature (especially for the new extensible load balancer).
- Fill in any content gaps that may exist.
- Consolidate existing documentation into the new IA, as it is currently scattered and disorganized.
- Organize the documentation in a cohesive manner, ensuring it flows logically.

Consequently, we’ve created the following content development plans:
- [Broker Load Balancing | Information Architecture](https://xmind.works/share/dzbyKsnS)  
  This document presents a high-level architecture overview, including how we address content gaps and reconcile existing documentation.

- [Broker Load Balancing | Doc Outline](https://docs.google.com/document/d/1zshyn93XJp8Y-uvYLTnFCrcUWaHxeiTjPqdaUrR6zf0/edit#heading=h.6iz0wf853c5u)
  This document delves into the specifics of the content development plan, providing purpose and context for each section.

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->

## Ackowledgements

@Demogorgon314 thanks for your technical guidance and great support! 