### PR TITLE
[improve][doc] Explain how to use mutiple ZooKeeper in BookKeeper metadataServiceUri settings

### DIFF
--- a/docs/deploy-bare-metal.md
+++ b/docs/deploy-bare-metal.md
@@ -306,6 +306,18 @@ You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](referenc
 metadataServiceUri=zk://zk1.us-west.example.com:2181/ledgers
 ```
 
+:::note
+
+If you want to use multiple ZooKeeper servers, you can use as follow format:
+
+```properties
+metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
+```
+
+Which using `;` as separator in `metadataServiceUri`
+
+:::
+
 Once you appropriately modify the `metadataServiceUri` parameter, you can make any other configuration changes that you require. You can find a full listing of the available BookKeeper configuration parameters [here](reference-configuration.md#bookkeeper). However, consulting the [BookKeeper documentation](https://bookkeeper.apache.org/docs/next/reference/config/) for a more in-depth guide might be a better choice.
 
 Once you apply the desired configuration in `conf/bookkeeper.conf`, you can start up a bookie on each of your BookKeeper hosts. You can start up each bookie either in the background, using [nohup](https://en.wikipedia.org/wiki/Nohup), or in the foreground.


### PR DESCRIPTION
Add explanation for using multiple ZooKeeper server in BookKeeper metadataServiceUri setting

Ref: https://github.com/apache/bookkeeper/issues/1756

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
