### PR TITLE
[feat][doc] add development docs for broker load balancing

### DIFF
--- a/docs/develop-load-manager.md
+++ b/docs/develop-load-manager.md
@@ -4,15 +4,20 @@ title: Broker load balancer
 sidebar_label: "Broker load balancer"
 ---
 
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+````
+
 If you want to develop a broker load balancer, check out the following docs.
 
 Pulsar has the following types of load managers:
 
-- Simple load manager, implemented in [`SimpleLoadManagerImpl`](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java), which attempts to simplify how the load is managed while also providing abstractions so that complex load management strategies may be implemented.
+- Simple load manager, implemented in [SimpleLoadManagerImpl](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java), which attempts to simplify how the load is managed while also providing abstractions so that complex load management strategies may be implemented.
 
-- Modular load manager, implemented in [`ModularLoadManagerImpl`](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java), which is a flexible alternative to the [`SimpleLoadManagerImpl`](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java).
+- Modular load manager, implemented in [ModularLoadManagerImpl](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java), which is a flexible alternative to the [`SimpleLoadManagerImpl`](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java).
 
-- Extensible load manager, implemented in 
+- Extensible load manager, implemented in [ExtensibleLoadManagerImpl](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java), which is dependent on system topics and table views for load balance metadata store and replication.
 
 ## Concepts
 
@@ -107,6 +112,16 @@ assigned.
 
 You can enable a simple, modular, or extensible load manager by following the steps below.
 
+:::note 
+
+For simple and modular load managers:
+
+- Any mistakes in specifying the load manager will cause Pulsar to default to `SimpleLoadManagerImpl`. 
+
+- If you do not specify load manager, the default load manager (`ModularLoadManagerImpl`) is used.
+
+:::
+
 ### Enable simple load manager
 
 You can enable the simple load manager using one of the following methods: 
@@ -124,12 +139,6 @@ You can enable the simple load manager using one of the following methods:
    --config loadManagerClassName \
    --value org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl
    ``` 
-
-  :::note 
-  
-  Any mistakes in specifying the load manager will cause Pulsar to default to `SimpleLoadManagerImpl`.
-
-  :::
 
 ### Enable modular load manager
 
@@ -149,19 +158,13 @@ You can enable the modular load manager using one of the following methods:
    --value org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
    ```
 
