### PR TITLE
Add the release note for C++ client 3.4.1

### DIFF
--- a/data/release-cpp.js
+++ b/data/release-cpp.js
@@ -1,5 +1,6 @@
 module.exports = [
-{tagName: "v3.4.0",vtag:"3.4.x",releaseNotes:"/release-notes/versioned/client-cpp-3.4.0/",doc:"/docs/client-libraries-cpp",version:"v3.4.x"},
+{tagName: "v3.4.1",vtag:"3.4.x",releaseNotes:"/release-notes/versioned/client-cpp-3.4.1/",doc:"/docs/client-libraries-cpp",version:"v3.4.x"},
+{tagName: "v3.4.0",vtag:"3.4.x",releaseNotes:"/release-notes/versioned/client-cpp-3.4.0/",doc:"/docs/client-libraries-cpp",version:""},
 {tagName: "v3.3.0",vtag:"3.3.x",releaseNotes:"/release-notes/versioned/client-cpp-3.3.0/",doc:"/docs/client-libraries-cpp",version:"v3.3.x"},
 {tagName: "v3.2.0",vtag:"3.2.x",releaseNotes:"/release-notes/versioned/client-cpp-3.2.0/",doc:"/docs/client-libraries-cpp",version:"v3.2.x"},
 {tagName: "v3.1.2",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-cpp-3.1.2/",doc:"/docs/client-libraries-cpp",version:"v3.1.x"},

--- a/release-notes/versioned/client-cpp-3.4.1.md
+++ b/release-notes/versioned/client-cpp-3.4.1.md
@@ -1,0 +1,17 @@
+---
+id: client-cpp-3.4.1
+title: Client CPP 3.4.1
+sidebar_label: Client CPP 3.4.1
+---
+
+## What's Changed
+* Fix Protobuf symbols not found in libpulsarwithdeps.a when building on macOS by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/354
+* Fix the flush callback might be called repeatedly by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/353
+* Log topic lookup result by @erobot in https://github.com/apache/pulsar-client-cpp/pull/351
+* Fix bad_weak_ptr when close a ClientConnection during construction by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/350
+* Fix crash when removing connection from the pool by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/347
+* Fix lazy partitioned producer might send duplicated messages by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/342
+* Use absolute path to find credential files in unit tests by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/340
+* Fix close() returns ResultAlreadyClosed after unsubscribe or close by @BewareMyPower in https://github.com/apache/pulsar-client-cpp/pull/338
+
+**Full Changelog**: https://github.com/apache/pulsar-client-cpp/compare/v3.4.0...v3.4.1


### PR DESCRIPTION

<img width="1202" alt="image" src="https://github.com/apache/pulsar-site/assets/18204803/f67fe6a2-554a-4a5f-b972-4b0e2f881710">


- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
