### PR TITLE
[doc][client feature matrix] improve experience for .NET users looking for information on .NET/C# clients

### DIFF
--- a/client-feature-matrix/index.mdx
+++ b/client-feature-matrix/index.mdx
@@ -14,6 +14,8 @@ import {
   tableview,
 } from "../data/matrix.js";
 
+To get more information on clients, see [Pulsar Client Libraries](/docs/next/client-libraries).
+
 ### Client
 
 <Matrix data={client} name="client" />

--- a/data/matrix.js
+++ b/data/matrix.js
@@ -6,9 +6,9 @@ module.exports = {
     "Python",
     "Node.js",
     "C#/DotPulsar",
+    ".NET (C#/F#/VB)",
     "Websocket",
     "REST",
-    ".NET (C#/F#/VB)",
   ],
   client: [
     {

--- a/docs/client-libraries.md
+++ b/docs/client-libraries.md
@@ -16,7 +16,7 @@ Pulsar supports the following language-specific client libraries:
 | Python    | [User doc](client-libraries-python.md) <br/> [API doc](@pulsar:apidoc:python@)                                     | [Standalone](pathname:///release-notes/client-python) | [Standalone](https://github.com/apache/pulsar-client-python)          |
 | Go client | [User doc](client-libraries-go.md)   <br/> [API doc](https://pkg.go.dev/github.com/apache/pulsar-client-go/pulsar) | [Standalone](pathname:///release-notes/client-go)     | [Standalone](https://github.com/apache/pulsar-client-go)              |
 | Node.js   | [User doc](client-libraries-node.md)  <br/> [API doc](@pulsar:apidoc:js@)                                          | [Standalone](pathname:///release-notes/client-node)   | [Standalone](https://github.com/apache/pulsar-client-node)            |
-| C#        | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](pathname:///release-notes/client-cs)     | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
+| C#/DotPulsar | [User doc](client-libraries-dotnet.md)                                                                             | [Standalone](pathname:///release-notes/client-cs)     | [Standalone](https://github.com/apache/pulsar-dotpulsar)              |
 
 :::tip
 
@@ -55,7 +55,7 @@ Want your repository listed here? Click the "Edit this page" button at the botto
 
 :::
 
-#### .NET
+#### .NET (C#/F#/VB)
 
 | Project                                                                    | Description                                     | License                                    | Badges                                                                                                                                                                                                                                                   |
 |----------------------------------------------------------------------------|-------------------------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/components/Matrix/util.js
+++ b/src/components/Matrix/util.js
@@ -15,11 +15,13 @@ export const genColumns = () => {
           ? 180
           : index === 1
           ? 150
-          : index === 7
+          : index === 7 // DotPulsar
           ? 120
-          : index === 8
+          : index === 8 // .NET
+          ? 100
+          : index === 9 // WS
           ? 90
-          : index === 10
+          : index === 11 // REST
           ? 126
           : 74,
       dataGetter: ({ column, rowData }) => {


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

This PR aims to improve the experience for .NET/C# users looking for information on .NET/C# clients. The goal is to help the users choose which client best suits their needs.

Two .NET clients exist: C#/DotPulsar and .NET client. They don't provide the same feature coverage. The PR fixes the client features matrix to display the two clients side by side to highlight this coverage difference.

Additionally, the PR adds a link to the client docs to facilitate the navigation and help the user compare the two clients in details.

Finally, the PR makes the doc use the same names for the clients in both the feature matrix and the client libraries page to improve clarity.

Preview:

<img width="942" alt="Screenshot 2023-12-18 at 3 33 49 PM" src="https://github.com/apache/pulsar-site/assets/351773/63b98b7c-db95-47bd-a7ef-4ccc10bfc09a">

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
