### PR TITLE
Fix out of date Helm documentation around monitoring component customization

### DIFF
--- a/docs/helm-deploy.md
+++ b/docs/helm-deploy.md
@@ -100,15 +100,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images
@@ -149,6 +161,26 @@ images:
     pullPolicy: IfNotPresent
     hasCommand: false
 ```
+
+The Pulsar Helm Chart also lets you specify the image versions used by initialization containers used to coordinate creation and connection of dependent Pulsar resources.
+
+```yaml
+## Images
+##
+## Control what image to use for Pulsar init containers
+pulsar_metadata:
+  component: pulsar-init
+  image:
+    repository: apachepulsar/pulsar-all
+    tag: @pulsar:version@
+    pullPolicy: IfNotPresent
+```
+
+:::tip
+
+If using a private Docker repository or pull-thru cache, the `repository` configuration option must be changed accordingly for all component defintions including the `pulsar_metadata` component.
+
+:::
 
 #### TLS
 
@@ -351,6 +383,17 @@ To find the IP addresses of those components, run the following command:
 
 ```bash
 kubectl get service -n <k8s-namespace>
+```
+
+You can configure the Proxy and the Pulsar Manager as a `NodePort` instead of a `ClusterIP`.
+
+```yaml
+proxy:
+  service:
+    type: NodePort
+pulsar_manager:
+  service:
+    type: NodePort
 ```
 
 ## Troubleshoot

--- a/versioned_docs/version-2.10.x/helm-deploy.md
+++ b/versioned_docs/version-2.10.x/helm-deploy.md
@@ -129,16 +129,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
-
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 ### Docker images

--- a/versioned_docs/version-2.11.x/helm-deploy.md
+++ b/versioned_docs/version-2.11.x/helm-deploy.md
@@ -103,15 +103,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images

--- a/versioned_docs/version-3.0.x/helm-deploy.md
+++ b/versioned_docs/version-3.0.x/helm-deploy.md
@@ -103,15 +103,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images

--- a/versioned_docs/version-3.1.x/helm-deploy.md
+++ b/versioned_docs/version-3.1.x/helm-deploy.md
@@ -103,15 +103,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images

--- a/versioned_docs/version-3.2.x/helm-deploy.md
+++ b/versioned_docs/version-3.2.x/helm-deploy.md
@@ -100,15 +100,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images

--- a/versioned_docs/version-3.3.x/helm-deploy.md
+++ b/versioned_docs/version-3.3.x/helm-deploy.md
@@ -100,15 +100,27 @@ components:
   toolset: true
   # pulsar manager
   pulsar_manager: true
+```
 
+##### Monitoring Components
+
+The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.
+
+```yaml
 ## Monitoring Components
 ##
-## Control what components of the monitoring stack to deploy for the cluster
-monitoring:
-  # monitoring - prometheus
-  prometheus: true
-  # monitoring - grafana
-  grafana: true
+## Control what components of the kube-prometheus-stack Helm chart to deploy for the cluster
+kube-prometheus-stack:
+  # Control deployment of this Helm chart entirely
+  enabled: true
+  # prometheus
+  prometheus:
+    enabled: true
+  promtheus-node-exporter:
+    enabled: true
+  # grafana
+  grafana:
+    enabled: true
 ```
 
 #### Docker images


### PR DESCRIPTION
### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [ ] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)

This fixes pulsar-helm-chart issue [442](https://github.com/apache/pulsar-helm-chart/issues/442). The change to use a dependent Helm chart for Prometheus and Grafana was introduced in Helm version [3.0.0](https://github.com/apache/pulsar-helm-chart/releases/tag/pulsar-3.0.0) which shipped with version 2.10.2 of Pulsar by default. I updated the versioned documentation up to that point.

I also added some documentation improvements from a recent Kubernetes deployment. Since I only improved documentation and didn't fix incorrect documentation, I didn't add these changes into any versioned docs.

Changes to monitoring components in the Helm Deployment documentation
![image](https://github.com/apache/pulsar-site/assets/47787825/f8b9d17e-1d5e-4b9d-9e1d-659ecc20f955)

Other updates:
![image](https://github.com/apache/pulsar-site/assets/47787825/66ae9c64-e2b2-4779-8840-246ac1d79643)
I am assuming the version tag didn't resolve since this is running on the development server

![image](https://github.com/apache/pulsar-site/assets/47787825/ad59fb19-55b7-48df-a8a2-bb308292b909)
