### PR TITLE
Remove Pulsar Summit EU 2024 announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,7 +152,7 @@ module.exports = {
       id: "summit",
       content: renderAnnouncementBar(
         "👋 Start your Pulsar journey by becoming a member of our community",
-        "https://pulsar.apache.org/community/#section-discussions"
+        "/community/#section-discussions"
       ),
       backgroundColor: "#282826",
       textColor: "#fff",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -151,10 +151,11 @@ module.exports = {
     announcementBar: {
       id: "summit",
       content: renderAnnouncementBar(
-        "Get your free pass for Pulsar Virtual Summit Europe 2024 on May 14, 2024 🗓️",
-        "https://registration.socio.events/e/pulsarvirtualsummiteurope2024"
+        "👋 Start your Pulsar journey by becoming a member of our community",
+        "https://pulsar.apache.org/community/#section-discussions"
       ),
       backgroundColor: "#282826",
+      // backgroundColor: "#FFCD4B",
       textColor: "#fff",
       isCloseable: false,
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,7 +155,6 @@ module.exports = {
         "https://pulsar.apache.org/community/#section-discussions"
       ),
       backgroundColor: "#282826",
-      // backgroundColor: "#FFCD4B",
       textColor: "#fff",
       isCloseable: false,
     },

--- a/src/components/pages/CommunityPage/sections/discussions/DiscussionPlatforms.module.css
+++ b/src/components/pages/CommunityPage/sections/discussions/DiscussionPlatforms.module.css
@@ -41,7 +41,10 @@
   box-sizing: border-box;
   width: 100%;
 }
-.DiscussionPlatformCardText h3, .DiscussionPlatformCardText div{
+.DiscussionPlatformCardText h3 {
+  margin-bottom: 0;
+}
+.DiscussionPlatformCardText div{
   line-height: 20px;
   font-size: 16px;
   font-weight: 400;

--- a/src/components/ui/renderAnnouncementBar.js
+++ b/src/components/ui/renderAnnouncementBar.js
@@ -23,9 +23,9 @@ function renderAnnouncementBar(html, href) {
   return `
     <a class="announcement-bar" href="${href}" target="_blank">
       <div class="announcement-bar__content">
-        <svg class="announcement-bar__icon">
+        <!-- <svg class="announcement-bar__icon">
           ${boltIcon}
-        </svg>
+        </svg> -->
 
         <span>
           ${html}

--- a/src/css/announcement-bar.css
+++ b/src/css/announcement-bar.css
@@ -39,7 +39,6 @@ div[class^="announcementBar"][role="banner"] .announcement-bar__content {
   justify-content: flex-start;
   align-items: center;
   height: 2.4rem;
-  background-color: #282826;
   color: #f6f6f6;
 }
 


### PR DESCRIPTION
- Ask for joining the Pulsar community at the announcement bar. The link refers to the [Discussion section at the community page](https://pulsar.apache.org/community/#section-discussions).
  
  <img width="1440" alt="Screenshot 2024-05-16 at 2 18 23 PM" src="https://github.com/apache/pulsar-site/assets/9302460/51c6452e-3b22-49c9-bae8-5ef6ff194843">

- Minor style changes at at the community page according to the Figma design
  
  **Before**
  <img width="1440" alt="Screenshot 2024-05-16 at 2 18 37 PM" src="https://github.com/apache/pulsar-site/assets/9302460/13bb7de6-6c1f-4f44-9a37-e673a88c7a40">

  **After**
  <img width="1440" alt="Screenshot 2024-05-16 at 2 21 08 PM" src="https://github.com/apache/pulsar-site/assets/9302460/ffa879ea-2e59-4930-a480-418361edec15">
