### PR TITLE
Fix incorrect command to generate public key for end-to-end encryption

### DIFF
--- a/docs/security-encryption.md
+++ b/docs/security-encryption.md
@@ -69,7 +69,7 @@ To enable end-to-end encryption in Puslar, complete the following steps.
 
      ```shell
      openssl genrsa -out test_rsa_privkey.pem 2048
-     openssl rsa -in test_rsa_privkey.pem -outform PEM -pubout -out test_rsa_pubkey.pem
+     openssl rsa -in test_rsa_privkey.pem -pubout -outform PEM -out test_rsa_pubkey.pem
      ```
 
    </TabItem>

--- a/docs/security-encryption.md
+++ b/docs/security-encryption.md
@@ -69,7 +69,7 @@ To enable end-to-end encryption in Puslar, complete the following steps.
 
      ```shell
      openssl genrsa -out test_rsa_privkey.pem 2048
-     openssl rsa -in test_rsa_privkey.pem -pubout -outform pkcs8 -out test_rsa_pubkey.pem
+     openssl rsa -in test_rsa_privkey.pem -outform PEM -pubout -out test_rsa_pubkey.pem
      ```
 
    </TabItem>

--- a/versioned_docs/version-3.0.x/security-encryption.md
+++ b/versioned_docs/version-3.0.x/security-encryption.md
@@ -64,7 +64,7 @@ If the produced messages are consumed across application boundaries, you need to
 
      ```shell
      openssl genrsa -out test_rsa_privkey.pem 2048
-     openssl rsa -in test_rsa_privkey.pem -pubout -outform pkcs8 -out test_rsa_pubkey.pem
+     openssl rsa -in test_rsa_privkey.pem -pubout -outform PEM -out test_rsa_pubkey.pem
      ```
 
    </TabItem>

--- a/versioned_docs/version-3.1.x/security-encryption.md
+++ b/versioned_docs/version-3.1.x/security-encryption.md
@@ -64,7 +64,7 @@ If the produced messages are consumed across application boundaries, you need to
 
      ```shell
      openssl genrsa -out test_rsa_privkey.pem 2048
-     openssl rsa -in test_rsa_privkey.pem -pubout -outform pkcs8 -out test_rsa_pubkey.pem
+     openssl rsa -in test_rsa_privkey.pem -pubout -outform PEM -out test_rsa_pubkey.pem
      ```
 
    </TabItem>


### PR DESCRIPTION
The command in the document does not work for OpenSSL 1.1 or 3.2.

```bash
$ openssl rsa -in test_rsa_privkey.pem -pubout -outform pkcs8 -out test_rsa_pubkey.pem
rsa: Bad format "pkcs8"
rsa: Invalid format "pkcs8" for option -outform
rsa: Use -help for summary.
$ openssl --version
OpenSSL 3.2.0 23 Nov 2023 (Library: OpenSSL 3.2.0 23 Nov 2023)
$ /opt/homebrew/opt/openssl@1.1/bin/openssl rsa -in test_rsa_privkey.pem -pubout -outform pkcs8 -out test_rsa_pubkey2.pem
rsa: Invalid format "pkcs8" for -outform
rsa: Use -help for summary.
$ /opt/homebrew/opt/openssl@1.1/bin/openssl version
OpenSSL 1.1.1w  11 Sep 2023
```


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
