### PR TITLE
[doc][fix] Typo on Client Feature Matrix page

### DIFF
--- a/client-feature-matrix/index.mdx
+++ b/client-feature-matrix/index.mdx
@@ -1,7 +1,7 @@
 ---
-id: pulsar-client-feaure-matrix
-title: Pulsar Client Feaure Matrix
-sidebar_label: Pulsar Client Feaure Matrix
+id: pulsar-client-feature-matrix
+title: Pulsar Client Feature Matrix
+sidebar_label: Pulsar Client Feature Matrix
 ---
 
 import Matrix from "../src/components/Matrix/matrix";


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

This PR fixes a typo on the Client Feature Matrix page (Feaure → Feature). The preview looks good, the link in the nav bar also still works (I've also changed the `id` of the page).

<img width="1811" alt="Screenshot Preview Client Feature Matrix page" src="https://github.com/apache/pulsar-site/assets/1119531/08e92527-95b2-4e5c-9316-52a7a7d2787e">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
