### PR TITLE
Fix typo in HTTP sink connector

### DIFF
--- a/versioned_docs/version-3.1.x/io-http-sink.md
+++ b/versioned_docs/version-3.1.x/io-http-sink.md
@@ -1,6 +1,6 @@
 ---
 id: io-http-sink
-title: HTTTP sink connector
+title: HTTP sink connector
 sidebar_label: "HTTP sink connector"
 ---
 


### PR DESCRIPTION
Fixes a typo in the title

- [x] `doc`