### PR TITLE
[doc] Add a note: if using Delayed messages, advisable to exercise caution when using the Backlog Quota strategy

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1193,7 +1193,11 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+Work with retention policy: In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+
+Work with backlog quota policy: After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy. This is because delayed messages can result in not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+
+Work with backlog TTL policy: When the TTL expires, Pulsar automatically moves the message to the acknowledged state (and thus makes it ready for deletion) even if the messages are delayed messages and does not care about when the expected delayed time is.
 
 :::
 

--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -1193,7 +1193,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
 
 :::
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -990,7 +990,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
 
 :::
 

--- a/versioned_docs/version-2.10.x/concepts-messaging.md
+++ b/versioned_docs/version-2.10.x/concepts-messaging.md
@@ -990,7 +990,11 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+Work with retention policy: In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+
+Work with backlog quota policy: After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy. This is because delayed messages can result in not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+
+Work with backlog TTL policy: When the TTL expires, Pulsar automatically moves the message to the acknowledged state (and thus makes it ready for deletion) even if the messages are delayed messages and does not care about when the expected delayed time is.
 
 :::
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1145,7 +1145,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
 
 :::
 

--- a/versioned_docs/version-2.11.x/concepts-messaging.md
+++ b/versioned_docs/version-2.11.x/concepts-messaging.md
@@ -1145,7 +1145,11 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+Work with retention policy: In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+
+Work with backlog quota policy: After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy. This is because delayed messages can result in not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+
+Work with backlog TTL policy: When the TTL expires, Pulsar automatically moves the message to the acknowledged state (and thus makes it ready for deletion) even if the messages are delayed messages and does not care about when the expected delayed time is.
 
 :::
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1142,7 +1142,11 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+Work with retention policy: In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+
+Work with backlog quota policy: After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy. This is because delayed messages can result in not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+
+Work with backlog TTL policy: When the TTL expires, Pulsar automatically moves the message to the acknowledged state (and thus makes it ready for deletion) even if the messages are delayed messages and does not care about when the expected delayed time is.
 
 :::
 

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -1142,7 +1142,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
 
 :::
 

--- a/versioned_docs/version-3.1.x/concepts-messaging.md
+++ b/versioned_docs/version-3.1.x/concepts-messaging.md
@@ -1162,7 +1162,7 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
 
 :::
 

--- a/versioned_docs/version-3.1.x/concepts-messaging.md
+++ b/versioned_docs/version-3.1.x/concepts-messaging.md
@@ -1162,7 +1162,11 @@ A broker saves a message without any check. When a consumer consumes a message, 
 
 :::note
 
-In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed. After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+Work with retention policy: In Pulsar, the ledger will be deleted automatically after the messages in this ledger have been consumed. Pulsar will delete the front ledgers of a topic but will not delete ledgers from the middle of a topic. It means that if you send a message that is delayed for a long time, the message will not be consumed until it reaches the delay time. This means all the ledgers on this topic could not be deleted until the delayed message is consumed, even if some subsequent ledgers are fully consumed.
+
+Work with backlog quota policy: After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy. This is because delayed messages can result in not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.
+
+Work with backlog TTL policy: When the TTL expires, Pulsar automatically moves the message to the acknowledged state (and thus makes it ready for deletion) even if the messages are delayed messages and does not care about when the expected delayed time is.
 
 :::
 


### PR DESCRIPTION
After using delayed messages, it is advisable to exercise caution when using the Backlog Quota strategy.  This is because delayed messages can result in messages not being consumed for an extended period, triggering the Backlog Quota strategy and causing subsequent message sends to be rejected.

This PR fixes #xyz 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
