### PR TITLE
[improve][doc] Dedup section needs to remark that producer name is a requirement

### DIFF
--- a/docs/cookbooks-deduplication.md
+++ b/docs/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages)
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages).
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.

--- a/docs/cookbooks-deduplication.md
+++ b/docs/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer.
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages)
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.

--- a/versioned_docs/version-2.11.x/cookbooks-deduplication.md
+++ b/versioned_docs/version-2.11.x/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer.
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages).
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.

--- a/versioned_docs/version-3.0.x/cookbooks-deduplication.md
+++ b/versioned_docs/version-3.0.x/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer.
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages).
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.

--- a/versioned_docs/version-3.1.x/cookbooks-deduplication.md
+++ b/versioned_docs/version-3.1.x/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer.
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages).
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.

--- a/versioned_docs/version-3.2.x/cookbooks-deduplication.md
+++ b/versioned_docs/version-3.2.x/cookbooks-deduplication.md
@@ -73,7 +73,7 @@ If you enable message deduplication in Pulsar brokers, namespaces, or topics, it
 
 So you need to complete the following tasks for your client producers:
 
-1. Specify a name for the producer.
+1. Specify a name for the producer (this is a requirement, Pulsar will use the producer name to filter duplicated messages).
 1. Set the message timeout to `0` (namely, no timeout).
 
 The instructions for Java, Python, and C++ clients are different.


### PR DESCRIPTION
The explanation doesn't remark this is a requirement as mentioned in the design:

https://github.com/apache/pulsar/wiki/PIP-6%3A-Guaranteed-Message-Deduplication#design

<!--

### Contribution Checklist

  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

-->
<!-- or fixes a doc issue -->

This PR fixes [apache/pulsar#22210](https://github.com/apache/pulsar/issues/22210)
