### PR TITLE
[fix][doc] Fixes example code in Cluster Failover Java Client

### DIFF
--- a/docs/client-libraries-cluster-level-failover.md
+++ b/docs/client-libraries-cluster-level-failover.md
@@ -66,7 +66,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -113,6 +114,7 @@ public PulsarClient getControlledFailoverClient() throws IOException {
 
     PulsarClient pulsarClient =
             PulsarClient.builder()
+                    .serviceUrlProvider(provider)
                     .build();
 
     provider.initialize(pulsarClient);

--- a/versioned_docs/version-2.10.x/client-libraries-java.md
+++ b/versioned_docs/version-2.10.x/client-libraries-java.md
@@ -376,7 +376,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -419,7 +420,9 @@ public PulsarClient getControlledFailoverClient() throws IOException {
         .urlProviderHeader(header)
         .build();
 
-    PulsarClient pulsarClient = PulsarClient.builder().build();
+    PulsarClient pulsarClient = PulsarClient.builder()
+        .serviceUrlProvider(provider)
+        .build();
 
     provider.initialize(pulsarClient);
     return pulsarClient;

--- a/versioned_docs/version-2.11.x/client-libraries-java.md
+++ b/versioned_docs/version-2.11.x/client-libraries-java.md
@@ -1238,7 +1238,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -1281,7 +1282,9 @@ public PulsarClient getControlledFailoverClient() throws IOException {
         .urlProviderHeader(header)
         .build();
 
-    PulsarClient pulsarClient = PulsarClient.builder().build();
+    PulsarClient pulsarClient = PulsarClient.builder()
+        .serviceUrlProvider(provider)
+        .build();
 
     provider.initialize(pulsarClient);
     return pulsarClient;

--- a/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.0.x/client-libraries-cluster-level-failover.md
@@ -65,7 +65,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -112,6 +113,7 @@ public PulsarClient getControlledFailoverClient() throws IOException {
 
     PulsarClient pulsarClient =
             PulsarClient.builder()
+                    .serviceUrlProvider(provider)
                     .build();
 
     provider.initialize(pulsarClient);

--- a/versioned_docs/version-3.1.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.1.x/client-libraries-cluster-level-failover.md
@@ -65,7 +65,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -112,6 +113,7 @@ public PulsarClient getControlledFailoverClient() throws IOException {
 
     PulsarClient pulsarClient =
             PulsarClient.builder()
+                    .serviceUrlProvider(provider)
                     .build();
 
     provider.initialize(pulsarClient);

--- a/versioned_docs/version-3.2.x/client-libraries-cluster-level-failover.md
+++ b/versioned_docs/version-3.2.x/client-libraries-cluster-level-failover.md
@@ -66,7 +66,8 @@ private PulsarClient getAutoFailoverClient() throws PulsarClientException {
         .build();
 
     PulsarClient pulsarClient = PulsarClient.builder()
-        .authentication(primaryAuthentication) 
+        .serviceUrlProvider(failover)
+        .authentication(primaryAuthentication)
         .tlsTrustCertsFilePath(primaryTlsTrustCertsFilePath)
         .build();
 
@@ -113,6 +114,7 @@ public PulsarClient getControlledFailoverClient() throws IOException {
 
     PulsarClient pulsarClient =
             PulsarClient.builder()
+                    .serviceUrlProvider(provider)
                     .build();
 
     provider.initialize(pulsarClient);


### PR DESCRIPTION
Cluster failover Java client is available for 2.10.0 and later versions.
This PR fixes example code shown in [Automatic-failover](https://pulsar.apache.org/docs/3.2.x/client-libraries-cluster-level-failover/#automatic-failover) and [Controlled-failover](https://pulsar.apache.org/docs/3.2.x/client-libraries-cluster-level-failover/#controlled-failover)

It adds required ServiceUrlProvider while building PulsarClient
`.serviceUrlProvider(failover)`

![Controlled Failover](https://github.com/apache/pulsar-site/assets/27077091/09a5bf40-5fae-4021-86c4-68b64db22447)

![Automatic Failover](https://github.com/apache/pulsar-site/assets/27077091/4732088e-7387-4998-9db5-65fee5b46c23)


### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
