### PR TITLE
[doc] Avoid users send messages with too long delay time

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1191,6 +1191,12 @@ The diagram below illustrates the concept of delayed message delivery:
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
 
+:::note
+
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+
+:::
+
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1193,7 +1193,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
 
 :::
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -990,7 +990,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
 
 :::
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -988,6 +988,12 @@ The diagram below illustrates the concept of delayed message delivery:
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
 
+:::note
+
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+
+:::
+
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1145,7 +1145,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
 
 :::
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1143,6 +1143,12 @@ The diagram below illustrates the concept of delayed message delivery:
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
 
+:::note
+
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+
+:::
+
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1140,6 +1140,12 @@ The diagram below illustrates the concept of delayed message delivery:
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
 
+:::note
+
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+
+:::
+
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1142,7 +1142,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
 
 :::
 

--- a/versioned_docs/version-3.1.x/concepts-messaging.md
+++ b/versioned_docs/version-3.1.x/concepts-messaging.md
@@ -1160,6 +1160,12 @@ The diagram below illustrates the concept of delayed message delivery:
 
 A broker saves a message without any check. When a consumer consumes a message, if the message is set to delay, then the message is added to `DelayedDeliveryTracker`. A subscription checks and gets timeout messages from `DelayedDeliveryTracker`.
 
+:::note
+
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+
+:::
+
 ### Broker
 Delayed message delivery is enabled by default. You can change it in the broker configuration file as below:
 

--- a/versioned_docs/version-3.1.x/concepts-messaging.md
+++ b/versioned_docs/version-3.1.x/concepts-messaging.md
@@ -1162,7 +1162,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger has been consumed. Pulsar will delete the front ledgers of a topic, it will not delete from the middle of a topic. It means that if you send a message that is delayed for a long time, the messages will not be consumed util it reach the specified time. Which leading all the ledgers of this topic could not be deleted, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
 
 :::
 


### PR DESCRIPTION
In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
