### PR TITLE
Open Case Studies links in new tab

### DIFF
--- a/src/components/pages/CaseStudiesPage/Cards/Cards.tsx
+++ b/src/components/pages/CaseStudiesPage/Cards/Cards.tsx
@@ -7,7 +7,12 @@ import SvgIcon from "@site/src/components/ui/SvgIcon/SvgIcon";
 const Card: React.FC<data.Resource> = (props) => {
   return (
     <div className={s.Card}>
-      <a className={s.CardImage} href={props.link} style={{ backgroundImage: `url(${props.image})`, ...props.extraStyles }}>
+      <a
+        target="_blank"
+        className={s.CardImage}
+        href={props.link}
+        style={{ backgroundImage: `url(${props.image})`, ...props.extraStyles }}
+      >
         <div className={s.LinkIcon}>
           <SvgIcon svg={linkIcon} />
         </div>


### PR DESCRIPTION
I made this change according to the approved design in Figma that adds external link icons to cards on the Case Studies page: https://pulsar.apache.org/case-studies/

<img width="875" alt="Screenshot 2024-02-28 at 9 30 04 PM" src="https://github.com/apache/pulsar-site/assets/9302460/3a247355-9fc1-4a56-a7e9-51b32bb38d55">
