### PR TITLE
Remove duplicate pulsar-io-netty nar on download page

### DIFF
--- a/data/connectors.js
+++ b/data/connectors.js
@@ -180,12 +180,6 @@ module.exports = [
     link: 'https://lucene.apache.org/solr/'
   },
   {
-    name: 'netty',
-    longName: 'TCP/UDP with Netty source',
-    type: 'Source',
-    link: 'https://netty.io/'
-  },
-  {
     name: 'data-generator',
     longName: 'Test Data Generator source',
     type: 'Source',


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22229

The artifact pulsar-io-netty-3.2.1.nar appears twice on the download page with different descriptions.

### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [ ] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
