### PR TITLE
[fix][doc]Update security-encryption.md for key pairs of golang

### DIFF
--- a/versioned_docs/version-3.1.x/security-encryption.md
+++ b/versioned_docs/version-3.1.x/security-encryption.md
@@ -51,7 +51,7 @@ If the produced messages are consumed across application boundaries, you need to
    ````mdx-code-block
    <Tabs groupId="lang-choice"
      defaultValue="ECDSA"
-     values={[{"label":"ECDSA (for Java and Go clients)","value":"ECDSA"},{"label":"RSA (for Python, C++ and Node.js clients)","value":"RSA"}]}>
+     values={[{"label":"ECDSA (for Java clients)","value":"ECDSA"},{"label":"RSA (for Python, C++, Go and Node.js clients)","value":"RSA"}]}>
    <TabItem value="ECDSA">
 
      ```shell


### PR DESCRIPTION
golang client: only RSA keys are supported

func (d *DefaultMessageCrypto) addPublicKeyCipher(keyName string, keyReader KeyReader) error {
	d.cipherLock.Lock()
	defer d.cipherLock.Unlock()
	if keyName == "" || keyReader == nil {
		return fmt.Errorf("keyname or keyreader is null")
	}

	// read the public key and its info using keyReader
	keyInfo, err := keyReader.PublicKey(keyName, nil)
	if err != nil {
		return err
	}

	parsedKey, err := d.loadPublicKey(keyInfo.Key())
	if err != nil {
		return err
	}

	// try to cast to RSA key
	rsaPubKey, ok := parsedKey.(*rsa.PublicKey)
	if !ok {
		return fmt.Errorf("only RSA keys are supported")
	}

	encryptedDataKey, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, rsaPubKey, d.dataKey, nil)
	if err != nil {
		return err
	}

	d.encryptedDataKeyMap.Store(keyName, NewEncryptionKeyInfo(keyName, encryptedDataKey, keyInfo.Metadata()))

	return nil
}

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #xyz

<!-- or fixes a doc issue -->

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
