### PR TITLE
[improve][doc]Add athenz copper argos sample code in python/nodejs

### DIFF
--- a/docs/security-athenz.md
+++ b/docs/security-athenz.md
@@ -183,7 +183,7 @@ client, err := pulsar.NewClient(pulsar.ClientOptions{
 
 Athenz has a mechanism called [Copper Argos](https://github.com/AthenZ/athenz/blob/master/docs/copper_argos.md). This means that ZTS distributes an X.509 certificate and private key pair to each service, which it can use to identify itself to other services within the organization.
 
-Currently, Pulsar supports Copper Argos in Java, C++, and Go. When using Copper Argos, you need to provide at least the following four parameters:
+When using Copper Argos, you need to provide at least the following four parameters:
 * `providerDomain`
 * `x509CertChain`
 * `privateKey`

--- a/docs/security-athenz.md
+++ b/docs/security-athenz.md
@@ -194,7 +194,7 @@ In this case, `tenantDomain`, `tenantService` and `keyId` are ignored.
 ````mdx-code-block
 <Tabs groupId="lang-choice"
   defaultValue="Java"
-  values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"},{"label":"Go","value":"Go"}]}>
+  values={[{"label":"Java","value":"Java"},{"label":"Python","value":"Python"},{"label":"C++","value":"C++"},{"label":"Node.js","value":"Node.js"},{"label":"Go","value":"Go"}]}>
 <TabItem value="Java">
 
 ```java
@@ -215,6 +215,27 @@ PulsarClient client = PulsarClient.builder()
 ```
 
 </TabItem>
+<TabItem value="Python">
+
+```python
+authPlugin = "athenz"
+authParams = """
+{
+"ztsUrl": "http://localhost:9998",
+"providerDomain": "pulsar",
+"x509CertChain": "file:///path/to/x509cert.pem",
+"privateKey": "file:///path/to/private.pem",
+"caCert": "file:///path/to/cacert.pem"
+}
+"""
+
+client = Client(
+    "pulsar://my-broker.com:6650",
+    authentication=Authentication(authPlugin, authParams),
+)
+```
+
+</TabItem>
 <TabItem value="C++">
 
 ```cpp
@@ -231,6 +252,24 @@ config.setAuth(auth);
 Client client("pulsar://my-broker.com:6650", config);
 ```
 
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript
+const auth = new Pulsar.AuthenticationAthenz({
+    ztsUrl: "http://localhost:9998",
+    providerDomain: "pulsar",
+    x509CertChain: "file:///path/to/x509cert.pem",
+    privateKey: "file:///path/to/private.pem",
+    caCert: "file:///path/to/cacert.pem"
+});
+
+const client = new Pulsar.Client({
+    serviceUrl: 'pulsar://my-broker.com:6650',
+    authentication: auth
+});
+
+```
 </TabItem>
 <TabItem value="Go">
 


### PR DESCRIPTION
This PR adds doc for https://github.com/apache/pulsar-client-cpp/pull/274

Python client v3.3.0 and next release version of Node.js client support Copper Argos because they use cpp client v3.3.0 or above.
Therefore, I add sample codes for Copper Argos in python/Node.js.


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->  

 <br>
  
I previewed my changes locally and they appeared as expected.

**1. description**

<img width="500" alt="image" src="https://github.com/apache/pulsar-site/assets/22829228/149088dd-bd0f-41ee-8304-5ff606857357">

**2. python sample code**

<img width="500" alt="image" src="https://github.com/apache/pulsar-site/assets/22829228/d072aae9-7c5b-4019-9c0f-879fd4e90644">

**3. Node.js sample code**

<img width="500" alt="image" src="https://github.com/apache/pulsar-site/assets/22829228/11cbdc73-741a-4e7a-a697-87447649f438">