-  :::note 
-  
-  Any mistakes in specifying the load manager will cause Pulsar to default to `SimpleLoadManagerImpl`.
-
-  :::
-
 ### Enable extensible load manager
 
 You can enable the extensible load manager by updating the value of [loadManagerClassName](https://github.com/apache/pulsar/blob/782e91fe327efe2c9c9107d6c679c2837d43935b/conf/broker.conf#L1309) to `org.apache.pulsar.broker.loadbalance.impl.ExtensibleLoadManagerImpl` in `conf/broker.conf`.
 
 :::note
 
-The pulsar-admin tool is not supported for enabling the extensible load manager.
+The [pulsar-admin tool](./reference-cli-tools.md) is not supported for enabling the extensible load manager.
 
 :::
 
@@ -193,126 +196,241 @@ If there is no `loadManagerClassName` element, then the value of [loadManagerCla
 
 To double-check which load manager is used, you can [check the ZooKeeper load report](#method-1-check-zookeeper-load-report) or [check monitor-brokers output](#method-2-check-monitor-brokers-output).  
 
-#### Method 1: check ZooKeeper load report
+#### Method 1: check load report
 
-Check the ZooKeeper load report. The load report in `/loadbalance/brokers/...`.
+Different load managers have different load reports. You can verify which load manager is used based on the output.
+
+````mdx-code-block
+<Tabs groupId="load-manager-report"
+  defaultValue="Simple"
+  values={[{"label":"Simple","value":"Simple"},{"label":"Modular","value":"Modular"},{"label":"Extensible","value":"Extensible"}]}>
+<TabItem value="Simple">
+
+You can check ZooKeeper load reports.
+
+1. Connect to ZooKeeper.
+
+    **Input**
+
+    ```bash
+    bin/pulsar zookeeper-shell -server zookeeper:2181
+    ```
+
+    **Output**
+
+    ```bash
+    Connecting to zookeeper:2181
+    2023-08-02T12:48:58,655+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:zookeeper.version=3.8.1-74db005175a4ec545697012f9069cb9dcc8cdda7, built on 2023-01-25 16:31 UTC
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:host.name=broker-1
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.version=17.0.7
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.vendor=Eclipse Adoptium
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.home=/usr/lib/jvm/temurin-17-jdk-amd64
+    ```
+
+2. List all brokers.
+
+    **Input**
+
+    ```bash
+    ls /loadbalance/brokers
+    ```
+
+    **Output**
+
+    This output shows that there are 2 brokers.
+
+    ```bash
+    [broker-1:8080, broker-2:8080]
+    ```
+
+3. Check ZooKeeper load report for broker 1. The load report in `/loadbalance/brokers/...`. 
+
+    **Input**
+
+    ```bash
+    get /loadbalance/brokers/broker-1:8080
+    ```
+
+    **Output**
+
+    ```bash
+    {"name":"broker-1:8080","brokerVersionString":"3.1.0-SNAPSHOT","webServiceUrl":"http://broker-1:8080","pulsarServiceUrl":"pulsar://broker-1:6650","persistentTopicsEnabled":true,"nonPersistentTopicsEnabled":true,"timestamp":1691042931108,"msgRateIn":0.0,"msgRateOut":0.0,"numTopics":0,"numConsumers":0,"numProducers":0,"numBundles":0,"protocols":{},"loadManagerClassName":"org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl","startTimestamp":1691042931108,"systemResourceUsage":{"bandwidthIn":{"usage":0.595387281695773,"limit":1.0E7},"bandwidthOut":{"usage":0.5799226769764033,"limit":1.0E7},"cpu":{"usage":6.224803359552059,"limit":800.0},"memory":{"usage":152.0,"limit":2096.0},"directMemory":{"usage":0.0,"limit":256.0}},"bundleStats":{},"bundleGains":[],"bundleLosses":[],"allocatedCPU":0.0,"allocatedMemory":0.0,"allocatedBandwidthIn":0.0,"allocatedBandwidthOut":0.0,"allocatedMsgRateIn":0.0,"allocatedMsgRateOut":0.0,"preAllocatedCPU":0.0,"preAllocatedMemory":0.0,"preAllocatedBandwidthIn":0.0,"preAllocatedBandwidthOut":0.0,"preAllocatedMsgRateIn":0.0,"preAllocatedMsgRateOut":0.0,"underLoaded":true,"overLoaded":false,"loadReportType":"LoadReport","msgThroughputIn":0.0,"msgThroughputOut":0.0,"bandwidthIn":{"usage":0.595387281695773,"limit":1.0E7},"bandwidthOut":{"usage":0.5799226769764033,"limit":1.0E7},"memory":{"usage":152.0,"limit":2096.0},"cpu":{"usage":6.224803359552059,"limit":800.0},"directMemory":{"usage":0.0,"limit":256.0},"lastUpdate":1691042931108}
+    ```
+
+</TabItem>
+<TabItem value="Modular">
+
+You can check ZooKeeper load reports.
+
+1. Connect to ZooKeeper.
+
+    **Input**
+
+    ```bash
+    bin/pulsar zookeeper-shell -server zookeeper:2181
+    ```
+
+    **Output**
+
+    ```bash
+    Connecting to zookeeper:2181
+    2023-08-02T12:48:58,655+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:zookeeper.version=3.8.1-74db005175a4ec545697012f9069cb9dcc8cdda7, built on 2023-01-25 16:31 UTC
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:host.name=broker-1
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.version=17.0.7
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.vendor=Eclipse Adoptium
+    2023-08-02T12:48:58,662+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Client environment:java.home=/usr/lib/jvm/temurin-17-jdk-amd64
+    ```
+
+2. List all brokers.
+  
+    **Input**
+
+    ```bash
+    ls /loadbalance/brokers
+    ```
+
+    **Output**
+
+    This output shows that there are 2 brokers.
+
+    ```bash
+    [broker-1:8080, broker-2:8080]
+    ```
+
+3. Check ZooKeeper load report for broker 1. The load report in `/loadbalance/brokers/...`. 
+    
+    **Input**
+
+    ```bash
+    get /loadbalance/brokers/broker-1:8080
+    ```
+
+    **Output**
+
+    ```bash
+    {"webServiceUrl":"http://broker-1:8080","pulsarServiceUrl":"pulsar://broker-1:6650","persistentTopicsEnabled":true,"nonPersistentTopicsEnabled":true,"cpu":{"usage":7.311714728372232,"limit":800.0},"memory":{"usage":124.0,"limit":2096.0},"directMemory":{"usage":36.0,"limit":256.0},"bandwidthIn":{"usage":0.8324254085661579,"limit":1.0E7},"bandwidthOut":{"usage":0.7155446715644209,"limit":1.0E7},"msgThroughputIn":0.0,"msgThroughputOut":0.0,"msgRateIn":0.0,"msgRateOut":0.0,"lastUpdate":1690979816792,"lastStats":{"my-tenant/my-namespace/0x4ccccccb_0x66666664":{"msgRateIn":0.0,"msgThroughputIn":0.0,"msgRateOut":0.0,"msgThroughputOut":0.0,"consumerCount":2,"producerCount":0,"topics":1,"cacheSize":0}},"numTopics":1,"numBundles":1,"numConsumers":2,"numProducers":0,"bundles":["my-tenant/my-namespace/0x4ccccccb_0x66666664"],"lastBundleGains":[],"lastBundleLosses":[],"brokerVersionString":"3.1.0-SNAPSHOT","protocols":{},"advertisedListeners":{"internal":{"brokerServiceUrl":"pulsar://broker-1:6650"}},"loadManagerClassName":"org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl","startTimestamp":1690940955211,"maxResourceUsage":0.140625,"loadReportType":"LocalBrokerData"}
+    ```
+
+</TabItem>
+<TabItem value="Extensible">
+
+:::note
+
+[Extensible load manager](./concepts-broker-load-balancing-types.md) does not have the ZooKeepr load report because its internal stats are stored in system topics rather than ZooKeeper.
+
+:::
+
+You can check load report from system topics using the [pulsar-client tool](./reference-cli-tools.md).
+
+**Input**
 
 ```bash
-tbd
+bin/pulsar-client consume non-persistent://pulsar/system/loadbalancer-broker-load-data --subscription-name test
 ```
-   
-Different load managers have different ZooKeeper load reports. 
 
-- [Simple load manager](./concepts-broker-load-balancing-types.md)
+**Output**
 
-  ```json
-  {
-    "systemResourceUsage": {
-      "bandwidthIn": {
-        "limit": 10240000.0,
-        "usage": 0.0
-      },
-      "bandwidthOut": {
-        "limit": 10240000.0,
-        "usage": 0.0
-      },
-      "cpu": {
-        "limit": 2400.0,
-        "usage": 0.0
-      },
-      "directMemory": {
-        "limit": 16384.0,
-        "usage": 1.0
-      },
-      "memory": {
-        "limit": 8192.0,
-        "usage": 3903.0
-      }
-    }
-  }
-  ```
+```bash
+2023-08-03T06:21:48,841+0000 [pulsar-client-io-1-3] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x69a65535, L:/127.0.0.1:59086 - R:localhost/127.0.0.1:6650]] Connected to server
+2023-08-03T06:21:48,926+0000 [pulsar-client-io-1-3] WARN  org.apache.pulsar.client.impl.ConsumerImpl - [non-persistent://pulsar/system/loadbalancer-broker-load-data] Cannot create a [Durable] subscription for a NonPersistentTopic, will use [NonDurable] to subscribe. Subscription name: test
+2023-08-03T06:21:49,189+0000 [pulsar-client-io-1-3] INFO  org.apache.pulsar.client.impl.ConsumerStatsRecorderImpl - Starting Pulsar consumer status recorder with config: {"topicNames":["non-persistent://pulsar/system/loadbalancer-broker-load-data"],"topicsPattern":null,"subscriptionName":"test","subscriptionType":"Exclusive","subscriptionProperties":null,"subscriptionMode":"NonDurable","receiverQueueSize":1000,"acknowledgementsGroupTimeMicros":100000,"maxAcknowledgmentGroupSize":1000,"negativeAckRedeliveryDelayMicros":60000000,"maxTotalReceiverQueueSizeAcrossPartitions":50000,"consumerName":null,"ackTimeoutMillis":0,"tickDurationMillis":1000,"priorityLevel":0,"maxPendingChunkedMessage":10,"autoAckOldestChunkedMessageOnQueueFull":false,"expireTimeOfIncompleteChunkedMessageMillis":60000,"cryptoFailureAction":"FAIL","properties":{},"readCompacted":false,"subscriptionInitialPosition":"Latest","patternAutoDiscoveryPeriod":60,"regexSubscriptionMode":"PersistentOnly","deadLetterPolicy":null,"retryEnable":false,"autoUpdatePartitions":true,"autoUpdatePartitionsIntervalSeconds":60,"replicateSubscriptionState":false,"resetIncludeHead":false,"batchIndexAckEnabled":false,"ackReceiptEnabled":false,"poolMessages":true,"startPaused":false,"autoScaledReceiverQueueSizeEnabled":false,"topicConfigurations":[],"maxPendingChuckedMessage":10}
+2023-08-03T06:21:49,214+0000 [pulsar-client-io-1-3] INFO  org.apache.pulsar.client.impl.ConsumerStatsRecorderImpl - Pulsar client config: {"serviceUrl":"pulsar://localhost:6650/","authPluginClassName":null,"authParams":null,"authParamMap":null,"operationTimeoutMs":30000,"lookupTimeoutMs":30000,"statsIntervalSeconds":60,"numIoThreads":8,"numListenerThreads":8,"connectionsPerBroker":1,"connectionMaxIdleSeconds":180,"useTcpNoDelay":true,"useTls":false,"tlsKeyFilePath":"","tlsCertificateFilePath":"","tlsTrustCertsFilePath":"","tlsAllowInsecureConnection":false,"tlsHostnameVerificationEnable":false,"concurrentLookupRequest":5000,"maxLookupRequest":50000,"maxLookupRedirects":20,"maxNumberOfRejectedRequestPerConnection":50,"keepAliveIntervalSeconds":30,"connectionTimeoutMs":10000,"requestTimeoutMs":60000,"readTimeoutMs":60000,"autoCertRefreshSeconds":300,"initialBackoffIntervalNanos":100000000,"maxBackoffIntervalNanos":60000000000,"enableBusyWait":false,"listenerName":null,"useKeyStoreTls":false,"sslProvider":null,"tlsKeyStoreType":"JKS","tlsKeyStorePath":"","tlsKeyStorePassword":"*****","tlsTrustStoreType":"JKS","tlsTrustStorePath":"","tlsTrustStorePassword":"*****","tlsCiphers":[],"tlsProtocols":[],"memoryLimitBytes":0,"proxyServiceUrl":null,"proxyProtocol":null,"enableTransaction":false,"dnsLookupBindAddress":null,"dnsLookupBindPort":0,"socks5ProxyAddress":null,"socks5ProxyUsername":null,"socks5ProxyPassword":null,"description":null}
+2023-08-03T06:21:49,236+0000 [pulsar-client-io-1-5] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0xbeee21f2, L:/172.31.0.4:44850 - R:broker-1/172.31.0.4:6650]] Connected to server
+2023-08-03T06:21:49,241+0000 [pulsar-client-io-1-5] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [non-persistent://pulsar/system/loadbalancer-broker-load-data][test] Subscribing to topic on cnx [id: 0xbeee21f2, L:/172.31.0.4:44850 - R:broker-1/172.31.0.4:6650], consumerId 0
+2023-08-03T06:21:49,273+0000 [pulsar-client-io-1-5] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [non-persistent://pulsar/system/loadbalancer-broker-load-data][test] Subscribed to topic on broker-1/172.31.0.4:6650 -- consumer: 0
+----- got message -----
+key:[broker-1:8080], properties:[], content:{"cpu":{"usage":14.397985201479854,"limit":800.0},"memory":{"usage":300.0,"limit":2096.0},"directMemory":{"usage":40.0,"limit":256.0},"bandwidthIn":{"usage":0.7817884878178855,"limit":1.0E7},"bandwidthOut":{"usage":0.7213945272139455,"limit":1.0E7},"msgThroughputIn":3.000538680274058,"msgThroughputOut":3.0005621893825616,"msgRateIn":0.03333931866971176,"msgRateOut":0.033339579882028465,"bundleCount":3,"topics":3,"maxResourceUsage":0.15625,"weightedMaxEMA":0.15625,"msgThroughputEMA":38.88925615962549,"updatedAt":1691043751060,"reportedAt":1691043631073}
+```
 
-- [Modular load manager](./concepts-broker-load-balancing-types.md)
+</TabItem>
 
-   Modular load manager has different ZooKeeper load report from that of the simple load manager. For example, the `systemResourceUsage` sub-elements (`bandwidthIn`, `bandwidthOut`, etc.) are now all at the top level. 
-
-  ```json
-  {
-    "bandwidthIn": {
-      "limit": 10240000.0,
-      "usage": 4.256510416666667
-    },
-    "bandwidthOut": {
-      "limit": 10240000.0,
-      "usage": 5.287239583333333
-    },
-    "bundles": [],
-    "cpu": {
-      "limit": 2400.0,
-      "usage": 5.7353247655435915
-    },
-    "directMemory": {
-      "limit": 16384.0,
-      "usage": 1.0
-    }
-  }
-  ```
-
-- Extensible load manager
-
-  :::note
-
-  [Extensible load manager](./concepts-broker-load-balancing-types.md) does not have the ZooKeepr load report because its internal stats are stored in system topics rather than ZooKeeper.
-
-  :::
-   
+</Tabs>
+````
 
 #### Method 2: check monitor-brokers output
 
 You can use the [pulsar-perf tool](reference-cli-tools.md) to start a broker monitor. 
   
+Different load managers have different outputs. This output is the same as the output of the [Method 1: check ZooKeeper load report](#method-1-check-zookeeper-load-report), but it is well formatted for better readability.
+
+````mdx-code-block
+<Tabs groupId="load-manager-report"
+  defaultValue="Simple"
+  values={[{"label":"Simple","value":"Simple"},{"label":"Modular","value":"Modular"},{"label":"Extensible","value":"Extensible"}]}>
+<TabItem value="Simple">
+
+**Input**
+
 ```bash
 pulsar-perf monitor-brokers --connect-string <zookeeper host:port>
 ````
 
-Different load managers have different outputs. This output is the same as the output of the [Method 1: check ZooKeeper load report](#method-1-check-zookeeper-load-report), but it is well formatted for better readability.
+**Output**
 
-- Simple load manager
+```bash
+===================================================================================================================
+||COUNT          |TOPIC          |BUNDLE         |PRODUCER       |CONSUMER       |BUNDLE +       |BUNDLE -       ||
+||               |4              |4              |0              |2              |0              |0              ||
+||RAW SYSTEM     |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
+||               |0.25           |47.94          |0.01           |0.00           |0.00           |47.94          ||
+||ALLOC SYSTEM   |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
+||               |0.20           |1.89           |               |1.27           |3.21           |3.21           ||
+||RAW MSG        |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |0.00           |0.00           |0.00           |0.01           |0.01           |0.01           ||
+||ALLOC MSG      |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |54.84          |134.48         |189.31         |126.54         |320.96         |447.50         ||
+===================================================================================================================
+```
 
-  ```bash
-  ===================================================================================================================
-  ||COUNT          |TOPIC          |BUNDLE         |PRODUCER       |CONSUMER       |BUNDLE +       |BUNDLE -       ||
-  ||               |4              |4              |0              |2              |0              |0              ||
-  ||RAW SYSTEM     |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
-  ||               |0.25           |47.94          |0.01           |0.00           |0.00           |47.94          ||
-  ||ALLOC SYSTEM   |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
-  ||               |0.20           |1.89           |               |1.27           |3.21           |3.21           ||
-  ||RAW MSG        |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
-  ||               |0.00           |0.00           |0.00           |0.01           |0.01           |0.01           ||
-  ||ALLOC MSG      |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
-  ||               |54.84          |134.48         |189.31         |126.54         |320.96         |447.50         ||
-  ===================================================================================================================
-  ```
+</TabItem>
+<TabItem value="Modular">
 
-  - Modular load manager
+**Input**
 
-  ```bash
-  ===================================================================================================================
-  ||SYSTEM         |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
-  ||               |0.00           |48.33          |0.01           |0.00           |0.00           |48.33          ||
-  ||COUNT          |TOPIC          |BUNDLE         |PRODUCER       |CONSUMER       |BUNDLE +       |BUNDLE -       ||
-  ||               |4              |4              |0              |2              |4              |0              ||
-  ||LATEST         |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
-  ||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
-  ||SHORT          |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
-  ||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
-  ||LONG           |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
-  ||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
-  ===================================================================================================================
-  ```
+```bash
+pulsar-perf monitor-brokers --connect-string <zookeeper host:port>
+````
 
- - Extensible load manager
-   
-   ```bash
-   tbd
-   ````
+**Output**
+
+```bash
+===================================================================================================================
+||SYSTEM         |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
+||               |0.00           |48.33          |0.01           |0.00           |0.00           |48.33          ||
+||COUNT          |TOPIC          |BUNDLE         |PRODUCER       |CONSUMER       |BUNDLE +       |BUNDLE -       ||
+||               |4              |4              |0              |2              |4              |0              ||
+||LATEST         |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
+||SHORT          |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
+||LONG           |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |0.00           |0.00           |0.00           |0.00           |0.00           |0.00           ||
+===================================================================================================================
+```
+
+</TabItem>
+<TabItem value="Extensible">
+
+**Input**
+
+```bash
+pulsar-perf monitor-brokers --connect-string pulsar://<host:port> --extensions 
+````
+
+**Output**
+
+```bash
+===================================================================================================================
+||SYSTEM         |CPU %          |MEMORY %       |DIRECT %       |BW IN %        |BW OUT %       |MAX %          ||
+||               |17.24          |12.40          |26.95          |0.00           |0.00           |26.95          ||
+||COUNT          |TOPIC          |BUNDLE         |PRODUCER       |CONSUMER       |BUNDLE +       |BUNDLE -       ||
+||               |               |4              |               |               |               |               ||
+||LATEST         |MSG/S IN       |MSG/S OUT      |TOTAL          |KB/S IN        |KB/S OUT       |TOTAL          ||
+||               |100.02         |0.02           |100.03         |103.89         |0.01           |103.90         ||
+===================================================================================================================
+````
+
+</TabItem>
+
+</Tabs>
+````


### PR DESCRIPTION
## What change does this PR introduce?

This PR adds and optimizes development docs for broker load balancing (topics in the red box below)

<img width="1337" alt="image" src="https://github.com/apache/pulsar-site/assets/50226895/1f84a33a-b5a9-451f-9f85-21dbb947b3b5">


## Doc development plan - Read before review

For the current doc of Broker Load Balancer, we want to tackle the following challenges:
- Create new documentation to cover all aspects of the feature (especially for the new extensible load balancer).
- Fill in any content gaps that may exist.
- Consolidate existing documentation into the new IA, as it is currently scattered and disorganized.
- Organize the documentation in a cohesive manner, ensuring it flows logically.

Consequently, we’ve created the following content development plans:
- [Broker Load Balancing | Information Architecture](https://xmind.works/share/dzbyKsnS)  
  This document presents a high-level architecture overview, including how we address content gaps and reconcile existing documentation.

- [Broker Load Balancing | Doc Outline](https://docs.google.com/document/d/1zshyn93XJp8Y-uvYLTnFCrcUWaHxeiTjPqdaUrR6zf0/edit#heading=h.6iz0wf853c5u)
  This document delves into the specifics of the content development plan, providing purpose and context for each section.

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->

## Ackowledgements

@Demogorgon314 many thanks for your technical guidance and great support! 

cc @heesung-sn @@D-2-Ed