### PR TITLE
Always use multiple zookeeper server address in the deployment doc

### DIFF
--- a/docs/deploy-bare-metal.md
+++ b/docs/deploy-bare-metal.md
@@ -300,14 +300,6 @@ You can obtain the metadata service URI of the existing BookKeeper cluster by us
 You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the ZooKeeper cluster. The following is an example:
 
 ```properties
-metadataServiceUri=zk://zk1.us-west.example.com:2181/ledgers
-```
-
-:::note
-
-If you want to use multiple ZooKeeper servers, you can use as follow format:
-
-```properties
 metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
 ```
 

--- a/versioned_docs/version-3.0.x/deploy-bare-metal.md
+++ b/versioned_docs/version-3.0.x/deploy-bare-metal.md
@@ -304,8 +304,10 @@ You can obtain the metadata service URI of the existing BookKeeper cluster by us
 You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the ZooKeeper cluster. The following is an example:
 
 ```properties
-metadataServiceUri=zk://zk1.us-west.example.com:2181/ledgers
+metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
 ```
+
+Which using `;` as separator in `metadataServiceUri`
 
 Once you appropriately modify the `metadataServiceUri` parameter, you can make any other configuration changes that you require. You can find a full listing of the available BookKeeper configuration parameters [here](reference-configuration.md#bookkeeper). However, consulting the [BookKeeper documentation](https://bookkeeper.apache.org/docs/next/reference/config/) for a more in-depth guide might be a better choice.
 

--- a/versioned_docs/version-3.1.x/deploy-bare-metal.md
+++ b/versioned_docs/version-3.1.x/deploy-bare-metal.md
@@ -304,8 +304,10 @@ You can obtain the metadata service URI of the existing BookKeeper cluster by us
 You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the ZooKeeper cluster. The following is an example:
 
 ```properties
-metadataServiceUri=zk://zk1.us-west.example.com:2181/ledgers
+metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
 ```
+
+Which using `;` as separator in `metadataServiceUri`
 
 Once you appropriately modify the `metadataServiceUri` parameter, you can make any other configuration changes that you require. You can find a full listing of the available BookKeeper configuration parameters [here](reference-configuration.md#bookkeeper). However, consulting the [BookKeeper documentation](https://bookkeeper.apache.org/docs/next/reference/config/) for a more in-depth guide might be a better choice.
 

--- a/versioned_docs/version-3.2.x/deploy-bare-metal.md
+++ b/versioned_docs/version-3.2.x/deploy-bare-metal.md
@@ -300,20 +300,10 @@ You can obtain the metadata service URI of the existing BookKeeper cluster by us
 You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the ZooKeeper cluster. The following is an example:
 
 ```properties
-metadataServiceUri=zk://zk1.us-west.example.com:2181/ledgers
-```
-
-:::note
-
-If you want to use multiple ZooKeeper servers, you can use as follow format:
-
-```properties
 metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
 ```
 
 Which using `;` as separator in `metadataServiceUri`
-
-:::
 
 Once you appropriately modify the `metadataServiceUri` parameter, you can make any other configuration changes that you require. You can find a full listing of the available BookKeeper configuration parameters [here](reference-configuration.md#bookkeeper). However, consulting the [BookKeeper documentation](https://bookkeeper.apache.org/docs/next/reference/config/) for a more in-depth guide might be a better choice.
 


### PR DESCRIPTION
### Motivation

Always use the multiple zookeeper server address in the bare deployment documentation. Users might don't know much details about the the differences between single zookeeper server address and multiple zookeeper server address. It will be a risk for user if they applied the single zookeeper server address in production. The configured zookeeper server crash will cause the bookie cluster shutdown due to the zookeeper connection issue. 

### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
