### PR TITLE
[improve][misc] ASF branding

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -10,8 +10,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
@@ -19,10 +19,10 @@ const ShortInfo: React.FC = () => {
         <Parallax>
           <div className={s.docs_container}>
             <h1 className={s.header}>
-              <span className={s.title}> Apache Pulsar</span><br />
-              <span className={s.subtitle}> Cloud-Native, Distributed Messaging and Streaming </span>
+              <span className={s.title}>Apache Pulsar™</span><br/>
+              <span className={s.subtitle}>Cloud-Native, Distributed Messaging and Streaming</span>
             </h1>
-            <span className={s.text}>Apache® Pulsar™ is an open-source, distributed messaging and streaming platform built for the cloud. </span>
+            <span className={s.text}>Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud. </span>
 
             <div className={s.buttons}>
               <Button

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -24,7 +24,7 @@ import Page from '@site/src/components/ui/Page/Page';
 
 <Page>
 
-# Downloads
+# Downloads for Apache Pulsar™
 
 ## Release notes
 

--- a/versioned_docs/version-2.10.x/about.md
+++ b/versioned_docs/version-2.10.x/about.md
@@ -9,8 +9,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/versioned_docs/version-2.11.x/about.md
+++ b/versioned_docs/version-2.11.x/about.md
@@ -9,8 +9,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/versioned_docs/version-2.8.x/about.md
+++ b/versioned_docs/version-2.8.x/about.md
@@ -9,8 +9,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/versioned_docs/version-2.9.x/about.md
+++ b/versioned_docs/version-2.9.x/about.md
@@ -9,8 +9,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 ## Choose your path....

--- a/versioned_docs/version-3.0.x/about.md
+++ b/versioned_docs/version-3.0.x/about.md
@@ -9,8 +9,7 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/versioned_docs/version-3.1.x/about.md
+++ b/versioned_docs/version-3.1.x/about.md
@@ -10,7 +10,7 @@ import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
 
-# Welcome to the Apache Pulsar documentation portal
+# Welcome to the Apache Pulsar™ documentation portal
 ***
 
 This portal holds a variety of topics, tutorials, guides, and reference material to help you work with Pulsar.

--- a/versioned_docs/version-3.1.x/about.md
+++ b/versioned_docs/version-3.1.x/about.md
@@ -9,7 +9,6 @@ import BlockLinks from "@site/src/components/ui/BlockLinks";
 import BlockLink from "@site/src/components/ui/BlockLink";
 import { docUrl } from "@site/src/utils/index";
 
-
 # Welcome to the Apache Pulsar™ documentation portal
 ***
 


### PR DESCRIPTION
cc @markt-asf 

According to your suggestions:

> 1. While "Apache® Pulsar™" is strictly correct, it can also look a
> little awkward / busy so it is OK to use "Apache Pulsar™" if you prefer.

Thank you! Although I don't have a strong feeling, with point 2 below the refer to "Apache® Pulsar™" in homepage is not the first and most prominent usage so I accept your suggestion. Other occurrences of "Apache® Pulsar™" if any doesn't change.

> 2. Pages such as https://pulsar.apache.org/ should use "Apache Pulsar™"
> for the "Apache Pulsar" in blue text since that is both the first and
> most prominent usage.

I can't read "such as" so I handle exactly the homepage. Now the "Apache Pulsar" in blue text is changed to "Apache Pulsar™":

<img width="1728" alt="image" src="https://github.com/apache/pulsar-site/assets/18818196/16eaf749-35aa-460f-8f71-ef73b42c6ecc">

> 3. The documentation pages such as https://pulsar.apache.org/docs/3.1.x/
> should use "Apache Pulsar™" for the first and most prominent usages
> (which may be the same) of "Apache Pulsar"

Also I can't read "such as" and I provide more details on the mailing list. For https://pulsar.apache.org/docs/3.1.x/, it's changed to:

<img width="1728" alt="image" src="https://github.com/apache/pulsar-site/assets/18818196/4ae0736a-3348-4fe8-9830-597ca0b168f3">

I update it for the NEXT version also so the following versions will follow the suggestion.

> 4. The download page https://pulsar.apache.org/download/ should use
> "Apache Pulsar™" for the first and most prominent usages (which may be
> the same) of "Pulsar"

Sorry. There is not clear "first and most prominent usages". Could you point it out? If you refer to the first occurrence "Release notes for all Pulsar's versions." as a sentence, it doesn't seems to be "most prominent usages" but fair with any other.

I may extend "Download" title to "Download Apache Pulsar™", but it reflects a case that a page may not have "first and most prominent usages". This is common especially in a doc page talk about a certain technical topic like https://pulsar.apache.org/docs/3.1.x/security-tls-authentication/. But still it's clearly that this is under the official Pulsar website.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->
