### PR TITLE
Fix examples that use cassandra docker container

### DIFF
--- a/contribute/validate-release-candidate.md
+++ b/contribute/validate-release-candidate.md
@@ -324,7 +324,7 @@ Make sure you have docker available at your laptop. If you haven't installed doc
 1. Set up a cassandra cluster.
 
 ```shell
-docker run -d --rm  --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm  --name=cassandra -p 9042:9042 cassandra:3.11
 ```
 
 Make sure that the cassandra cluster is running.

--- a/docs/io-quickstart.md
+++ b/docs/io-quickstart.md
@@ -124,7 +124,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 1. Start a Cassandra cluster.
 
    ```bash
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
    ```
 
    :::note

--- a/versioned_docs/version-2.10.x/io-quickstart.md
+++ b/versioned_docs/version-2.10.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.11.x/io-quickstart.md
+++ b/versioned_docs/version-2.11.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 1. Start a Cassandra cluster.
 
    ```bash
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
    ```
 
    :::note

--- a/versioned_docs/version-2.2.0/io-quickstart.md
+++ b/versioned_docs/version-2.2.0/io-quickstart.md
@@ -169,7 +169,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.2.1/io-quickstart.md
+++ b/versioned_docs/version-2.2.1/io-quickstart.md
@@ -169,7 +169,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.3.0/io-quickstart.md
+++ b/versioned_docs/version-2.3.0/io-quickstart.md
@@ -162,7 +162,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.3.1/io-quickstart.md
+++ b/versioned_docs/version-2.3.1/io-quickstart.md
@@ -162,7 +162,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.3.2/io-quickstart.md
+++ b/versioned_docs/version-2.3.2/io-quickstart.md
@@ -162,7 +162,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.4.0/io-quickstart.md
+++ b/versioned_docs/version-2.4.0/io-quickstart.md
@@ -116,7 +116,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.4.1/io-quickstart.md
+++ b/versioned_docs/version-2.4.1/io-quickstart.md
@@ -116,7 +116,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.4.2/io-quickstart.md
+++ b/versioned_docs/version-2.4.2/io-quickstart.md
@@ -116,7 +116,7 @@ We are using `cassandra` docker image to start a single-node cassandra cluster i
 
 ```bash
 
-docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
 ```
 

--- a/versioned_docs/version-2.5.0/io-quickstart.md
+++ b/versioned_docs/version-2.5.0/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.5.1/io-quickstart.md
+++ b/versioned_docs/version-2.5.1/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.5.2/io-quickstart.md
+++ b/versioned_docs/version-2.5.2/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.6.0/io-quickstart.md
+++ b/versioned_docs/version-2.6.0/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.6.1/io-quickstart.md
+++ b/versioned_docs/version-2.6.1/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.6.2/io-quickstart.md
+++ b/versioned_docs/version-2.6.2/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.6.3/io-quickstart.md
+++ b/versioned_docs/version-2.6.3/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.6.4/io-quickstart.md
+++ b/versioned_docs/version-2.6.4/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.0/io-quickstart.md
+++ b/versioned_docs/version-2.7.0/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.1/io-quickstart.md
+++ b/versioned_docs/version-2.7.1/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.2/io-quickstart.md
+++ b/versioned_docs/version-2.7.2/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.3/io-quickstart.md
+++ b/versioned_docs/version-2.7.3/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.4/io-quickstart.md
+++ b/versioned_docs/version-2.7.4/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.7.5/io-quickstart.md
+++ b/versioned_docs/version-2.7.5/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.8.x/io-quickstart.md
+++ b/versioned_docs/version-2.8.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-2.9.x/io-quickstart.md
+++ b/versioned_docs/version-2.9.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 
    ```bash
 
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
 
    ```
 

--- a/versioned_docs/version-3.0.x/io-quickstart.md
+++ b/versioned_docs/version-3.0.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 1. Start a Cassandra cluster.
 
    ```bash
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
    ```
 
    :::note

--- a/versioned_docs/version-3.1.x/io-quickstart.md
+++ b/versioned_docs/version-3.1.x/io-quickstart.md
@@ -121,7 +121,7 @@ This example uses `cassandra` Docker image to start a single-node Cassandra clus
 1. Start a Cassandra cluster.
 
    ```bash
-   docker run -d --rm --name=cassandra -p 9042:9042 cassandra
+   docker run -d --rm --name=cassandra -p 9042:9042 cassandra:3.11
    ```
 
    :::note


### PR DESCRIPTION
### Motivation

When validating 3.2.0 release, I noticed that the instructions no longer worked for the Cassandra connector steps. The problem was fixed by using `cassandra:3.11` container instead of `cassandra:latest`.

### Modifications

Update examples to use `cassandra:3.11` container.


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
