### PR TITLE
Show supported versions on download page

### DIFF
--- a/src/components/SupportedVersionsTable.tsx
+++ b/src/components/SupportedVersionsTable.tsx
@@ -1,5 +1,5 @@
 import lodash from 'lodash'
-import React from 'react'
+import React, { FC } from 'react'
 import semver from "semver/preload"
 import {Stack, Table, TableBody, TableCell, TableHead, TableRow} from "@mui/material"
 
@@ -116,7 +116,11 @@ function renderLatestVersionCell(d: SupportedVersionData): JSX.Element {
   </TableCell>
 }
 
-export default function SupportedVersionsTable(): JSX.Element {
+type SupportedVersionsTableProps = {
+  isHideUnmaintained?: boolean
+};
+
+const SupportedVersionsTable: FC<SupportedVersionsTableProps> = (props) => {
   let releaseList: SimpleReleaseData[] = releases.map(r => ({
     version: semver.coerce(r.tagName),
     released: moment(r.publishedAt),
@@ -147,6 +151,13 @@ export default function SupportedVersionsTable(): JSX.Element {
     })
   }
 
+  if (props.isHideUnmaintained) {
+    supportedVersionList = supportedVersionList.filter(v =>
+      v.activeSupport.isAfter(new Date()) ||
+      v.securitySupport.isAfter(new Date())
+    );
+  }
+
   const TableHeaderCell = styled(TableCell)({fontWeight: "bold"})
 
   return <>
@@ -162,8 +173,8 @@ export default function SupportedVersionsTable(): JSX.Element {
       </TableHead>
       <TableBody>
         {
-          supportedVersionList.map(r => <>
-            <TableRow>
+          supportedVersionList.map((r, i) => <>
+            <TableRow key={i}>
               {renderVersionCell(r.version)}
               {renderReleasedCell(r.released)}
               {renderSupportCell(r.activeSupport)}
@@ -176,3 +187,5 @@ export default function SupportedVersionsTable(): JSX.Element {
     </Table>
   </>
 }
+
+export default SupportedVersionsTable;

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -28,7 +28,14 @@ import Page from '@site/src/components/ui/Page/Page';
 
 ## Release notes
 
-[Release notes](pathname:///release-notes) for all Pulsar's versions.
+````mdx-code-block
+import SupportedVersionsTable from "@site/src/components/SupportedVersionsTable";
+
+<SupportedVersionsTable isHideUnmaintained />
+````
+
+- [All Release notes](pathname:///release-notes)
+- [Full Supported Versions Table](pathname:///release-notes)
 
 ## Current version <CurrentPulsarVersion/>
 

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -26,7 +26,7 @@ import Page from '@site/src/components/ui/Page/Page';
 
 # Downloads for Apache Pulsar™
 
-## Release notes
+## Supported Versions
 
 ````mdx-code-block
 import SupportedVersionsTable from "@site/src/components/SupportedVersionsTable";
@@ -34,7 +34,7 @@ import SupportedVersionsTable from "@site/src/components/SupportedVersionsTable"
 <SupportedVersionsTable isHideUnmaintained />
 ````
 
-- [All Release notes](pathname:///release-notes)
+- [Release notes](pathname:///release-notes)
 - [Full Supported Versions Table](pathname:///release-notes)
 
 ## Current version <CurrentPulsarVersion/>


### PR DESCRIPTION
It probably makes sense to place the release schedule and supported versions in a more visible place to regular users.

Now users should perform the following trip to get this info: Download -> Release Notes -> Release Policy

The Release Policy page is on the `/contribute/release-policy/` route, but it's unlikely that most of the users are contributors.

Also, there is no way to figure out which version is LTS from the `/download` page.

### Proposed Solution

- Show supported versions on the `/download` page

<img width="1440" alt="Screenshot 2024-03-14 at 11 16 38 PM" src="https://github.com/apache/pulsar-site/assets/9302460/120aa4aa-c263-4325-80ca-64a2b5d00499">

---

Show all versions on the `/contribute/release-policy` (no changes here)

<img width="1433" alt="Screenshot 2024-03-14 at 11 01 11 PM" src="https://github.com/apache/pulsar-site/assets/9302460/14424687-eee5-4b66-bdd3-71ab28a26ed4">
