### PR TITLE
Clarify the data retention policy for topic and partitions

### DIFF
--- a/docs/cookbooks-retention-expiry.md
+++ b/docs/cookbooks-retention-expiry.md
@@ -65,7 +65,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/versioned_docs/version-2.10.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-2.10.x/cookbooks-retention-expiry.md
@@ -65,7 +65,7 @@ For more information of the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs

--- a/versioned_docs/version-2.11.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-2.11.x/cookbooks-retention-expiry.md
@@ -64,7 +64,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/versioned_docs/version-3.0.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-3.0.x/cookbooks-retention-expiry.md
@@ -64,7 +64,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/versioned_docs/version-3.1.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-3.1.x/cookbooks-retention-expiry.md
@@ -64,7 +64,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/versioned_docs/version-3.2.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-3.2.x/cookbooks-retention-expiry.md
@@ -65,7 +65,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"

--- a/versioned_docs/version-3.3.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-3.3.x/cookbooks-retention-expiry.md
@@ -65,7 +65,7 @@ For more information on the two parameters, refer to the [`broker.conf`](referen
 
 ### Set retention policy
 
-You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java.
+You can set a retention policy for a namespace by specifying the namespace, a size limit and a time limit in `pulsar-admin`, REST API and Java. And all the non-partitioned topics and topic partitions will apply the specified data retention policy for the namespace unless you overwrite the data retention policy for the specific topic by using topic level policies.
 
 ````mdx-code-block
 <Tabs groupId="api-choice"


### PR DESCRIPTION
### Motivation

The namespace level data retention policy is not clear for topic partitions. Users might think the size of the retention is for the whole partitioned topic, but it actually applied to all the partitions of a partitioned topic. For example, if you set the retention policy to 10GB, that means each partition of a partitioned topic will retain 10GB data.

### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
