### PR TITLE
[fix] Update release docker image in release process

### DIFF
--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -332,7 +332,7 @@ regctl image copy ${OTHER_DOCKER_USER}/pulsar:${CANDIDATE_TAG} apachepulsar/puls
 regctl image copy ${OTHER_DOCKER_USER}/pulsar-all:${CANDIDATE_TAG} apachepulsar/pulsar-all:${PULSAR_VERSION}
 ```
 
-If this release is a feature rlease, you should also push these images to the latest tag.
+If this release is a feature rlease or a patch release of the last feature release, you should also push these images to the latest tag.
 
 If you don't have the permission, you can ask someone with access to apachepulsar org to do that.
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -332,7 +332,7 @@ regctl image copy ${OTHER_DOCKER_USER}/pulsar:${CANDIDATE_TAG} apachepulsar/puls
 regctl image copy ${OTHER_DOCKER_USER}/pulsar-all:${CANDIDATE_TAG} apachepulsar/pulsar-all:${PULSAR_VERSION}
 ```
 
-If this release is a feature rlease or a patch release of the last feature release, you should also push these images to the latest tag.
+If this release is a feature release or a patch release of the last feature release, you should also push these images to the latest tag.
 
 If you don't have the permission, you can ask someone with access to apachepulsar org to do that.
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -334,8 +334,6 @@ regctl image copy ${OTHER_DOCKER_USER}/pulsar-all:${CANDIDATE_TAG} apachepulsar/
 
 If this release is a feature release or a patch release of the last feature release, you should also push these images to the `latest` tag.
 
-If this release is a LTS release or a patch release of the last LTS release, you should also push these images to the `lts` tag.
-
 If you don't have the permission, you can ask someone with access to apachepulsar org to do that.
 
 ### Update project version

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -323,16 +323,14 @@ Promote the Maven staging repository for release. Login to `https://repository.a
 Copy the approved candidate docker images from your personal account to apachepulsar org.
 
 ```bash
-PULSAR_VERSION=2.x.x
+PULSAR_VERSION=3.x.x
 OTHER_DOCKER_USER=otheruser
-for image in pulsar pulsar-all pulsar-grafana pulsar-standalone; do
-    docker pull "${OTHER_DOCKER_USER}/$image:${PULSAR_VERSION}" && {
-      docker tag "${OTHER_DOCKER_USER}/$image:${PULSAR_VERSION}" "apachepulsar/$image:${PULSAR_VERSION}"
-      echo "Pushing apachepulsar/$image:${PULSAR_VERSION}"
-      docker push "apachepulsar/$image:${PULSAR_VERSION}"
-    }
-done
+CANDIDATE_TAG=3.x.x-80fb390
+regctl image copy ${OTHER_DOCKER_USER}/pulsar:${CANDIDATE_TAG} apachepulsar/pulsar:${PULSAR_VERSION}
+regctl image copy ${OTHER_DOCKER_USER}/pulsar-all:${CANDIDATE_TAG} apachepulsar/pulsar-all:${PULSAR_VERSION}
 ```
+
+If this release is a feature rlease, you should also push these images to the latest tag.
 
 If you don't have the permission, you can ask someone with access to apachepulsar org to do that.
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -332,7 +332,9 @@ regctl image copy ${OTHER_DOCKER_USER}/pulsar:${CANDIDATE_TAG} apachepulsar/puls
 regctl image copy ${OTHER_DOCKER_USER}/pulsar-all:${CANDIDATE_TAG} apachepulsar/pulsar-all:${PULSAR_VERSION}
 ```
 
-If this release is a feature release or a patch release of the last feature release, you should also push these images to the latest tag.
+If this release is a feature release or a patch release of the last feature release, you should also push these images to the `latest` tag.
+
+If this release is a LTS release or a patch release of the last LTS release, you should also push these images to the `lts` tag.
 
 If you don't have the permission, you can ask someone with access to apachepulsar org to do that.
 

--- a/contribute/release-process.md
+++ b/contribute/release-process.md
@@ -320,7 +320,9 @@ Promote the Maven staging repository for release. Login to `https://repository.a
 
 ### Release Docker images
 
-Copy the approved candidate docker images from your personal account to apachepulsar org.
+Please ensure that the regctl tools have been properly installed. They can be obtained from the following link: https://github.com/regclient/regclient/blob/main/docs/install.md
+
+Copy the approved candidate Docker images from your personal account to the apachepulsar organization:
 
 ```bash
 PULSAR_VERSION=3.x.x


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

The current release docker images process doesn't work for Pulsar above versions 3.0.0. Pulsar has added arm and amd arch supports for the docker image. If we use the original command to push the image, it will push only one arch.

We recommend use tools like regctl to push images.

For the latest tag of the pulsar image, this PR proposes to use the last feature release version or the patch release of the last feature release as the `latest` tag.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
