### PR TITLE
Fix wrong path define Pulsar release verify doc

### DIFF
--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -18,8 +18,8 @@ cd apache-pulsar-<release>
 Check the bookkeeper libs are complied on Linux:
 
 ```shell
-unzip -t ./lib/org.apache.bookkeeper-circe-checksum-<version>.jar | grep lib
-unzip -t ./lib/org.apache.bookkeeper-cpu-affinity-<version>.jar | grep lib
+unzip -t ./lib/org.apache.bookkeeper-circe-checksum-*.jar | grep lib
+unzip -t ./lib/org.apache.bookkeeper-cpu-affinity-*.jar | grep lib
 ```
 
 The output should look like:

--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -18,8 +18,8 @@ cd apache-pulsar-<release>
 Check the bookkeeper libs are complied on Linux:
 
 ```shell
-unzip -t ./org.apache.bookkeeper-circe-checksum-*.jar | grep lib
-unzip -t ./org.apache.bookkeeper-cpu-affinity-*.jar | grep lib
+unzip -t ./lib/org.apache.bookkeeper-circe-checksum-<version>.jar | grep lib
+unzip -t ./lib/org.apache.bookkeeper-cpu-affinity-<version>.jar | grep lib
 ```
 
 The output should look like:


### PR DESCRIPTION
`org.apache.bookkeeper-circe-checksum-<version>.jar` and `org.apache.bookkeeper-cpu-affinity-<version>.jar` are under the folder `{PULSAR_HOME}/lib`, not `{PULSAR_HOME}`

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
