### PR TITLE
Add notice about supported versions of Pulsar on the release policy page

### DIFF
--- a/contribute/release-policy.md
+++ b/contribute/release-policy.md
@@ -3,6 +3,16 @@ id: release-policy
 title: Release policy
 ---
 
+## Supported Versions
+
+Please plan your Pulsar deployment updates according to the dates provided below. However, note that the Apache Pulsar project may provide ad hoc releases for some older patch versions, depending on resource availability, time constraints, or the severity of an issue, such as a significant CVE. These releases would be provided on a 'best-effort' basis. For supported versions, the Apache Pulsar project follows the [Security policy](/security).
+
+````mdx-code-block
+import SupportedVersionsTable from "@site/src/components/SupportedVersionsTable";
+
+<SupportedVersionsTable />
+````
+
 ## Release semantics
 
 The Pulsar project follows a variant of Semantic Versioning (semver), which replacing `major.minor.patch` with `LTS.feature.patch`.
@@ -50,14 +60,6 @@ This can be translated into:
 * Security patches are provided for the past 3 LTS releases and 2 feature releases
 
 Therefore, users can choose between stay in an LTS release until they are ready to jump into the next LTS, or try the latest releases which contains required features.
-
-## Supported Versions
-
-````mdx-code-block
-import SupportedVersionsTable from "@site/src/components/SupportedVersionsTable";
-
-<SupportedVersionsTable />
-````
 
 ## Release cycles
 


### PR DESCRIPTION
- added notice, as per discussion on the mailing list, https://lists.apache.org/thread/y6ct7446d3d91w0ph7pqrk54xy6p1pq6
- moved the supported versions to the beginning of the page