### PR TITLE
 [fix][doc] auth problem in getting-started-docker-compose.md

### DIFF
--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -113,9 +113,10 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-To authorize volumes for default uid(10000) in Pulsar dockerfile.
+To create data directories and change the ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
+# this step might not be necessary on other than Linux platforms
 sudo chown 10000 -R data
 ```
 

--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -113,7 +113,7 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-To create data directories and change the ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
+As preparation, create data directories and change the data directory ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
 # this step might not be necessary on other than Linux platforms

--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -113,6 +113,12 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
+To authorize volumes for default uid(10000) in Pulsar dockerfile.
+```bash
+sudo mkdir -p ./data/zookeeper ./data/bookkeeper
+sudo chown 10000 -R data
+```
+
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 
 ```bash


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #[getting-started-docker-compose](https://pulsar.apache.org/docs/next/getting-started-docker-compose/)

<!-- or fixes a doc issue -->

This PR fixes #[getting-started-docker-compose](https://pulsar.apache.org/docs/next/getting-started-docker-compose/)

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
![image](https://github.com/apache/pulsar-site/assets/1729424/9d2747cc-cb22-49b9-9342-513533e1b95a)
