### PR TITLE
chore: update footer to fix the ASF's full name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -350,7 +350,7 @@ module.exports = {
       copyright: `
         <div>
           <img class="footer-apache-logo" src="/img/feather-logo-white.svg" alt="" width="20">
-          Apache Foundation
+          The Apache Software Foundation
         </div>
         <p>Apache Pulsar is available under the Apache License, version 2.0. Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud.</p>
         <p>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. All Rights Reserved. Apache, Pulsar, Apache Pulsar, and the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.</p>


### PR DESCRIPTION
I think the previous one is not correct.
<img width="254" alt="image" src="https://github.com/apache/pulsar-site/assets/24221472/9edae606-2dfd-4c4b-b9bc-ceb592ec4e31">

After:
<img width="309" alt="image" src="https://github.com/apache/pulsar-site/assets/24221472/45051acd-8848-4da9-9aa2-501b6563f43f">



<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
