### PR TITLE
[fix][doc] Update antiquated link in install cert-manager

### DIFF
--- a/versioned_docs/version-3.1.x/helm-deploy.md
+++ b/versioned_docs/version-3.1.x/helm-deploy.md
@@ -290,7 +290,7 @@ If you want to use **local** [persistent volumes](#persistence) as the persisten
 
 The Pulsar Helm Chart uses the [cert-manager](https://github.com/jetstack/cert-manager) to provision and manage TLS certificates automatically. To enable TLS encryption for brokers or proxies, you need to install the cert-manager in advance.
 
-For details about how to install the cert-manager, follow the [official instructions](https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm).
+For details about how to install the cert-manager, follow the [official instructions](https://cert-manager.io/docs/installation/helm/).
 
 Alternatively, we provide a bash script [install-cert-manager.sh](https://github.com/apache/pulsar-helm-chart/blob/master/scripts/cert-manager/install-cert-manager.sh) to install a cert-manager release to the namespace `cert-manager`.
 


### PR DESCRIPTION
seem like the link of cert-manager official instructions outdated

<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->



<!-- or fixes a doc issue -->



<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


Doesn't affect any visible doc elements, screenshot is unnecessary.