### PR TITLE
Add missing metadata for python client 3.1.0-3.3.0 release notes

### DIFF
--- a/release-notes/versioned/client-python-3.1.0.md
+++ b/release-notes/versioned/client-python-3.1.0.md
@@ -1,3 +1,9 @@
+---
+id: client-python-3.1.0
+title: Client Python 3.1.0
+sidebar_label: Client Python 3.1.0
+---
+
 ## What's Changed
 * Wrap the interruption to a custom exception when a blocking API is interrupted by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/99
 * Upgrade to pulsar-client-cpp 3.1.2 by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/96

--- a/release-notes/versioned/client-python-3.2.0.md
+++ b/release-notes/versioned/client-python-3.2.0.md
@@ -1,3 +1,9 @@
+---
+id: client-python-3.2.0
+title: Client Python 3.2.0
+sidebar_label: Client Python 3.2.0
+---
+
 ## What's Changed
 * Bumped version to 3.2.0a1 by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/105
 * Upgrade fastavro to 1.7.3 by @BewareMyPower in https://github.com/apache/pulsar-client-python/pull/110

--- a/release-notes/versioned/client-python-3.3.0.md
+++ b/release-notes/versioned/client-python-3.3.0.md
@@ -1,3 +1,9 @@
+---
+id: client-python-3.3.0
+title: Client Python 3.3.0
+sidebar_label: Client Python 3.3.0
+---
+
 ## What's Changed
 * Added support for KeySharedPolicy for the consumer when in KeyShared mode by @hyperevo https://github.com/apache/pulsar-client-python/pull/109
 * Bumped version to 3.3.0a1 @BewareMyPower https://github.com/apache/pulsar-client-python/pull/130


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

After the PR, the title for the release note will be shown correctly:
<img width="1096" alt="image" src="https://github.com/apache/pulsar-site/assets/16974619/9ea58a28-7fe3-42d6-8810-e16d3f4a27bb">


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
