### PR TITLE
[fix][doc] Highlights that Pulsar clients can seamlessly access data in offloaded ledgers.

### DIFF
--- a/docs/tiered-storage-overview.md
+++ b/docs/tiered-storage-overview.md
@@ -83,6 +83,6 @@ Tiered storage works as follows:
 
 5. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-6. After offloading ledgers to long-term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/docs/tiered-storage-overview.md
+++ b/docs/tiered-storage-overview.md
@@ -83,6 +83,6 @@ Tiered storage works as follows:
 
 5. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
+6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval.
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-2.11.x/tiered-storage-overview.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After offloading ledgers to long-term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-2.11.x/tiered-storage-overview.md
+++ b/versioned_docs/version-2.11.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL.
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.0.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.0.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After offloading ledgers to long-term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.0.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.0.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL.
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.1.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.1.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After offloading ledgers to long-term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.1.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.1.x/tiered-storage-overview.md
@@ -68,6 +68,6 @@ Data written to BookKeeper is replicated to 3 physical machines by default. Howe
 
 Before offloading ledgers to long-term storage, you need to configure buckets, credentials, and other properties for the cloud storage service. Additionally, Pulsar uses multi-part objects to upload the segment data and brokers may crash while uploading the data. It is recommended that you add a life cycle rule for your bucket to expire incomplete multi-part upload after a day or two days to avoid getting charged for incomplete uploads. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
+After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL.
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.2.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.2.x/tiered-storage-overview.md
@@ -83,6 +83,6 @@ Tiered storage works as follows:
 
 5. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-6. After offloading ledgers to long-term storage, you can still query data in the offloaded ledgers with Pulsar SQL.
+6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).

--- a/versioned_docs/version-3.2.x/tiered-storage-overview.md
+++ b/versioned_docs/version-3.2.x/tiered-storage-overview.md
@@ -83,6 +83,6 @@ Tiered storage works as follows:
 
 5. Moreover, you can trigger the offloading operation manually (via REST API or CLI) or automatically (via CLI).
 
-6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval. Additionally, you can query data in the offloaded ledgers using Pulsar SQL..
+6. After transferring ledgers to long-term storage, the messages within these ledgers remain accessible to Pulsar consumers and readers, ensuring transparency in data retrieval.
 
 For more information about tiered storage for Pulsar topics, see [PIP-17](https://github.com/apache/pulsar/wiki/PIP-17:-Tiered-storage-for-Pulsar-topics) and [offload metrics](reference-metrics.md#offload-metrics).


### PR DESCRIPTION
This PR emphasizes that Pulsar clients can still transparently read the data in the offloaded ledgers.
This should remove possible confusion, [as seen here](https://github.com/apache/pulsar/discussions/22113).