### PR TITLE
Add GitHub user ids for committers and PMC members to team.js

### DIFF
--- a/data/team.js
+++ b/data/team.js
@@ -486,7 +486,9 @@ module.exports = {
     {
       "name": "Kiryl Valkovich",
       "apacheId": "visortelle",
-      "githubUsername": []
+      "githubUsername": [
+        "visortelle"
+      ]
     },
     {
       "name": "Vineeth Polamreddy",

--- a/data/team.js
+++ b/data/team.js
@@ -2,333 +2,559 @@ module.exports = {
   "pmc": [
     {
       "name": "Sahaya Andrews",
-      "apacheId": "andrews"
+      "apacheId": "andrews",
+      "githubUsername": [
+        "saandrews"
+      ]
     },
     {
       "name": "Daniel Blankensteiner",
-      "apacheId": "blankensteiner"
+      "apacheId": "blankensteiner",
+      "githubUsername": [
+        "blankensteiner"
+      ]
     },
     {
       "name": "Bo Cong",
-      "apacheId": "bogong"
+      "apacheId": "bogong",
+      "githubUsername": [
+        "congbobo184"
+      ]
     },
     {
       "name": "Brad McMillen",
-      "apacheId": "bradtm"
+      "apacheId": "bradtm",
+      "githubUsername": []
     },
     {
       "name": "Hang Chen",
-      "apacheId": "chenhang"
+      "apacheId": "chenhang",
+      "githubUsername": [
+        "hangc0276"
+      ]
     },
     {
       "name": "David Jensen",
-      "apacheId": "djensen"
+      "apacheId": "djensen",
+      "githubUsername": []
     },
     {
       "name": "Enrico Olivelli",
-      "apacheId": "eolivelli"
+      "apacheId": "eolivelli",
+      "githubUsername": [
+        "eolivelli"
+      ]
     },
     {
       "name": "Jennifer Huang",
-      "apacheId": "hjf"
+      "apacheId": "hjf",
+      "githubUsername": [
+        "jennifer88huang",
+        "Jennifer88huang-zz"
+      ]
     },
     {
       "name": "Hiroyuki Sakai",
-      "apacheId": "hrsakai"
+      "apacheId": "hrsakai",
+      "githubUsername": [
+        "hrsakai"
+      ]
     },
     {
       "name": "Ivan Brendan Kelly",
-      "apacheId": "ivank"
+      "apacheId": "ivank",
+      "githubUsername": [
+        "ivankelly"
+      ]
     },
     {
       "name": "Jai Asher",
-      "apacheId": "jai1"
+      "apacheId": "jai1",
+      "githubUsername": [
+        "jai1"
+      ]
     },
     {
       "name": "Boyang Jerry Peng",
-      "apacheId": "jerrypeng"
+      "apacheId": "jerrypeng",
+      "githubUsername": [
+        "jerrypeng"
+      ]
     },
     {
       "name": "Haiting Jiang",
-      "apacheId": "jianghaiting"
+      "apacheId": "jianghaiting",
+      "githubUsername": [
+        "Jason918"
+      ]
     },
     {
       "name": "Jim Jagielski",
-      "apacheId": "jim"
+      "apacheId": "jim",
+      "githubUsername": [
+        "jimjag"
+      ]
     },
     {
       "name": "Joe Francis",
-      "apacheId": "joef"
+      "apacheId": "joef",
+      "githubUsername": [
+        "joefk"
+      ]
     },
     {
       "name": "Lari Hotari",
-      "apacheId": "lhotari"
+      "apacheId": "lhotari",
+      "githubUsername": [
+        "lhotari"
+      ]
     },
     {
       "name": "Lin Lin",
-      "apacheId": "linlin"
+      "apacheId": "linlin",
+      "githubUsername": [
+        "315157973"
+      ]
     },
     {
       "name": "Liu Yu",
-      "apacheId": "liuyu"
+      "apacheId": "liuyu",
+      "githubUsername": [
+        "Anonymitaet"
+      ]
     },
     {
       "name": "Ludwig Pummer",
-      "apacheId": "ludwigp"
+      "apacheId": "ludwigp",
+      "githubUsername": []
     },
     {
       "name": "Masakazu Kitajo",
-      "apacheId": "maskit"
+      "apacheId": "maskit",
+      "githubUsername": [
+        "maskit"
+      ]
     },
     {
       "name": "Masahiro Sakamoto",
-      "apacheId": "massakam"
+      "apacheId": "massakam",
+      "githubUsername": [
+        "massakam"
+      ]
     },
     {
       "name": "Qiang Zhao",
-      "apacheId": "mattisonchao"
+      "apacheId": "mattisonchao",
+      "githubUsername": [
+        "mattisonchao"
+      ]
     },
     {
       "name": "Michael Marshall",
-      "apacheId": "mmarshall"
+      "apacheId": "mmarshall",
+      "githubUsername": [
+        "michaeljmarshall"
+      ]
     },
     {
       "name": "Matteo Merli",
-      "apacheId": "mmerli"
+      "apacheId": "mmerli",
+      "githubUsername": [
+        "merlimat"
+      ]
     },
     {
       "name": "Nicolò Boschi",
-      "apacheId": "nicoloboschi"
+      "apacheId": "nicoloboschi",
+      "githubUsername": [
+        "nicoloboschi"
+      ]
     },
     {
       "name": "Nozomi Kurihara",
-      "apacheId": "nkurihar"
+      "apacheId": "nkurihar",
+      "githubUsername": [
+        "nkurihar"
+      ]
     },
     {
       "name": "Penghui Li",
-      "apacheId": "penghui"
+      "apacheId": "penghui",
+      "githubUsername": [
+        "codelipenghui"
+      ]
     },
     {
       "name": "P. Taylor Goetz",
-      "apacheId": "ptgoetz"
+      "apacheId": "ptgoetz",
+      "githubUsername": [
+        "ptgoetz"
+      ]
     },
     {
       "name": "Rajan Dhabalia",
-      "apacheId": "rdhabalia"
+      "apacheId": "rdhabalia",
+      "githubUsername": [
+        "rdhabalia"
+      ]
     },
     {
       "name": "Sanjeev Kulkarni",
-      "apacheId": "sanjeevrk"
+      "apacheId": "sanjeevrk",
+      "githubUsername": [
+        "srkukarni"
+      ]
     },
     {
       "name": "Siddharth Boobna",
-      "apacheId": "sboobna"
+      "apacheId": "sboobna",
+      "githubUsername": [
+        "sboobna"
+      ]
     },
     {
       "name": "Sijie Guo",
-      "apacheId": "sijie"
+      "apacheId": "sijie",
+      "githubUsername": [
+        "sijie"
+      ]
     },
     {
       "name": "Sebastián Schepens",
-      "apacheId": "sschepens"
+      "apacheId": "sschepens",
+      "githubUsername": [
+        "sschepens"
+      ]
     },
     {
       "name": "Guo Jiwei",
-      "apacheId": "technoboy"
+      "apacheId": "technoboy",
+      "githubUsername": [
+        "Technoboy-"
+      ]
     },
     {
       "name": "Zili Chen",
-      "apacheId": "tison"
+      "apacheId": "tison",
+      "githubUsername": [
+        "tisonkun"
+      ]
     },
     {
       "name": "Francis Christopher Liu",
-      "apacheId": "toffer"
+      "apacheId": "toffer",
+      "githubUsername": [
+        "francisliu"
+      ]
     },
     {
       "name": "David Fisher",
-      "apacheId": "wave"
+      "apacheId": "wave",
+      "githubUsername": [
+        "dave2wave"
+      ]
     },
     {
       "name": "Yunze Xu",
-      "apacheId": "xyz"
+      "apacheId": "xyz",
+      "githubUsername": [
+        "BewareMyPower"
+      ]
     },
     {
       "name": "Yubiao Feng",
-      "apacheId": "yubiao"
+      "apacheId": "yubiao",
+      "githubUsername": []
     },
     {
       "name": "Yuki Shiga",
-      "apacheId": "yushiga"
+      "apacheId": "yushiga",
+      "githubUsername": [
+        "yush1ga"
+      ]
     },
     {
       "name": "Jia Zhai",
-      "apacheId": "zhaijia"
+      "apacheId": "zhaijia",
+      "githubUsername": [
+        "jiazhai",
+        "zhaijack"
+      ]
     }
   ],
   "committers": [
     {
       "name": "Ali Ahmed",
-      "apacheId": "aahmed"
+      "apacheId": "aahmed",
+      "githubUsername": [
+        "aahmed-se"
+      ]
     },
     {
       "name": "Addison Higham",
-      "apacheId": "addisonj"
+      "apacheId": "addisonj",
+      "githubUsername": [
+        "addisonj"
+      ]
     },
     {
       "name": "Aloys Zhang",
-      "apacheId": "aloyszhang"
+      "apacheId": "aloyszhang",
+      "githubUsername": [
+        "aloyszhang"
+      ]
     },
     {
       "name": "Asaf Mesika",
-      "apacheId": "amesika"
+      "apacheId": "amesika",
+      "githubUsername": []
     },
     {
       "name": "Andrey Yegorov",
-      "apacheId": "ayegorov"
+      "apacheId": "ayegorov",
+      "githubUsername": [
+        "dlg99"
+      ]
     },
     {
       "name": "Baodi Shi",
-      "apacheId": "baodi"
+      "apacheId": "baodi",
+      "githubUsername": [
+        "shibd"
+      ]
     },
     {
       "name": "Christophe Bornet",
-      "apacheId": "cbornet"
+      "apacheId": "cbornet",
+      "githubUsername": [
+        "cbornet"
+      ]
     },
     {
       "name": "Chris Kellogg",
-      "apacheId": "cckellogg"
+      "apacheId": "cckellogg",
+      "githubUsername": [
+        "cckellogg"
+      ]
     },
     {
       "name": "Tao Jiuming",
-      "apacheId": "daojun"
+      "apacheId": "daojun",
+      "githubUsername": []
     },
     {
       "name": "davidkj",
-      "apacheId": "davekj"
+      "apacheId": "davekj",
+      "githubUsername": [
+        "david-streamlio"
+      ]
     },
     {
       "name": "Dezhi Liu",
-      "apacheId": "dezhiliu"
+      "apacheId": "dezhiliu",
+      "githubUsername": [
+        "liudezhi2098"
+      ]
     },
     {
       "name": "Yuri Mizushima",
-      "apacheId": "equanz"
+      "apacheId": "equanz",
+      "githubUsername": []
     },
     {
       "name": "Guangning E",
-      "apacheId": "guangning"
+      "apacheId": "guangning",
+      "githubUsername": [
+        "tuteng"
+      ]
     },
     {
       "name": "Heesung Sohn",
-      "apacheId": "heesung"
+      "apacheId": "heesung",
+      "githubUsername": [
+        "heesung-sn"
+      ]
     },
     {
       "name": "Yan Zhao",
-      "apacheId": "horizonzy"
+      "apacheId": "horizonzy",
+      "githubUsername": [
+        "horizonzy"
+      ]
     },
     {
       "name": "Xiaoyu Hou",
-      "apacheId": "houxiaoyu"
+      "apacheId": "houxiaoyu",
+      "githubUsername": [
+        "AnonHxy"
+      ]
     },
     {
       "name": "Qiang Huang",
-      "apacheId": "huangqiang"
+      "apacheId": "huangqiang",
+      "githubUsername": [
+        "hqebupt"
+      ]
     },
     {
       "name": "Huanli Meng",
-      "apacheId": "huanlimeng"
+      "apacheId": "huanlimeng",
+      "githubUsername": [
+        "Huanli-Meng"
+      ]
     },
     {
       "name": "Jun Ma",
-      "apacheId": "junma"
+      "apacheId": "junma",
+      "githubUsername": []
     },
     {
       "name": "Yuto Furuta",
-      "apacheId": "k2la"
+      "apacheId": "k2la",
+      "githubUsername": [
+        "k2la"
+      ]
     },
     {
       "name": "Kai Wang",
-      "apacheId": "kwang"
+      "apacheId": "kwang",
+      "githubUsername": [
+        "Demogorgon314"
+      ]
     },
     {
       "name": "Lin Chen",
-      "apacheId": "lordcheng10"
+      "apacheId": "lordcheng10",
+      "githubUsername": [
+        "lordcheng10"
+      ]
     },
     {
       "name": "Neng Lu",
-      "apacheId": "nlu90"
+      "apacheId": "nlu90",
+      "githubUsername": [
+        "nlu90"
+      ]
     },
     {
       "name": "Chris Bono",
-      "apacheId": "onobc"
+      "apacheId": "onobc",
+      "githubUsername": []
     },
     {
       "name": "Rui Fu",
-      "apacheId": "rfu"
+      "apacheId": "rfu",
+      "githubUsername": [
+        "freeznet"
+      ]
     },
     {
       "name": "Ran Gao",
-      "apacheId": "rgao"
+      "apacheId": "rgao",
+      "githubUsername": [
+        "gaoran10"
+      ]
     },
     {
       "name": "Xiaolong Ran",
-      "apacheId": "rxl"
+      "apacheId": "rxl",
+      "githubUsername": [
+        "wolfstudy"
+      ]
     },
     {
       "name": "ZhangJian He",
-      "apacheId": "shoothzj"
+      "apacheId": "shoothzj",
+      "githubUsername": [
+        "Shoothzj"
+      ]
     },
     {
       "name": "Fangbin Sun",
-      "apacheId": "sunfangbin"
+      "apacheId": "sunfangbin",
+      "githubUsername": [
+        "murong00"
+      ]
     },
     {
       "name": "Li Li",
-      "apacheId": "urfree"
+      "apacheId": "urfree",
+      "githubUsername": [
+        "urfreespace"
+      ]
     },
     {
       "name": "Kiryl Valkovich",
-      "apacheId": "visortelle"
+      "apacheId": "visortelle",
+      "githubUsername": []
     },
     {
       "name": "Vineeth Polamreddy",
-      "apacheId": "vpolamreddy"
+      "apacheId": "vpolamreddy",
+      "githubUsername": []
     },
     {
       "name": "Xiangying Meng",
-      "apacheId": "xiangying"
+      "apacheId": "xiangying",
+      "githubUsername": [
+        "liangyepianzhou"
+      ]
     },
     {
       "name": "Marvin Cai",
-      "apacheId": "xxc"
+      "apacheId": "xxc",
+      "githubUsername": [
+        "MarvinCai"
+      ]
     },
     {
       "name": "Yijie Shen",
-      "apacheId": "yjshen"
+      "apacheId": "yjshen",
+      "githubUsername": [
+        "yjshen"
+      ]
     },
     {
       "name": "Yong Zhang",
-      "apacheId": "yong"
+      "apacheId": "yong",
+      "githubUsername": [
+        "zymap"
+      ]
     },
     {
       "name": "Ruguo Yu",
-      "apacheId": "yuruguo"
+      "apacheId": "yuruguo",
+      "githubUsername": [
+        "yuruguo"
+      ]
     },
     {
       "name": "Gavin Gao",
-      "apacheId": "zhangmingao"
+      "apacheId": "zhangmingao",
+      "githubUsername": [
+        "gaozhangmin"
+      ]
     },
     {
       "name": "Cong Zhao",
-      "apacheId": "zhaocong"
+      "apacheId": "zhaocong",
+      "githubUsername": [
+        "coderzc"
+      ]
     },
     {
       "name": "Zike Yang",
-      "apacheId": "zike"
+      "apacheId": "zike",
+      "githubUsername": [
+        "RobertIndie"
+      ]
     },
     {
       "name": "Zixuan Liu",
-      "apacheId": "zixuan"
+      "apacheId": "zixuan",
+      "githubUsername": [
+        "nodece"
+      ]
     }
   ]
 };

--- a/scripts/sync-team-js.sh
+++ b/scripts/sync-team-js.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This script is used to sync the team.js file with the Pulsar PMC and committers.
+# Usage:
+# 1. Log in to https://whimsy.apache.org/roster/committee/pulsar with browser
+# 2. Append ".json" to URL so that browser goes to https://whimsy.apache.org/roster/committee/pulsar.json
+# 3. Click "Save as..." and store the JSON as ~/Downloads/pulsar.json
+# 4. Run this script with "scripts/sync-team-js.sh"
+PULSAR_JSON="${1:-"$HOME/Downloads/pulsar.json"}"
+{ 
+  echo -n "module.exports = " && cat "$PULSAR_JSON" \
+    | jq '{"pmc": [.roster| to_entries | sort_by(.key) | .[] | select(.value.role|startswith("PMC")) | {"name":.value.name, "apacheId": .key, "githubUsername": (.value.githubUsername|split(", "))}], "committers": [.roster| to_entries | sort_by(.key) | .[] | select(.value.role=="Committer") | {"name":.value.name, "apacheId": .key, "githubUsername": (.value.githubUsername|split(", "))}]}'
+} | perl -pe 's/$/;\n/ if eof' > data/team.js

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -11,6 +11,7 @@ import ProjectGovernance from "./sections/project-governance/ProjectGovernance";
 import Slider from '@site/src/components/ui/Slider/Slider';
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Button from "@site/src/components/ui/Button/Button";
+import _ from 'lodash'
 
 export default function CommunityPage(): JSX.Element {
 
@@ -24,23 +25,9 @@ export default function CommunityPage(): JSX.Element {
     <Button title={isShowMoreCmtrs ? 'Show less' : 'Show more'} variant="transparentWhite" onClick={() => setIsShowMoreCmtrs(!isShowMoreCmtrs)}/>
   );
 
-  function shuffleArray(array) {
-    let currentIndex = array.length;
-    // While there remain elements to shuffle
-    while (0 !== currentIndex) {
-      // Pick a remaining element
-      const randomIndex = Math.floor(Math.random() * currentIndex);
-      currentIndex -= 1;
-      // And swap it with the current element.
-      const temporaryValue = array[currentIndex];
-      array[currentIndex] = array[randomIndex];
-      array[randomIndex] = temporaryValue;
-    }
-  }
-
   // Shuffle the team members so that the order is different each time the page is loaded
-  shuffleArray(team.pmc);
-  shuffleArray(team.committers);
+  team.pmc = _.shuffle(team.pmc);
+  team.committers = _.shuffle(team.committers);
 
   let TeamPMCSets = new Array(Math.ceil(team.pmc.length/5));
   let teamCtrsSets = new Array(Math.ceil(team.committers.length/5));

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -65,7 +65,7 @@ export default function CommunityPage(): JSX.Element {
 
   function MemberCard({ member, index }) {
     const githubUsername = member.githubUsername?.[0] || member.apacheId;
-    const href = member.githubUsername && member.githubUsername.length > 0 ? ('https://github.com/' + githubUsername) : "#";
+    const href = githubUsername ? ('https://github.com/' + githubUsername) : "#";
     const target = member.githubUsername && member.githubUsername.length > 0 ? "_blank" : "_self";
   
     return (

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -66,7 +66,7 @@ export default function CommunityPage(): JSX.Element {
   function MemberCard({ member, index }) {
     const githubUsername = member.githubUsername?.[0] || member.apacheId;
     const href = githubUsername ? ('https://github.com/' + githubUsername) : "#";
-    const target = member.githubUsername && member.githubUsername.length > 0 ? "_blank" : "_self";
+    const target = githubUsername ? "_blank" : "_self";
   
     return (
       <a href={href} target={target} key={'m'+index} className={s.CommunityMembersMember}>

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -64,7 +64,7 @@ export default function CommunityPage(): JSX.Element {
   });
 
   function MemberCard({ member, index }) {
-    const githubUsername = member.githubUsername && member.githubUsername.length > 0 ? member.githubUsername[0] : member.apacheId;
+    const githubUsername = member.githubUsername?.[0] || member.apacheId;
     const href = member.githubUsername && member.githubUsername.length > 0 ? ('https://github.com/' + githubUsername) : "#";
     const target = member.githubUsername && member.githubUsername.length > 0 ? "_blank" : "_self";
   

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -24,14 +24,6 @@ export default function CommunityPage(): JSX.Element {
     <Button title={isShowMoreCmtrs ? 'Show less' : 'Show more'} variant="transparentWhite" onClick={() => setIsShowMoreCmtrs(!isShowMoreCmtrs)}/>
   );
 
-  type ApacheId = string
-  type GithubId = string
-  const GithubUsers: Record<ApacheId, GithubId> = {
-    "jianghaiting": "Jason918",
-    "technoboy": "Technoboy-",
-    "linlin": "315157973"
-  }
-  
   let TeamPMCSets = new Array(Math.ceil(team.pmc.length/5));
   let teamCtrsSets = new Array(Math.ceil(team.committers.length/5));
 
@@ -190,14 +182,16 @@ export default function CommunityPage(): JSX.Element {
               <div>
                 <div className={(isShowMorePMC ? s.CommunityMembersDesktopOpen : s.CommunityMembersDesktop)}>
                   {(team.pmc || []).map((member,i) => (
-                    <a href={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId)} target="_blank" key={'m'+i} className={s.CommunityMembersMember}>
+                    <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
                       <div>
+                        { member.githubUsername && (
                         <div className={s.CommunityMembersMemberPic}>
-                          <img src={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId) + '.png'} alt={GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId} />
+                          <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
                         </div>
+                        )}
                         <div className={s.CommunityMembersMemberName}>
                           <strong>{member.name}</strong><br />
-                          {GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId}
+                          {member.githubUsername ? member.githubUsername[0] : member.apacheId}
                         </div>
                       </div>
                     </a>
@@ -215,18 +209,20 @@ export default function CommunityPage(): JSX.Element {
                           {TeamPMCSets.map((set, i) => (
                             <div key={i} className={s.SlideTeam}>
                               {set.map((member, i) => (
-                                <a href={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId)} target="_blank" key={'ms'+i} className={s.CommunityMembersMember}>
-                                  <div>
-                                    <div className={s.CommunityMembersMemberPic}>
-                                      <img src={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId) + '.png'} alt={GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId} />
+                                  <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
+                                    <div>
+                                      { member.githubUsername && (
+                                      <div className={s.CommunityMembersMemberPic}>
+                                        <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
+                                      </div>
+                                      )}
+                                      <div className={s.CommunityMembersMemberName}>
+                                        <strong>{member.name}</strong><br />
+                                        {member.githubUsername ? member.githubUsername[0] : member.apacheId}
+                                      </div>
                                     </div>
-                                    <div className={s.CommunityMembersMemberName}>
-                                      <strong>{member.name}</strong><br />
-                                      {member.apacheId}
-                                    </div>
-                                  </div>
-                                </a>
-                              ))}
+                                  </a>
+                                ))}
                             </div>
                           ))}
                         </Slider>
@@ -239,14 +235,16 @@ export default function CommunityPage(): JSX.Element {
               <div>
                 <div className={(isShowMoreCmtrs ? s.CommunityMembersDesktopOpen : s.CommunityMembersDesktop)}>
                   {(team.committers || []).map((member,i) => (
-                    <a href={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId)} target="_blank" key={'c'+i} className={s.CommunityMembersMember}>
+                    <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
                       <div>
+                        { member.githubUsername && (
                         <div className={s.CommunityMembersMemberPic}>
-                          <img src={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId) + '.png'} alt={GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId} />
+                          <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
                         </div>
+                        )}
                         <div className={s.CommunityMembersMemberName}>
                           <strong>{member.name}</strong><br />
-                          {member.apacheId}
+                          {member.githubUsername ? member.githubUsername[0] : member.apacheId}
                         </div>
                       </div>
                     </a>
@@ -264,14 +262,16 @@ export default function CommunityPage(): JSX.Element {
                           {teamCtrsSets.map((set, i) => (
                             <div key={i} className={s.SlideTeam}>
                               {set.map((member, i) => (
-                                <a href={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId)} target="_blank" key={'cs'+i} className={s.CommunityMembersMember}>
+                                <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
                                   <div>
+                                    { member.githubUsername && (
                                     <div className={s.CommunityMembersMemberPic}>
-                                      <img src={'https://github.com/' + (GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId) + '.png'} alt={GithubUsers[member.apacheId] ? GithubUsers[member.apacheId] : member.apacheId} />
+                                      <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
                                     </div>
+                                    )}
                                     <div className={s.CommunityMembersMemberName}>
                                       <strong>{member.name}</strong><br />
-                                      {member.apacheId}
+                                      {member.githubUsername ? member.githubUsername[0] : member.apacheId}
                                     </div>
                                   </div>
                                 </a>

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -64,7 +64,10 @@ export default function CommunityPage(): JSX.Element {
   });
 
   function MemberCard({ member, index }) {
-    const githubUsername = member.githubUsername?.[0] || member.apacheId;
+    // require the member to have "GitHub username(s) (user-provided)" field information in Whimsy
+    // the user can go to Whimsy url https://whimsy.apache.org/roster/committer/__self__ to update the information
+    // since it's possible to have multiple GitHub usernames, we only take the first one
+    const githubUsername = member.githubUsername?.[0];
     const href = githubUsername ? ('https://github.com/' + githubUsername) : "#";
     const target = githubUsername ? "_blank" : "_self";
   
@@ -78,7 +81,7 @@ export default function CommunityPage(): JSX.Element {
           </div>
           <div className={s.CommunityMembersMemberName}>
             <strong>{member.name}</strong><br />
-            {githubUsername}
+            {githubUsername ? githubUsername : member.apacheId}
           </div>
         </div>
       </a>

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -24,6 +24,24 @@ export default function CommunityPage(): JSX.Element {
     <Button title={isShowMoreCmtrs ? 'Show less' : 'Show more'} variant="transparentWhite" onClick={() => setIsShowMoreCmtrs(!isShowMoreCmtrs)}/>
   );
 
+  function shuffleArray(array) {
+    let currentIndex = array.length;
+    // While there remain elements to shuffle
+    while (0 !== currentIndex) {
+      // Pick a remaining element
+      let randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+      // And swap it with the current element.
+      let temporaryValue = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temporaryValue;
+    }
+  }
+
+  // Shuffle the team members so that the order is different each time the page is loaded
+  shuffleArray(team.pmc);
+  shuffleArray(team.committers);
+
   let TeamPMCSets = new Array(Math.ceil(team.pmc.length/5));
   let teamCtrsSets = new Array(Math.ceil(team.committers.length/5));
 

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -29,10 +29,10 @@ export default function CommunityPage(): JSX.Element {
     // While there remain elements to shuffle
     while (0 !== currentIndex) {
       // Pick a remaining element
-      let randomIndex = Math.floor(Math.random() * currentIndex);
+      const randomIndex = Math.floor(Math.random() * currentIndex);
       currentIndex -= 1;
       // And swap it with the current element.
-      let temporaryValue = array[currentIndex];
+      const temporaryValue = array[currentIndex];
       array[currentIndex] = array[randomIndex];
       array[randomIndex] = temporaryValue;
     }

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -45,6 +45,27 @@ export default function CommunityPage(): JSX.Element {
     teamCtrsSets[CountTheSets].push(element);
   });
 
+  function MemberCard({ member, index }) {
+    const githubUsername = member.githubUsername && member.githubUsername.length > 0 ? member.githubUsername[0] : member.apacheId;
+    const href = member.githubUsername && member.githubUsername.length > 0 ? ('https://github.com/' + githubUsername) : "#";
+    const target = member.githubUsername && member.githubUsername.length > 0 ? "_blank" : "_self";
+  
+    return (
+      <a href={href} target={target} key={'m'+index} className={s.CommunityMembersMember}>
+        <div>
+          <div className={s.CommunityMembersMemberPic}>
+            { member.githubUsername && member.githubUsername.length > 0 && (
+            <img src={'https://github.com/' + githubUsername + '.png'} alt={githubUsername} />
+            )}
+          </div>
+          <div className={s.CommunityMembersMemberName}>
+            <strong>{member.name}</strong><br />
+            {githubUsername}
+          </div>
+        </div>
+      </a>
+    );
+  }
 
   return (
     <Layout title={"Community"} description={"Learn about the basics of using Apache Pulsar"} wrapperClassName="LandingPage">
@@ -182,19 +203,7 @@ export default function CommunityPage(): JSX.Element {
               <div>
                 <div className={(isShowMorePMC ? s.CommunityMembersDesktopOpen : s.CommunityMembersDesktop)}>
                   {(team.pmc || []).map((member,i) => (
-                    <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
-                      <div>
-                        { member.githubUsername && (
-                        <div className={s.CommunityMembersMemberPic}>
-                          <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
-                        </div>
-                        )}
-                        <div className={s.CommunityMembersMemberName}>
-                          <strong>{member.name}</strong><br />
-                          {member.githubUsername ? member.githubUsername[0] : member.apacheId}
-                        </div>
-                      </div>
-                    </a>
+                    <MemberCard member={member} index={i} />
                   ))}
                   <div className={s.CommunityMembersShowMore}>
                     {showMorePMCButton}
@@ -209,19 +218,7 @@ export default function CommunityPage(): JSX.Element {
                           {TeamPMCSets.map((set, i) => (
                             <div key={i} className={s.SlideTeam}>
                               {set.map((member, i) => (
-                                  <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
-                                    <div>
-                                      { member.githubUsername && (
-                                      <div className={s.CommunityMembersMemberPic}>
-                                        <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
-                                      </div>
-                                      )}
-                                      <div className={s.CommunityMembersMemberName}>
-                                        <strong>{member.name}</strong><br />
-                                        {member.githubUsername ? member.githubUsername[0] : member.apacheId}
-                                      </div>
-                                    </div>
-                                  </a>
+                                  <MemberCard member={member} index={i} />
                                 ))}
                             </div>
                           ))}
@@ -235,19 +232,7 @@ export default function CommunityPage(): JSX.Element {
               <div>
                 <div className={(isShowMoreCmtrs ? s.CommunityMembersDesktopOpen : s.CommunityMembersDesktop)}>
                   {(team.committers || []).map((member,i) => (
-                    <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
-                      <div>
-                        { member.githubUsername && (
-                        <div className={s.CommunityMembersMemberPic}>
-                          <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
-                        </div>
-                        )}
-                        <div className={s.CommunityMembersMemberName}>
-                          <strong>{member.name}</strong><br />
-                          {member.githubUsername ? member.githubUsername[0] : member.apacheId}
-                        </div>
-                      </div>
-                    </a>
+                    <MemberCard member={member} index={i} />
                   ))}
                   <div className={s.CommunityMembersShowMore}>
                     {showMoreCmtrsButton}
@@ -262,19 +247,7 @@ export default function CommunityPage(): JSX.Element {
                           {teamCtrsSets.map((set, i) => (
                             <div key={i} className={s.SlideTeam}>
                               {set.map((member, i) => (
-                                <a href={member.githubUsername ? ('https://github.com/' + member.githubUsername[0]) : "#"} target={member.githubUsername ? "_blank" : "_self"} key={'m'+i} className={s.CommunityMembersMember}>
-                                  <div>
-                                    { member.githubUsername && (
-                                    <div className={s.CommunityMembersMemberPic}>
-                                      <img src={'https://github.com/' + member.githubUsername[0] + '.png'} alt={member.githubUsername[0]} />
-                                    </div>
-                                    )}
-                                    <div className={s.CommunityMembersMemberName}>
-                                      <strong>{member.name}</strong><br />
-                                      {member.githubUsername ? member.githubUsername[0] : member.apacheId}
-                                    </div>
-                                  </div>
-                                </a>
+                                <MemberCard member={member} index={i} />
                               ))}
                             </div>
                           ))}

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -62,7 +62,7 @@ export default function CommunityPage(): JSX.Element {
       <a href={href} target={target} key={'m'+index} className={s.CommunityMembersMember}>
         <div>
           <div className={s.CommunityMembersMemberPic}>
-            { member.githubUsername && member.githubUsername.length > 0 && (
+            { githubUsername && (
             <img src={'https://github.com/' + githubUsername + '.png'} alt={githubUsername} />
             )}
           </div>


### PR DESCRIPTION
### Motivation

There seems to be a hardcoded ApacheID -> GitHub ID mappings: https://github.com/apache/pulsar-site/blob/d7e1e218f025fa8ad3f3a88c03eb9ec3cafe1a81/src/components/pages/CommunityPage/CommunityPage.tsx#L29-L33
This doesn't make sense since the GitHub usernames are available from ASF.
In ASF, it's possible to have multiple GitHub user ids so that's the reason why it's an array.

### Modification

- add script for updating information from ASF Whimsy's pulsar.json data file


### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [ ] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
