### PR TITLE
Add the "I don't understand it" link

### DIFF
--- a/src/components/ui/ArticleThumb/ArticleThumb.js
+++ b/src/components/ui/ArticleThumb/ArticleThumb.js
@@ -51,8 +51,8 @@ const ArticleThumb = () => {
       </div>
       <a
         target='_blank'
-        className={s.RequestImprovementButton}
-        href="https://github.com/apache/pulsar/issues/new?assignees=&labels=doc-required&projects=&template=doc.yml&title=%5BDoc%5D+"
+        className={s.RequestHelpButton}
+        href="https://github.com/apache/pulsar/discussions/new?category=q-a"
       >
         🛟 I don't understand it
       </a>

--- a/src/components/ui/ArticleThumb/ArticleThumb.js
+++ b/src/components/ui/ArticleThumb/ArticleThumb.js
@@ -1,56 +1,63 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import ThumbDown from './thumbs-down.svg';
 import ThumbUp from './thumbs-up.svg';
+import s from './ArticleThumb.module.css';
 
 const ArticleThumb = () => {
-    const [activeKey, setActiveKey] = useState();
-    const handleThumbClick = (val) => {
-        if (!activeKey) {
-            setActiveKey(val)
-            if (window && (window._paq)) {
-                window._paq.push(['trackEvent', 'Website Feedback', val, location.pathname])
-            }
-        }
-    }
-
-    let card_style = {borderWidth: '1px', padding: '3px', display: 'flex'}
-    let thumb_style = {
-        justifyContent: 'center', display: 'flex', borderRadius: '99999px',
-        width: '2.5rem', height: '2.5rem',
-    }
+  const [activeKey, setActiveKey] = useState();
+  const handleThumbClick = (val) => {
     if (!activeKey) {
-        thumb_style['cursor'] = "pointer"
+      setActiveKey(val)
+      if (window && (window._paq)) {
+        window._paq.push(['trackEvent', 'Website Feedback', val, location.pathname])
+      }
     }
-    return (
-      <div className="border">
-        <div style={{ color: "var(--ifm-toc-link-color)" }}>
-          Was this helpful?
+  }
+
+  let card_style = { borderWidth: '1px', padding: '3px', display: 'flex' }
+  let thumb_style = {
+    justifyContent: 'center', display: 'flex', borderRadius: '99999px',
+    width: '2.5rem', height: '2.5rem',
+  }
+  if (!activeKey) {
+    thumb_style['cursor'] = "pointer"
+  }
+  return (
+    <div className="border">
+      <div style={{ color: "var(--ifm-toc-link-color)" }}>
+        Was this helpful?
+      </div>
+      <div style={card_style}>
+        <div
+          style={{
+            ...thumb_style,
+            background: activeKey === "up" ? "var(--text-color)" : "",
+            color: activeKey === "up" ? "#fff" : "",
+          }}
+          onClick={() => handleThumbClick("up")}
+        >
+          <ThumbUp />
         </div>
-        <div style={card_style}>
-          <div
-            style={{
-              ...thumb_style,
-              background: activeKey === "up" ? "var(--text-color)" : "",
-              color: activeKey === "up" ? "#fff" : "",
-            }}
-            onClick={() => handleThumbClick("up")}
-          >
-            <ThumbUp />
-          </div>
-          <div
-            style={{
-              ...thumb_style,
-              marginLeft: "30px",
-              background: activeKey === "down" ? "var(--text-color)" : "",
-              color: activeKey === "down" ? "#fff" : "",
-            }}
-            onClick={() => handleThumbClick("down")}
-          >
-            <ThumbDown />
-          </div>
+        <div
+          style={{
+            ...thumb_style,
+            background: activeKey === "down" ? "var(--text-color)" : "",
+            color: activeKey === "down" ? "#fff" : "",
+          }}
+          onClick={() => handleThumbClick("down")}
+        >
+          <ThumbDown />
         </div>
       </div>
-    );
+      <a
+        target='_blank'
+        className={s.RequestImprovementButton}
+        href="https://github.com/apache/pulsar/issues/new?assignees=&labels=doc-required&projects=&template=doc.yml&title=%5BDoc%5D+"
+      >
+        Request page improvement
+      </a>
+    </div>
+  );
 };
 
 

--- a/src/components/ui/ArticleThumb/ArticleThumb.js
+++ b/src/components/ui/ArticleThumb/ArticleThumb.js
@@ -54,7 +54,7 @@ const ArticleThumb = () => {
         className={s.RequestImprovementButton}
         href="https://github.com/apache/pulsar/issues/new?assignees=&labels=doc-required&projects=&template=doc.yml&title=%5BDoc%5D+"
       >
-        Request page improvement
+        🛟 I don't understand it
       </a>
     </div>
   );

--- a/src/components/ui/ArticleThumb/ArticleThumb.module.css
+++ b/src/components/ui/ArticleThumb/ArticleThumb.module.css
@@ -1,10 +1,10 @@
-.RequestImprovementButton {
+.RequestHelpButton {
   font-size: 0.875rem;
   text-decoration: none;
   display: inline-block;
   margin-left: 1rem;
 }
 
-.RequestImprovementButton:hover {
+.RequestHelpButton:hover {
   opacity: 0.5;
 }

--- a/src/components/ui/ArticleThumb/ArticleThumb.module.css
+++ b/src/components/ui/ArticleThumb/ArticleThumb.module.css
@@ -1,17 +1,10 @@
 .RequestImprovementButton {
   font-size: 0.875rem;
-  background: var(--color-primary);
-  color: #fff;
-  border-radius: 0.5rem;
-  padding: 0.25rem 1rem;
-  font-weight: 500;
   text-decoration: none;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  margin-left: 1rem;
 }
 
 .RequestImprovementButton:hover {
   opacity: 0.5;
-  text-decoration: none;
-  color: #fff;
 }

--- a/src/components/ui/ArticleThumb/ArticleThumb.module.css
+++ b/src/components/ui/ArticleThumb/ArticleThumb.module.css
@@ -1,0 +1,17 @@
+.RequestImprovementButton {
+  font-size: 0.875rem;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 0.5rem;
+  padding: 0.25rem 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+
+.RequestImprovementButton:hover {
+  opacity: 0.5;
+  text-decoration: none;
+  color: #fff;
+}

--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -19,6 +19,12 @@ div[class^="docPage"] .alert--secondary {
   --ifm-alert-border-color: var(--ifm-color-info-dark);
 }
 
+.menu__caret::before,
+.menu__link--sublist-caret:after {
+  content: '';
+  background-size: 1.4rem 1.4rem;
+}
+
 .pagination-nav__link {
   border-color: var(--border-color) !important;
 }


### PR DESCRIPTION
It's rather an idea.

<img width="1440" alt="Screenshot 2024-03-01 at 12 11 14 AM" src="https://github.com/apache/pulsar-site/assets/9302460/6931a885-b44e-4eac-bf88-4802abe2d392">

**Goals:**
- Allow users to quickly ask a question in the right place.
- Improve the documentation by encouraging users to report unclear or incomplete parts of the documentation.

Try it live: https://pulsar-site-2024-updates-7uwroc4qs-visortelle.vercel.app/docs/next/concepts-cluster-level-failover/

If there are too many questions, we can change the link to another Google-indexable place like https://github.com/apache/pulsar/discussions/categories/q-a

Alternatively, we could add more links to doc page's bottom section that encourages users to communicate with Pulsar developers and the community:

<img width="712" alt="Screenshot 2024-03-01 at 12 36 57 AM" src="https://github.com/apache/pulsar-site/assets/9302460/3e1a0f07-7eb8-471e-8316-b884303f2cf2">

https://docs.confluent.io/platform/current/clients/index.html