### PR TITLE
Fix the release tables for 3.0.2

### DIFF
--- a/data/release-pulsar.js
+++ b/data/release-pulsar.js
@@ -1,14 +1,5 @@
 module.exports = [
     {
-        "author": "poorbarcode",
-        "tagName": "v3.0.2",
-        "publishedAt": "2023-12-3T11:17:000",
-        "vtag": "3.0.x",
-        "releaseNotes": "/release-notes/versioned/pulsar-3.0.2/",
-        "doc": "/docs/3.0.x",
-        "version": "v3.0.x"
-    },
-    {
         "author": "Technoboy-",
         "tagName": "v3.1.1",
         "publishedAt": "2023-10-24T16:37:40Z",
@@ -27,13 +18,22 @@ module.exports = [
         "version": ""
     },
     {
+      "author": "poorbarcode",
+      "tagName": "v3.0.2",
+      "publishedAt": "2023-12-03T11:17:00Z",
+      "vtag": "3.0.x",
+      "releaseNotes": "/release-notes/versioned/pulsar-3.0.2/",
+      "doc": "/docs/3.0.x",
+      "version": "v3.0.x"
+    },
+    {
         "author": "RobertIndie",
         "tagName": "v3.0.1",
         "publishedAt": "2023-08-07T15:00:00Z",
         "vtag": "3.0.x",
         "releaseNotes": "/release-notes/versioned/pulsar-3.0.1/",
         "doc": "/docs/3.0.x",
-        "version": "v3.0.x"
+        "version": ""
     },
     {
         "author": "RobertIndie",


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->



This PR fixes https://github.com/apache/pulsar/issues/21677

<img width="1155" alt="image" src="https://github.com/apache/pulsar-site/assets/16974619/a548a810-86b5-471a-9844-3e8577c3845d">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
