### PR TITLE
Add case studies link at the top of the home page

### DIFF
--- a/contribute/site-intro.md
+++ b/contribute/site-intro.md
@@ -77,38 +77,35 @@ If you're gonna to debug the reference generation process, read the [reference-d
 
 ### How to update data-driven pages?
 
-The following pages contain data-driven tables:
+You can update it by clicking on one of the **✍️ Edit <file_name>** links below and submitting a Pull Request.
 
-* [Case studies](pathname:///case-studies)
-  * data/users.js
-  * src/pages/case-studies.js
-* [Downloads](pathname:///download)
-  * releases.json
-  * data/connectors.js
-  * data/release-cpp.js
-  * data/release-pulsar-manager.js
-  * data/release-pulsar-adapters.js
-  * src/components/download.tsx
-  * src/pages/download.mdx
-* [Ecosystem](pathname:///ecosystem)
-  * data/ecosystem.js
-  * src/pages/ecosystem.js
-* [Events](pathname:///events)
-  * data/events.js
-  * src/pages/events.js
-* [Release notes](pathname:///release-notes)
+* **Case Studies** [/case-studies](pathname:///case-studies)
+  * [✍️ Edit case-studies.ts](https://github.com/apache/pulsar-site/edit/main/data/case-studies.ts)
+* **Powered by** [/powered-by](pathname:///powered-by)
+  * [✍️ Edit powered-by.ts](https://github.com/apache/pulsar-site/edit/main/data/powered-by.ts)
+* **Ecosystem** [/ecosystem](pathname:///ecosystem)
+  * [✍️ Edit ecosystem.ts](https://github.com/apache/pulsar-site/edit/main/data/ecosystem.ts)
+* **Events** [/events](pathname:///events)
+  * [✍️ Edit events.ts](https://github.com/apache/pulsar-site/edit/main/data/events.ts)
+* **Resources** [/resources](pathname:///resources)
+  * [✍️ Edit resources.ts](https://github.com/apache/pulsar-site/edit/main/data/resources.ts)
+* **Team** [/team](pathname:///team)
+  * [✍️ Edit team.js](https://github.com/apache/pulsar-site/edit/main/data/team.js)
+
+    PMC members can generate the `team.js` file as [lhotari](https://github.com/lhotari) did in https://github.com/apache/pulsar-site/pull/387.
+* **Downloads** [/downloads](pathname:///download)
+  * [✍️ Edit releases.json](https://github.com/apache/pulsar-site/edit/main/releases.json)
+  * [✍️ Edit connectors.js](https://github.com/apache/pulsar-site/edit/main/data/connectors.js)
+  * [✍️ Edit release-cpp.js](https://github.com/apache/pulsar-site/edit/main/data/release-cpp.js)
+  * [✍️ Edit release-pulsar-manager.js](https://github.com/apache/pulsar-site/edit/main/data/release-pulsar-manager.js)
+  * [✍️ Edit release-pulsar-adapters.js](https://github.com/apache/pulsar-site/edit/main/data/release-pulsar-adapters.js)
+  * [✍️ Edit download.tsx](https://github.com/apache/pulsar-site/edit/main/src/components/download.tsx)
+  * [✍️ Edit download.mdx](https://github.com/apache/pulsar-site/edit/main/src/pages/download.mdx)
+* **Release notes** [/release-notes](pathname:///release-notes)
   * data/release-*.js
   * release-notes/
   * src/components/ClientReleaseTable.js
   * src/components/PulsarReleaseTable.js
-* [Resources](pathname:///resources)
-  * data/resources.js
-  * src/pages/resources.js
-* [Team](pathname:///team)
-  * data/team.js
-  * src/pages/team.js
-* [Client feature matrix](pathname:///client-feature-matrix)
-  * data/matrix.js
-  * client-feature-matrix/index.mdx
-
-Additionally, PMC members can generate the `team.js` file as @lhotari did in https://github.com/apache/pulsar-site/pull/387.
+* **Client feature matrix** [/client-feature-matrix](pathname:///client-feature-matrix)
+  * [✍️ Edit matrix.js](https://github.com/apache/pulsar-site/edit/main/data/matrix.js)
+  * [✍️ Edit client-feature-matrix/index.mdx](https://github.com/apache/pulsar-site/edit/main/client-feature-matrix/index.mdx)

--- a/data/powered-by.ts
+++ b/data/powered-by.ts
@@ -1,11 +1,11 @@
-type Users = {
+type PoweredByUser = {
   name: string,
   url: string,
-  logo: string,
+  logo?: string,
   logo_white?: boolean,
 }
 
-const users: Users[] = [
+const users: PoweredByUser[] = [
   {
     name: "Kingsoft Cloud",
     url: "https://www.ksyun.com/",

--- a/src/components/pages/CaseStudiesPage/CaseStudiesPage.tsx
+++ b/src/components/pages/CaseStudiesPage/CaseStudiesPage.tsx
@@ -6,6 +6,7 @@ import Input from "@site/src/components/ui/Input/Input";
 import Select from "@site/src/components/ui/Select/Select";
 import Page from "@site/src/components/ui/Page/Page";
 import s from './CaseStudiesPage.module.css';
+import ContributeDataDrivenPage from "../../ui/ContributeDataDrivenPage/ContributeDataDrivenPage";
 
 type CategoryFilterOption = data.Category | 'any';
 const categoryFilterOptions = ['any', ...data.categories] as const;
@@ -23,6 +24,8 @@ const CaseStudiesPage: React.FC = () => {
         <section className={s.Header}>
           <h1 style={{ color: 'var(--color-primary-dark)', marginBottom: '0'}}>Case Studies</h1>
           <p>Organizations around the globe rely on Apache Pulsar to manage their most demanding real-time requirements.</p>
+
+          <ContributeDataDrivenPage />
         </section>
 
         <section>

--- a/src/components/pages/EcosystemPage/EcosystemPage.tsx
+++ b/src/components/pages/EcosystemPage/EcosystemPage.tsx
@@ -6,6 +6,7 @@ import Input from "@site/src/components/ui/Input/Input";
 import Select from "@site/src/components/ui/Select/Select";
 import Page from "@site/src/components/ui/Page/Page";
 import s from './EcosystemPage.module.css';
+import ContributeDataDrivenPage from "../../ui/ContributeDataDrivenPage/ContributeDataDrivenPage";
 
 type CategoryFilterOption = data.Category | 'any';
 const categoryFilterOptions = ['any', ...data.categories] as const;
@@ -24,6 +25,7 @@ const EcosystemPage: React.FC = () => {
           <h1>Ecosystem</h1>
           <p>To build better streaming data pipelines and event-driven applications, you can use the powerful extensions to Pulsar, including <a href="/docs/next/io-overview">connectors</a>, protocol handlers, tools, and more. Additionally, you can develop applications using <a href="/docs/next/client-libraries">client libraries</a>.</p>
           <p>This page lists both built-in and third-party tools. Note that some of the third-party tools were not tested throughly by the community, and may not work as expected. Only open source components with an <a href="https://opensource.org/licenses">OSI&nbsp;approved licenses</a> are allowed. </p>
+          <ContributeDataDrivenPage />
         </section>
 
         <section>

--- a/src/components/pages/EventsPage/EventsPage.tsx
+++ b/src/components/pages/EventsPage/EventsPage.tsx
@@ -6,6 +6,7 @@ import Page from "@site/src/components/ui/Page/Page";
 import s from './EventsPage.module.css';
 import Button from "@site/src/components/ui/Button/Button";
 import FeaturedEvent from "./FeaturedEvent/FeaturedEvent";
+import ContributeDataDrivenPage from "../../ui/ContributeDataDrivenPage/ContributeDataDrivenPage";
 
 type CategoryFilterOption = data.Category;
 
@@ -24,8 +25,8 @@ const CaseStudiesPage: React.FC = () => {
             <p>
               Below is a list of key industry events hosted by Pulsar contributors,
               as well as local meetups around the globe.
-              If you have one to add, learn more about submitting a pull request <a target="_blank" href="https://github.com/apache/pulsar/pulls">here</a>.
             </p>
+            <ContributeDataDrivenPage />
           </section>
 
           <div className={s.FeaturedEvent}>

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.module.css
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.module.css
@@ -44,6 +44,21 @@
   line-height: 3rem;
 }
 
+.case_studies {
+  line-height: 1.4;
+  margin-top: 2rem;
+  margin-right: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--text-color);
+  border-radius: 1rem;
+  backdrop-filter: blur(20px);
+  color: var(--text-color);
+}
+
+.case_studies:hover {
+  color: var(--text-color);
+}
+
 @keyframes scroll {
   0% {
     transform: translateY(-50%);

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
@@ -19,7 +19,7 @@ const ShortInfo: React.FC = () => {
         <Parallax>
           <div className={s.docs_container}>
             <h1 className={s.header}>
-              <span className={s.title}>Apache Pulsar™</span><br/>
+              <span className={s.title}>Apache Pulsar™</span><br />
               <span className={s.subtitle}>Cloud-Native, Distributed Messaging and Streaming</span>
             </h1>
             <span className={s.text}>Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud. </span>
@@ -36,6 +36,12 @@ const ShortInfo: React.FC = () => {
                 href={`${siteConfig.baseUrl}docs/${latestVersion}/concepts-overview`}
               />
             </div>
+
+            <p className={s.case_studies}>
+              Pulsar is proven at scale by <strong>Yahoo!</strong>, <strong>Discord</strong>, <strong>Cisco</strong>, <strong>Intuit</strong>, <strong>Tencent</strong>, and many other companies.
+              <br />
+              <a href="/case-studies">See the list</a>
+            </p>
           </div>
         </Parallax>
       </div>

--- a/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
+++ b/src/components/pages/HomePage/ShortInfo/ShortInfo.tsx
@@ -38,9 +38,9 @@ const ShortInfo: React.FC = () => {
             </div>
 
             <p className={s.case_studies}>
-              Pulsar is proven at scale by <strong>Yahoo!</strong>, <strong>Discord</strong>, <strong>Cisco</strong>, <strong>Intuit</strong>, <strong>Tencent</strong>, and many other companies.
+              Pulsar is proven at scale by hundreds of companies of different sizes, serving millions of messages per second.
               <br />
-              <a href="/case-studies">See the list</a>
+              <a href="/case-studies">See case studies</a>
             </p>
           </div>
         </Parallax>

--- a/src/components/pages/PoweredByPage/PoweredByPage.tsx
+++ b/src/components/pages/PoweredByPage/PoweredByPage.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 
 import Layout from "@theme/Layout";
 import Translate from "@docusaurus/Translate";
-import users from "../../../../data/users";
+import users from "../../../../data/powered-by";
 
 import s from './PoweredByPage.module.css';
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import ContributeDataDrivenPage from "../../ui/ContributeDataDrivenPage/ContributeDataDrivenPage";
 
 const PoweredByPage = () => {
   return (
@@ -18,6 +19,7 @@ const PoweredByPage = () => {
                 Companies using or contributing to Apache Pulsar
               </Translate>
             </h2>
+            <ContributeDataDrivenPage />
             <hr />
           </header>
 

--- a/src/components/pages/ResourcesPage/ResourcesPage.tsx
+++ b/src/components/pages/ResourcesPage/ResourcesPage.tsx
@@ -6,6 +6,7 @@ import Page from "@site/src/components/ui/Page/Page";
 import s from './ResourcesPage.module.css';
 import Button from "@site/src/components/ui/Button/Button";
 import Input from "@site/src/components/ui/Input/Input";
+import ContributeDataDrivenPage from "../../ui/ContributeDataDrivenPage/ContributeDataDrivenPage";
 
 const categoryFilterOptions = [...data.categories] as const;
 
@@ -25,6 +26,7 @@ const CaseStudiesPage: React.FC = () => {
             <p>
               Find Apache Pulsar tutorials, how-tos and other technical content by searching with keywords.
             </p>
+            <ContributeDataDrivenPage />
           </section>
         </div>
 

--- a/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.module.css
+++ b/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.module.css
@@ -1,0 +1,13 @@
+.ContributeDataDrivenPage {
+  background-color: var(--text-color);
+  border-radius: 0.5rem;
+  color: #fff;
+  padding: 0.25rem 1rem;
+  font-size: 14px;
+  display: inline-block;
+}
+
+.ContributeDataDrivenPage:hover {
+  color: #fff;
+  text-decoration: underline;
+}

--- a/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.tsx
+++ b/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import s from './ContributeDataDrivenPage.module.css'
+
+const ContributeDataDrivenPage: React.FC = () => {
+  return (
+    <a className={s.ContributeDataDrivenPage} href="/contribute/site-intro/#how-to-update-data-driven-pages">
+      <strong>Are we missing any?</strong> Please contribute updates by clicking here and following the instructions
+    </a>
+  );
+}
+
+export default ContributeDataDrivenPage;

--- a/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.tsx
+++ b/src/components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage.tsx
@@ -4,7 +4,7 @@ import s from './ContributeDataDrivenPage.module.css'
 const ContributeDataDrivenPage: React.FC = () => {
   return (
     <a className={s.ContributeDataDrivenPage} href="/contribute/site-intro/#how-to-update-data-driven-pages">
-      <strong>Are we missing any?</strong> Please contribute updates by clicking here and following the instructions
+      <strong>Are we missing any?</strong> Click here to contribute
     </a>
   );
 }

--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -1,8 +1,7 @@
 import * as React from "react";
 import Layout from "@theme/Layout";
 import TeamTable from "../components/pages/CommunityPage/TeamTable";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import Translate, { translate } from "@docusaurus/Translate";
+import ContributeDataDrivenPage from '../components/ui/ContributeDataDrivenPage/ContributeDataDrivenPage';
 import team from "../../data/team";
 
 export default function page(props) {
@@ -33,6 +32,10 @@ export default function page(props) {
               project is unbounded. Get involved today. All contributions to the
               project are greatly appreciated.
             </translate>
+          </p>
+
+          <p>
+            <ContributeDataDrivenPage />
           </p>
 
           <h2>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 import compareVersions from 'compare-versions';
 
-import users from '../../data/users';
+import users from '../../data/powered-by';
 // const featuredUsers = users.filter((x) => x.hasOwnProperty("featured"));
 // featuredUsers.sort((a, b) => (a.featured > b.featured ? 1 : -1));
 import versions from '../../versions.json';


### PR DESCRIPTION
The "Case Studies" section is currently placed at the bottom of the home page.

I think it's good for the project to show that many companies use Pulsar at the very beginning of the page.

This PR adds this block to the first homepage screen.

Live demo: https://pulsar-site-2024-updates-git-case-studies-at-top-visortelle.vercel.app/

<img width="1440" alt="Screenshot 2024-03-01 at 2 58 42 PM" src="https://github.com/apache/pulsar-site/assets/9302460/b719405d-06d6-45ed-9e61-af87061ccd90">

I'm not sure if is it allowed to mention specific companies. We can somehow rephrase the text if not.

- Apache Pinot has such a block that mentions LinkedIn on the homepage.

<img width="777" alt="Screenshot 2024-03-01 at 2 59 53 PM" src="https://github.com/apache/pulsar-site/assets/9302460/636f9abd-6ac9-4e8b-8e83-566d20355187">

- Apache Kafka has it at the top of its homepage.

<img width="828" alt="Screenshot 2024-03-01 at 3 00 56 PM" src="https://github.com/apache/pulsar-site/assets/9302460/c003af34-c149-46db-9bdd-8d3f70b84f53">

cc: @dave2wave @lhotari 
