### PR TITLE
Polish version switch on desktop

### DIFF
--- a/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/styles.module.css
@@ -53,7 +53,7 @@
 }
 
 .sidebarVersionSwitch a {
-  display: inline-block;
+  cursor: pointer;
 }
 
 .sidebarVersionSwitch div {

--- a/src/theme/DocSidebar/Mobile/styles.module.css
+++ b/src/theme/DocSidebar/Mobile/styles.module.css
@@ -14,10 +14,6 @@
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
 }
 
-.sidebarVersionSwitch a {
-  display: inline-block;
-}
-
 .sidebarVersionSwitch div {
   display: inline-block !important;
 }


### PR DESCRIPTION
This PR polishes the version switch on desktop.

The previous style reduced the clickable area, making it inconvenient for users to interact. 
And made changes to the pointer style, emphasizing its clickability by using the "pointer" cursor.

Before:
![image](https://github.com/apache/pulsar-site/assets/24221472/b7184f50-2e4a-4e21-a06e-f4c3bc232f24)

After:
![image](https://github.com/apache/pulsar-site/assets/24221472/01fc5fa6-d3c4-4953-80e8-e4d8a734cc40)



<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
