### PR TITLE
Add "Suggest changes" and "Get support" links

### DIFF
--- a/src/components/ui/ArticleThumb/ArticleThumb.js
+++ b/src/components/ui/ArticleThumb/ArticleThumb.js
@@ -49,13 +49,23 @@ const ArticleThumb = () => {
           <ThumbDown />
         </div>
       </div>
-      <a
-        target='_blank'
-        className={s.RequestHelpButton}
-        href="https://github.com/apache/pulsar/discussions/new?category=q-a"
-      >
-        🛟 I don't understand it
-      </a>
+
+      <div className={s.Actions}>
+        <a
+          target='_blank'
+          className={s.Action}
+          href="https://github.com/apache/pulsar/issues/new?assignees=&labels=doc-required&projects=&template=doc.yml&title=%5BDoc%5D+"
+        >
+          💡 Suggest changes
+        </a>
+        <a
+          target='_blank'
+          className={s.Action}
+          href="https://github.com/apache/pulsar/discussions/new?category=q-a"
+        >
+          🛟 Get support
+        </a>
+      </div>
     </div>
   );
 };

--- a/src/components/ui/ArticleThumb/ArticleThumb.module.css
+++ b/src/components/ui/ArticleThumb/ArticleThumb.module.css
@@ -1,10 +1,16 @@
-.RequestHelpButton {
+.Actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.Action {
   font-size: 0.875rem;
   text-decoration: none;
-  display: inline-block;
+  display: block;
   margin-left: 1rem;
 }
 
-.RequestHelpButton:hover {
+.Action:hover {
   opacity: 0.5;
 }


### PR DESCRIPTION
A variation of this PR: https://github.com/apache/pulsar-site/pull/807

<img width="448" alt="Screenshot 2024-03-01 at 12 49 23 PM" src="https://github.com/apache/pulsar-site/assets/9302460/34ffcce2-f73d-4020-bc5d-41acc0d395c6">

Suggest changes -> new GitHub issue with the "Document" template
Get Support -> new GitHub discussion in Q&A section
