### PR TITLE
Add the release note for Python client 3.4.0

### DIFF
--- a/data/release-python.js
+++ b/data/release-python.js
@@ -1,4 +1,5 @@
 module.exports = [
+{tagName: "v3.4.0",vtag:"3.4.x",releaseNotes:"/release-notes/versioned/client-python-3.4.0/",doc:"/docs/client-libraries-python",version:"v3.4.x"},
 {tagName: "v3.3.0",vtag:"3.3.x",releaseNotes:"/release-notes/versioned/client-python-3.3.0/",doc:"/docs/client-libraries-python",version:"v3.3.x"},
 {tagName: "v3.2.0",vtag:"3.2.x",releaseNotes:"/release-notes/versioned/client-python-3.2.0/",doc:"/docs/client-libraries-python",version:"v3.2.x"},
 {tagName: "v3.1.0",vtag:"3.1.x",releaseNotes:"/release-notes/versioned/client-python-3.1.0/",doc:"/docs/client-libraries-python",version:"v3.1.x"},

--- a/release-notes/versioned/client-python-3.4.0.md
+++ b/release-notes/versioned/client-python-3.4.0.md
@@ -1,0 +1,17 @@
+## What's Changed
+* Added missing publish option `ordering_key` by @sbreatnach in https://github.com/apache/pulsar-client-python/pull/152
+* Remove useless sleep on test_seek by @shibd in https://github.com/apache/pulsar-client-python/pull/154
+* Support configure startMessageIdInclusive for the reader by @RobertIndie in https://github.com/apache/pulsar-client-python/pull/157
+* Support schema field type promotion by @RobertIndie in https://github.com/apache/pulsar-client-python/pull/159
+* Support Python 3.12 wheels by @merlimat in https://github.com/apache/pulsar-client-python/pull/160
+* Improve the developer experience when running tests by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/163
+* Upgrade the C++ client to 3.4.1 by @RobertIndie in https://github.com/apache/pulsar-client-python/pull/167
+* Update Curl to 8.4.0 by @merlimat in https://github.com/apache/pulsar-client-python/pull/168
+* Add type annotations for enum parameters in methods by @shibd in https://github.com/apache/pulsar-client-python/pull/169
+* Upgrade grpcio to 1.60.0 to fix CVE-2023-1428 by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/174
+* Upgrade the C++ client to 3.4.2 by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/170
+
+## New Contributors
+* @sbreatnach made their first contribution in https://github.com/apache/pulsar-client-python/pull/152
+
+**Full Changelog**: https://github.com/apache/pulsar-client-python/compare/v3.3.0...v3.4.0

--- a/release-notes/versioned/client-python-3.4.0.md
+++ b/release-notes/versioned/client-python-3.4.0.md
@@ -1,3 +1,9 @@
+---
+id: client-python-3.4.0
+title: Client Python 3.4.0
+sidebar_label: Client Python 3.4.0
+---
+
 ## What's Changed
 * Added missing publish option `ordering_key` by @sbreatnach in https://github.com/apache/pulsar-client-python/pull/152
 * Remove useless sleep on test_seek by @shibd in https://github.com/apache/pulsar-client-python/pull/154


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

This PR adds the release note for Python client 3.4.0

<img width="1085" alt="image" src="https://github.com/apache/pulsar-site/assets/16974619/98d84f89-1eb3-4626-99db-5ca0119f7b93">
<img width="1028" alt="image" src="https://github.com/apache/pulsar-site/assets/16974619/d7002868-72db-4a81-a44b-7b480b5f977f">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
