### PR TITLE
Contribution guide: Add step for importing the committer's public GPG key from the key server

### DIFF
--- a/contribute/create-gpg-keys.md
+++ b/contribute/create-gpg-keys.md
@@ -136,6 +136,12 @@ cd pulsar-dist-release-keys
 svn up KEYS
 
 APACHEID=apacheid
+
+# import the key from the keyserver, ensure that the key id matches the one provided by the committer
+gpg --search-keys $APACHEID@apache.org
+KEY_ID=$(gpg --list-keys --with-colons $APACHEID@apache.org | egrep "^pub" | awk -F: '{print $5}')
+echo "key id: $KEY_ID"
+
 # Export the key in ascii format and append it to the file
 # Make sure that the GPG key id matches the one from the committer
 ( gpg --list-sigs $APACHEID@apache.org


### PR DESCRIPTION
A step was missing in adding the committer's GPG key to KEYS file in the contribution guide


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
