### PR TITLE
Fix REST API urls in documentation

### DIFF
--- a/docs/admin-api-brokers.md
+++ b/docs/admin-api-brokers.md
@@ -45,7 +45,7 @@ localhost:8080
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getActiveBrokers?summary=in+the+cluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -90,7 +90,7 @@ public/default/0x80000000_0xc0000000    [broker_assignment=shared is_controlled=
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getOwnedNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -104,7 +104,7 @@ admin.brokers().getOwnedNamespaces(cluster,brokerUrl);
 </Tabs>
 ````
 
-## Update broker conf 
+## Update broker conf
 
 You can update broker configurations using one of the following ways:
 
@@ -144,7 +144,7 @@ resourceUsageTransportPublishIntervalInSecs
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getDynamicConfigurationName)
 
 </TabItem>
 <TabItem value="Java">
@@ -175,7 +175,7 @@ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --va
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_updateDynamicConfiguration)
 
 </TabItem>
 <TabItem value="Java">
@@ -211,7 +211,7 @@ brokerShutdownTimeoutMs    100
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getAllDynamicConfigurations)
 
 </TabItem>
 <TabItem value="Java">
@@ -250,7 +250,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/leaderBroker|operation/getLeaderBroker?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getLeaderBroker)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-clusters.md
+++ b/docs/admin-api-clusters.md
@@ -53,7 +53,7 @@ pulsar-admin clusters create cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_createCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ Output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -140,7 +140,7 @@ pulsar-admin clusters update cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_updateCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -179,7 +179,7 @@ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_setPeerClusterNames)
 
 </TabItem>
 <TabItem value="Java">
@@ -218,7 +218,7 @@ cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -250,7 +250,7 @@ pulsar-admin clusters delete cluster-1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_deleteCluster)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-functions.md
+++ b/docs/admin-api-functions.md
@@ -52,7 +52,7 @@ pulsar-admin functions create \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName|operation/registerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_registerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -104,7 +104,7 @@ pulsar-admin functions update \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName|operation/updateFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_updateFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -153,7 +153,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -191,7 +191,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -234,7 +234,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -272,7 +272,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -315,7 +315,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -353,7 +353,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -390,7 +390,7 @@ pulsar-admin functions list \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace|operation/listFunctions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_listFunctions)
 
 </TabItem>
 <TabItem value="Java">
@@ -428,7 +428,7 @@ pulsar-admin functions delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName|operation/deregisterFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_deregisterFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -466,7 +466,7 @@ pulsar-admin functions get \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName|operation/getFunctionInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInfo)
 
 </TabItem>
 <TabItem value="Java">
@@ -508,7 +508,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status|operation/getFunctionInstanceStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -546,7 +546,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status|operation/getFunctionStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -588,7 +588,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats|operation/getFunctionInstanceStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -626,7 +626,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats|operation/getFunctionStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -667,7 +667,7 @@ pulsar-admin functions trigger \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger|operation/triggerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_triggerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -708,7 +708,7 @@ pulsar-admin functions putstate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/putFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_putFunctionState)
 
 </TabItem>
 <TabItem value="Java">
@@ -749,7 +749,7 @@ pulsar-admin functions querystate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/getFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionState)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-namespaces.md
+++ b/docs/admin-api-namespaces.md
@@ -52,7 +52,7 @@ pulsar-admin namespaces create test-tenant/test-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -111,7 +111,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -151,7 +151,7 @@ test-tenant/namespace2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getTenantNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -184,7 +184,7 @@ pulsar-admin namespaces delete test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_deleteNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -217,7 +217,7 @@ pulsar-admin namespaces set-clusters test-tenant/namespace1 --clusters cl1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -254,7 +254,7 @@ cluster2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -298,7 +298,7 @@ pulsar-admin namespaces set-backlog-quota --limit 10G \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -335,7 +335,7 @@ destination_storage    BacklogQuotaImpl(limit=10737418240, limitSize=10737418240
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -366,7 +366,7 @@ pulsar-admin namespaces remove-backlog-quota test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -410,7 +410,7 @@ pulsar-admin namespaces set-persistence \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -452,7 +452,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -487,7 +487,7 @@ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff --destinationBroke
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/unload|operation/unloadNamespaceBundle?version=@pulsar:version_number@&destinationBroker=broker1.use.org.com:8080}
+[](swagger:/admin/v2/Namespaces_unloadNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -518,7 +518,7 @@ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-tenant/
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/split|operation/splitNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_splitNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -551,7 +551,7 @@ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -587,7 +587,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -622,7 +622,7 @@ pulsar-admin namespaces remove-message-ttl test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -656,7 +656,7 @@ pulsar-admin namespaces clear-backlog --sub my-subscription test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -690,7 +690,7 @@ pulsar-admin namespaces clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/:bundle/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBundleBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -725,7 +725,7 @@ pulsar-admin namespaces set-retention --size 100M --time 10m test-tenant/namespa
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -763,7 +763,7 @@ pulsar-admin namespaces get-retention test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -808,7 +808,7 @@ pulsar-admin namespaces set-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -850,7 +850,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -887,7 +887,7 @@ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -929,7 +929,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -965,7 +965,7 @@ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1004,7 +1004,7 @@ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1037,7 +1037,7 @@ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1068,7 +1068,7 @@ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1099,7 +1099,7 @@ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1138,7 +1138,7 @@ pulsar-admin namespaces unload my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_unloadNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -1174,8 +1174,7 @@ pulsar-admin namespaces set-entry-filters \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/setEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1206,8 +1205,7 @@ pulsar-admin namespaces get-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/getEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1238,8 +1236,7 @@ pulsar-admin namespaces remove-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/removeEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceEntryFilters)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-packages.md
+++ b/docs/admin-api-packages.md
@@ -103,7 +103,7 @@ bin/pulsar-admin packages upload function://public/default/example@v0.1 --path p
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/upload?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_upload)
 
 </TabItem>
 <TabItem value="Java">
@@ -142,7 +142,7 @@ bin/pulsar-admin packages download function://public/default/example@v0.1 --path
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/download?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_download)
 
 </TabItem>
 <TabItem value="Java">
@@ -183,7 +183,7 @@ bin/pulsar-admin packages delete functions://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/delete?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_delete)
 
 </TabItem>
 <TabItem value="Java">
@@ -222,7 +222,7 @@ bin/pulsar-admin packages get-metadata function://public/default/test@v1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/getMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_getMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -261,7 +261,7 @@ bin/pulsar-admin packages update-metadata function://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/updateMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_updateMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -300,7 +300,7 @@ bin/pulsar-admin packages list-versions type://tenant/namespace/packageName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName|operation/listPackageVersion?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackageVersion)
 
 </TabItem>
 <TabItem value="Java">
@@ -340,7 +340,7 @@ bin/pulsar-admin packages list --type function public/default
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace|operation/listPackages?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackages)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-permissions.md
+++ b/docs/admin-api-permissions.md
@@ -89,7 +89,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_grantPermissionOnNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -128,7 +128,7 @@ my.role.*    [produce, consume]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPermissions)
 
 </TabItem>
 <TabItem value="Java">
@@ -162,7 +162,7 @@ pulsar-admin namespaces revoke-permission test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_revokePermissionsOnNamespace)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-schemas.md
+++ b/docs/admin-api-schemas.md
@@ -55,7 +55,7 @@ The `schema-definition-file` is in JSON format.
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to the endpoint documented here: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_postSchema?version=@pulsar:version_number@}
+Send a `POST` request to the endpoint documented here: [](swagger:/admin/v2/SchemasResource_postSchema)
 
 Below is an example with CURL with a payload stored on the `schema.json` file, Pulsar broker running on `localhost` and the topic `my-tenant/my-ns/my-topic`:
 
@@ -155,7 +155,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_getSchema?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=!version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -208,7 +208,7 @@ pulsar-admin schemas get <topic-name> --version <version>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/SchemasResource_getSchema?version=@pulsar:version_number@}
+Send a `GET` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -288,7 +288,7 @@ pulsar-admin schemas delete <topic-name>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_deleteSchema?version=@pulsar:version_number@}
+Send a `DELETE` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_deleteSchema)
 
 Here is an example of a response returned in JSON format.
 
@@ -339,13 +339,13 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --enable tenant/name
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/Namespaces_setIsAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
 ```json
 {
-“isAllowAutoUpdateSchema”: “true”
+"isAllowAutoUpdateSchema": "true"
 }
 ```
 
@@ -388,13 +388,13 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --disable tenant/nam
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/Namespaces_setIsAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
 ```json
 {
-“isAllowAutoUpdateSchema”: “false”
+"isAllowAutoUpdateSchema": "false"
 }
 ```
 
@@ -435,13 +435,13 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --enable tenant/namesp
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/Namespaces_setSchemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
 ```json
 {
-“schemaValidationEnforced”: “true”
+"schemaValidationEnforced": "true"
 }
 ```
 
@@ -478,13 +478,13 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --disable tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/Namespaces_setSchemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
 ```json
 {
-“schemaValidationEnforced”: “false”
+"schemaValidationEnforced": "false"
 }
 ```
 
@@ -529,7 +529,7 @@ pulsar-admin topicPolicies set-schema-compatibility-strategy <strategy> <topicNa
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/topics/:tenant/:namespace/:topic|operation/PersistentTopics_setSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -570,7 +570,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/schemaCompatibilityStrategy|operation/Namespaces_setSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/Namespaces_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -617,7 +617,7 @@ pulsar-admin topicPolicies get-schema-compatibility-strategy <topicName>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/schemaCompatibilityStrategy|operation/PersistentTopics_getSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -662,7 +662,7 @@ pulsar-admin namespaces get-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/schemaCompatibilityStrategy|operation/Namespaces_getSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/Namespaces_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-tenants.md
+++ b/docs/admin-api-tenants.md
@@ -56,7 +56,7 @@ my-tenant-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenants)
 
 </TabItem>
 <TabItem value="Java">
@@ -105,7 +105,7 @@ pulsar-admin tenants create my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/tenants/:tenant|operation/createTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_createTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -151,7 +151,7 @@ pulsar-admin tenants get my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants/:tenant|operation/getTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenantAdmin)
 
 </TabItem>
 <TabItem value="Java">
@@ -184,7 +184,7 @@ pulsar-admin tenants delete my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:tenant|operation/deleteTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_deleteTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -219,7 +219,7 @@ pulsar-admin tenants update my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/updateTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_updateTenant)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-topics.md
+++ b/docs/admin-api-topics.md
@@ -47,7 +47,7 @@ Whether it is a persistent or non-persistent topic, you can obtain the topic res
 :::note
 
 In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.
-Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+Take [](swagger:/admin/v2/PersistentTopics_getList) as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 :::
 
@@ -68,7 +68,7 @@ pulsar-admin topics list my-tenant/my-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ pulsar-admin topics grant-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_grantPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -143,7 +143,7 @@ application1    [consume, produce]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -177,7 +177,7 @@ pulsar-admin topics revoke-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_revokePermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -210,7 +210,7 @@ pulsar-admin topics delete persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -242,7 +242,7 @@ pulsar-admin topics unload persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_unloadTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -372,7 +372,7 @@ pulsar-admin topics stats persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -468,7 +468,7 @@ pulsar-admin topics stats-internal persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -515,7 +515,7 @@ Event time: 0
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_peekNthMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -550,7 +550,7 @@ pulsar-admin topics get-message-by-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageById)
 
 </TabItem>
 <TabItem value="Java">
@@ -585,7 +585,7 @@ pulsar-admin topics examine-messages \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/examinemessage?initialPosition=:initialPosition&messagePosition=:messagePosition|operation/examineMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_examineMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -619,7 +619,7 @@ pulsar-admin topics get-message-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/messageid/:timestamp|operation/getMessageIdByTimestamp?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageIdByTimestamp)
 
 </TabItem>
 <TabItem value="Java">
@@ -655,7 +655,7 @@ pulsar-admin topics skip \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -691,7 +691,7 @@ pulsar-admin topics clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipAllMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -726,7 +726,7 @@ pulsar-admin topics reset-cursor \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_resetCursor)
 
 </TabItem>
 <TabItem value="Java">
@@ -768,7 +768,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic-domain/:tenant/:namespace/:topic|operation/lookupTopicAsync?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_lookupTopicAsync)
 
 </TabItem>
 <TabItem value="Java">
@@ -855,7 +855,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|operation/getNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_getNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -893,7 +893,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -935,7 +935,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId|operation/getLastMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getLastMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -969,7 +969,7 @@ pulsar-admin topics get-backlog-size \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getBacklogSizeByMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -1005,7 +1005,7 @@ pulsar-admin topics get-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1038,7 +1038,7 @@ pulsar-admin topics set-deduplication-snapshot-interval my-topic -i 1000
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 ```json
 {
@@ -1075,7 +1075,7 @@ pulsar-admin topics remove-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1109,7 +1109,7 @@ pulsar-admin topics get-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/getInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1140,7 +1140,7 @@ pulsar-admin topics set-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/setInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1171,7 +1171,7 @@ pulsar-admin topics remove-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/removeInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1205,7 +1205,7 @@ pulsar-admin topics get-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/getOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1236,7 +1236,7 @@ pulsar-admin topics set-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/setOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1267,7 +1267,7 @@ pulsar-admin topics remove-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/removeOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1316,7 +1316,7 @@ When you create a non-partitioned topic with the suffix '-partition-' followed b
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createNonPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1349,7 +1349,7 @@ pulsar-admin topics delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1387,7 +1387,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1421,7 +1421,7 @@ pulsar-admin topics stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1527,7 +1527,7 @@ pulsar-admin topics stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1581,7 +1581,7 @@ If a non-partitioned topic with the suffix '-partition-' followed by a numeric v
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_createPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1617,7 +1617,7 @@ pulsar-admin topics create-missed-partitions \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createMissedPartitions)
 
 </TabItem>
 <TabItem value="Java">
@@ -1665,7 +1665,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -1703,7 +1703,7 @@ pulsar-admin topics update-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_updatePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1734,7 +1734,7 @@ pulsar-admin topics delete-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deletePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1772,7 +1772,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedTopicList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1805,7 +1805,7 @@ pulsar-admin topics partitioned-stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1933,7 +1933,7 @@ pulsar-admin topics partitioned-stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedStatsInternal)
 
 </TabItem>
 <TabItem value="Java">
@@ -1972,7 +1972,7 @@ pulsar-admin topics create-subscription \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subscription|operation/createSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -2012,7 +2012,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -2047,7 +2047,7 @@ pulsar-admin topics unsubscribe \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteSubscription)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/admin-api-transactions.md
+++ b/docs/admin-api-transactions.md
@@ -42,7 +42,7 @@ pulsar-admin transactions slow-transactions -c 1 -t 1s
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/slowTransactions/:timeout|operation/getSlowTransactions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getSlowTransactions)
 
 </TabItem>
 <TabItem value="Java">
@@ -162,7 +162,7 @@ pulsar-admin transactions scale-transactionCoordinators -r 17
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionCoordinator/:replicas|operation/scaleTransactionCoordinators?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_scaleTransactionCoordinators)
 
 </TabItem>
 <TabItem value="Java">
@@ -203,7 +203,7 @@ pulsar-admin transactions transaction-metadata -m 1 -l 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionMetadata/:mostSigBits/:leastSigBits|operation/getTransactionMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -261,7 +261,7 @@ pulsar-admin transactions transaction-in-pending-ack-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInPendingAckStats/:tenant/:namespace/:topic/:subName/:mostSigBits/:leastSigBits|operation/getTransactionInPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -304,7 +304,7 @@ pulsar-admin transactions transaction-in-buffer-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInBufferStats/:tenant/:namespace/:topic/:mostSigBits/:leastSigBits|operation/getTransactionInBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInBufferStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -355,7 +355,7 @@ pulsar-admin transactions coordinator-stats -c 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorStats|operation/getCoordinatorStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -405,7 +405,7 @@ pulsar-admin transactions coordinator-internal-stats -c 1 -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorInternalStats/:coordinatorId|operation/getCoordinatorInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -496,7 +496,7 @@ pulsar-admin.transactions()s pending-ack-stats -t my-topic -s mysubName -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -546,7 +546,7 @@ pulsar-admin transactions pending-ack-internal-stats -t my-topic -s mysubName -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckInternalStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -640,8 +640,7 @@ pulsar-admin transactions position-stats-in-pending-ack -t my-topic -s mysubName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats
-/:tenant/:namespace:/:topic:/:subName/:ledgerId/:entryId?batchIndex=batchIndex|operation/getPositionStatsInPendingAck?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPositionStatsInPendingAck)
 
 </TabItem>
 <TabItem value="Java">
@@ -694,7 +693,7 @@ pulsar-admin transactions transaction-buffer-stats -t my-topic -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionBufferStats/:tenant/:namespace:/:topic:/:subName|operation/getTransactionBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionBufferStats)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/administration-geo.md
+++ b/docs/administration-geo.md
@@ -180,7 +180,7 @@ bin/pulsar-admin topics stats persistent://my-tenant/my-namespace/my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 

--- a/docs/administration-isolation-bookie.md
+++ b/docs/administration-isolation-bookie.md
@@ -174,7 +174,7 @@ In addition, you can also group bookies across racks or regions to serve broker-
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/bookies/racks-info/:bookie|operation/updateBookieRackInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Bookies_updateBookieRackInfo)
 
 </TabItem>
 
@@ -257,7 +257,7 @@ For the bookie rack name restrictions, see [pulsar-admin bookies set-bookie-rack
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence/bookieAffinity|operation/setBookieAffinityGroup?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/docs/administration-isolation-broker.md
+++ b/docs/administration-isolation-broker.md
@@ -41,7 +41,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:namespace/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/docs/administration-upgrade.md
+++ b/docs/administration-upgrade.md
@@ -194,7 +194,7 @@ pulsar-admin brokers healthcheck
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/brokers/health|operation/healthCheck?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/BrokersBase_healthCheck)
 
 </TabItem>
 

--- a/docs/administration-zk-bk.md
+++ b/docs/administration-zk-bk.md
@@ -319,7 +319,7 @@ pulsar-admin namespaces set-persistence my-tenant/my-ns -e 3 -w 3 -a 3
 
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 </TabItem>
 
@@ -372,7 +372,7 @@ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 </TabItem>
 

--- a/docs/cookbooks-retention-expiry.md
+++ b/docs/cookbooks-retention-expiry.md
@@ -120,7 +120,7 @@ pulsar-admin namespaces set-retention my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 :::note
 
@@ -168,7 +168,7 @@ pulsar-admin namespaces get-retention my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -240,7 +240,7 @@ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns/my-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -283,7 +283,7 @@ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -321,7 +321,7 @@ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -378,7 +378,7 @@ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -412,7 +412,7 @@ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -445,7 +445,7 @@ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">

--- a/docs/io-use.md
+++ b/docs/io-use.md
@@ -194,7 +194,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_registerSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -279,7 +279,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_registerSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/docs/io-use.md
+++ b/docs/io-use.md
@@ -194,7 +194,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -279,7 +279,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -370,11 +370,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 
@@ -405,11 +405,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
 
 </TabItem>
 
@@ -511,7 +511,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -616,7 +616,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -718,7 +718,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace|operation/listSources?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_listSources)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -771,7 +771,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace|operation/listSinks?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_listSinks)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -830,11 +830,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** source connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -920,11 +920,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** sink connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkStatus)
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInstanceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1014,7 +1014,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_updateSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1103,7 +1103,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_updateSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1200,11 +1200,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=all)
 
 * Stop a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1290,11 +1290,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=all)
 
 * Stop a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1386,11 +1386,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1476,11 +1476,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1572,7 +1572,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete al Pulsar source connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1634,7 +1634,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete a sink connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/docs/io-use.md
+++ b/docs/io-use.md
@@ -370,11 +370,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=!all)
 
 </TabItem>
 
@@ -405,11 +405,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=!all)
 
 </TabItem>
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,8 +40,6 @@ const lookupApiUrl = url + "/lookup-rest-api";
 const githubUrl = "https://github.com/apache/pulsar";
 const githubSiteUrl = "https://github.com/apache/pulsar-site";
 const baseUrl = "/";
-const remarkMath = require('remark-math');
-const rehypeKatex = require('rehype-katex');
 
 const injectLinkParse = (prefix, name, path) => {
   if (prefix == "javadoc") {
@@ -88,7 +86,7 @@ const injectLinkParse = (prefix, name, path) => {
 };
 
 const injectLinkParseForEndpoint = (info) => {
-  let [ method, path, suffix ] = info.split("|");
+  let [method, path, suffix] = info.split("|");
 
   if (!suffix) {
     suffix = "";
@@ -127,247 +125,248 @@ const injectLinkParseForEndpoint = (info) => {
 };
 
 /** @type {import('@docusaurus/types').Config} */
-module.exports = {
-  title: "Apache Pulsar",
-  tagline:
-    "Apache Pulsar is a distributed, open source pub-sub messaging and streaming platform for real-time workloads, managing hundreds of billions of events per day.",
-  url: "https://pulsar.apache.org",
-  baseUrl: baseUrl,
-  onBrokenLinks: "warn",
-  onBrokenMarkdownLinks: "warn",
-  favicon: "img/favicon.ico",
-  organizationName: "apache",
-  projectName: "pulsar",
-  customFields: {
-    githubUrl,
-    oldUrl,
-  },
-  trailingSlash: true,
-  markdown: {
-    preprocessor: ({filePath, fileContent}) => {
-      return fileContent.replaceAll(/{@inject:([^}]+)}/g, (_, p1) => {
-        const p1Trimmed = p1.trim();
-        const endpointPrefix = 'endpoint|';
-        let link, text;
-        if (p1Trimmed.startsWith(endpointPrefix)) {
-          // @ts-ignore
-          ({ link, text } = injectLinkParseForEndpoint(p1Trimmed.substring(endpointPrefix.length)));
-        } else {
-          ({ link, text } = injectLinkParse(...p1Trimmed.split(':')));
-        }
-        return `[${text}](${link})`; // Format as a markdown link
-      });
+module.exports = async function createConfigAsync() {
+  return {
+    title: "Apache Pulsar",
+    tagline:
+      "Apache Pulsar is a distributed, open source pub-sub messaging and streaming platform for real-time workloads, managing hundreds of billions of events per day.",
+    url: "https://pulsar.apache.org",
+    baseUrl: baseUrl,
+    onBrokenLinks: "warn",
+    onBrokenMarkdownLinks: "warn",
+    favicon: "img/favicon.ico",
+    organizationName: "apache",
+    projectName: "pulsar",
+    customFields: {
+      githubUrl,
+      oldUrl,
     },
-  },
-  themeConfig:
-  /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-  ({
-    image: 'img/pulsar-social-media-card.png',
-    announcementBar: {
-      id: "summit",
-      content: renderAnnouncementBar(
-        "✨ Apache Pulsar 4.0 LTS is here! ✨",
-        "/blog/2024/10/24/announcing-apache-pulsar-4-0/"
-      ),
-      backgroundColor: "#282826",
-      textColor: "#fff",
-      isCloseable: false,
-    },
-    colorMode: {
-      disableSwitch: true,
-    },
-    zoom: {
-      selector: '.markdown img',
-      background: {
-        light: '#fff',
-        dark: '#111'
+    trailingSlash: true,
+    markdown: {
+      preprocessor: ({ filePath, fileContent }) => {
+        return fileContent.replaceAll(/{@inject:([^}]+)}/g, (_, p1) => {
+          const p1Trimmed = p1.trim();
+          const endpointPrefix = 'endpoint|';
+          let link, text;
+          if (p1Trimmed.startsWith(endpointPrefix)) {
+            // @ts-ignore
+            ({ link, text } = injectLinkParseForEndpoint(p1Trimmed.substring(endpointPrefix.length)));
+          } else {
+            ({ link, text } = injectLinkParse(...p1Trimmed.split(':')));
+          }
+          return `[${text}](${link})`; // Format as a markdown link
+        });
       },
-      config: {
-        // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
-      }
     },
-    navbar: {
-      title: "",
-      logo: {
-        alt: "Apache Pulsar logo",
-        src: "img/logo-black.svg",
-        width: 127,
-        height: 25
-      },
-      items: [
-        {
-          type: "dropdown",
-          label: "Get Started",
-          position: "left",
-          items: [
-               {
-              to: `/docs/${latestVersion}/concepts-overview/`,
-              activeBaseRegex: `docs/(${versions.join('|')})/concepts-overview/$`,
-              label: "Concepts",
-            },
-            {
-              to: `/docs/${latestVersion}/`,
-              activeBaseRegex: `docs/(${versions.join('|')})/$`,
-              label: "Quickstart",
-            },
-            {
-              to: "/ecosystem/",
-              label: "Ecosystem",
-            }
-          ],
+    themeConfig:
+      /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+      ({
+        image: 'img/pulsar-social-media-card.png',
+        announcementBar: {
+          id: "summit",
+          content: renderAnnouncementBar(
+            "✨ Apache Pulsar 4.0 LTS is here! ✨",
+            "/blog/2024/10/24/announcing-apache-pulsar-4-0/"
+          ),
+          backgroundColor: "#282826",
+          textColor: "#fff",
+          isCloseable: false,
         },
-        {
-          type: "doc",
-          docId: "about",
-          position: "left",
-          label: "Docs",
+        colorMode: {
+          disableSwitch: true,
         },
-        {
-          to: "/features/",
-          position: "left",
-          label: "Features",
+        zoom: {
+          selector: '.markdown img',
+          background: {
+            light: '#fff',
+            dark: '#111'
+          },
+          config: {
+            // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
+          }
         },
-        {
-          to: "/use-cases/",
-          position: "left",
-          label: "Use Cases",
-        },
-        {
-          type: "dropdown",
-          label: "Community",
-          position: "left",
-          className: "community-dropdown",
+        navbar: {
+          title: "",
+          logo: {
+            alt: "Apache Pulsar logo",
+            src: "img/logo-black.svg",
+            width: 127,
+            height: 25
+          },
           items: [
             {
-              to: "/community",
-              activeBaseRegex: "^$",
-              label: "Welcome",
-              className: "scroll-link scroll-welcome",
-              id: "scroll-welcome",
+              type: "dropdown",
+              label: "Get Started",
+              position: "left",
+              items: [
+                {
+                  to: `/docs/${latestVersion}/concepts-overview/`,
+                  activeBaseRegex: `docs/(${versions.join('|')})/concepts-overview/$`,
+                  label: "Concepts",
+                },
+                {
+                  to: `/docs/${latestVersion}/`,
+                  activeBaseRegex: `docs/(${versions.join('|')})/$`,
+                  label: "Quickstart",
+                },
+                {
+                  to: "/ecosystem/",
+                  label: "Ecosystem",
+                }
+              ],
             },
             {
-              to: "/community#section-discussions",
-              activeBaseRegex: "^$",
-              label: "Discussions",
-              className: "scroll-link scroll-discussions",
-              id: "scroll-discussions",
+              type: "doc",
+              docId: "about",
+              position: "left",
+              label: "Docs",
             },
             {
-              to: "/community#section-governance",
-              activeBaseRegex: "^$",
-              label: "Governance",
-              className: "scroll-link",
-              id: "scroll-governance",
+              to: "/features/",
+              position: "left",
+              label: "Features",
             },
             {
-              to: "/community#section-community",
-              activeBaseRegex: "^$",
-              label: "Meet the Community",
-              className: "scroll-link",
-              id: "scroll-community",
+              to: "/use-cases/",
+              position: "left",
+              label: "Use Cases",
             },
             {
-              to: "/community#section-contribute",
-              activeBaseRegex: "^$",
-              label: "Contribute",
-              className: "scroll-link",
-              id: "scroll-contribute",
+              type: "dropdown",
+              label: "Community",
+              position: "left",
+              className: "community-dropdown",
+              items: [
+                {
+                  to: "/community",
+                  activeBaseRegex: "^$",
+                  label: "Welcome",
+                  className: "scroll-link scroll-welcome",
+                  id: "scroll-welcome",
+                },
+                {
+                  to: "/community#section-discussions",
+                  activeBaseRegex: "^$",
+                  label: "Discussions",
+                  className: "scroll-link scroll-discussions",
+                  id: "scroll-discussions",
+                },
+                {
+                  to: "/community#section-governance",
+                  activeBaseRegex: "^$",
+                  label: "Governance",
+                  className: "scroll-link",
+                  id: "scroll-governance",
+                },
+                {
+                  to: "/community#section-community",
+                  activeBaseRegex: "^$",
+                  label: "Meet the Community",
+                  className: "scroll-link",
+                  id: "scroll-community",
+                },
+                {
+                  to: "/community#section-contribute",
+                  activeBaseRegex: "^$",
+                  label: "Contribute",
+                  className: "scroll-link",
+                  id: "scroll-contribute",
+                },
+                {
+                  to: "/contribute/",
+                  label: "Contribution Guide",
+                },
+                {
+                  to: "https://github.com/apache/pulsar/wiki",
+                  label: "Wiki",
+                },
+                {
+                  to: "https://github.com/apache/pulsar/issues",
+                  label: "Issue Tracking",
+                },
+              ],
             },
             {
-              to: "/contribute/",
-              label: "Contribution Guide",
+              type: "dropdown",
+              label: "Learn",
+              position: "left",
+              items: [
+                {
+                  to: "/blog",
+                  label: "Blog",
+                },
+                {
+                  to: "/books",
+                  label: "Books",
+                },
+                {
+                  to: "/case-studies",
+                  label: "Case Studies",
+                },
+                {
+                  to: "/articles",
+                  label: "Articles",
+                },
+                {
+                  to: "/presentations",
+                  label: "Presentations",
+                },
+                {
+                  to: "/events",
+                  label: "Events",
+                },
+              ],
             },
             {
-              to: "https://github.com/apache/pulsar/wiki",
-              label: "Wiki",
-            },
-            {
-              to: "https://github.com/apache/pulsar/issues",
-              label: "Issue Tracking",
-            },
-          ],
-        },
-        {
-          type: "dropdown",
-          label: "Learn",
-          position: "left",
-          items: [
-            {
-              to: "/blog",
-              label: "Blog",
-            },
-            {
-              to: "/books",
-              label: "Books",
-            },
-            {
-              to: "/case-studies",
-              label: "Case Studies",
-            },
-            {
-              to: "/articles",
-              label: "Articles",
-            },
-            {
-              to: "/presentations",
-              label: "Presentations",
-            },
-            {
-              to: "/events",
-              label: "Events",
-            },
-          ],
-        },
-        {
-          to: "/download",
-          label: "Download",
-          position: "right",
-          className: "navbar_download_button",
-        },
-      ],
-    },
-    footer: {
-      logo: { alt: "Pulsar Logo", src: "img/pulsar-white.svg", href: "/" },
-      links: [
-        {
-          items: [
-            { label: "Foundation", href: "https://www.apache.org/" },
-            {
-              label: "Events",
-              href: "https://www.apache.org/events/current-event.html",
-            },
-          ],
-        },
-        {
-          items: [
-            { label: "License", href: "https://www.apache.org/licenses/" },
-            {
-              label: "Thanks",
-              href: "https://www.apache.org/foundation/thanks",
-            },
-            {
-              label: "Sponsorship",
-              href: "https://www.apache.org/foundation/sponsorship",
-            },
-          ],
-        },
-        {
-          items: [
-            { label: "Security", to: "/security" },
-            {
-              label: "Privacy",
-              href: "https://www.apache.org/foundation/policies/privacy.html",
-            },
-            {
-              label: "Contact",
-              to: "/contact",
+              to: "/download",
+              label: "Download",
+              position: "right",
+              className: "navbar_download_button",
             },
           ],
         },
-        {
-          items: [
+        footer: {
+          logo: { alt: "Pulsar Logo", src: "img/pulsar-white.svg", href: "/" },
+          links: [
             {
-              html: `
+              items: [
+                { label: "Foundation", href: "https://www.apache.org/" },
+                {
+                  label: "Events",
+                  href: "https://www.apache.org/events/current-event.html",
+                },
+              ],
+            },
+            {
+              items: [
+                { label: "License", href: "https://www.apache.org/licenses/" },
+                {
+                  label: "Thanks",
+                  href: "https://www.apache.org/foundation/thanks",
+                },
+                {
+                  label: "Sponsorship",
+                  href: "https://www.apache.org/foundation/sponsorship",
+                },
+              ],
+            },
+            {
+              items: [
+                { label: "Security", to: "/security" },
+                {
+                  label: "Privacy",
+                  href: "https://www.apache.org/foundation/policies/privacy.html",
+                },
+                {
+                  label: "Contact",
+                  to: "/contact",
+                },
+              ],
+            },
+            {
+              items: [
+                {
+                  html: `
                 <div class="social-icons">
                   <a
                     target="_blank"
@@ -385,11 +384,11 @@ module.exports = {
                   </a>
                 </div>
               `,
-              },
-            ],
-          },
-        ],
-        copyright: `
+                },
+              ],
+            },
+          ],
+          copyright: `
         <div>
           <img class="footer-apache-logo" src="/img/feather-logo-white.svg" alt="" width="20">
           The Apache Software Foundation
@@ -397,142 +396,142 @@ module.exports = {
         <p>Apache Pulsar is available under the Apache License, version 2.0. Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud.</p>
         <p>Copyright © ${new Date().getFullYear()} The Apache Software Foundation. All Rights Reserved. Apache, Pulsar, Apache Pulsar, and the Apache feather logo are trademarks or registered trademarks of The Apache Software Foundation.</p>
       `,
-    },
-    prism: {
-      theme: require("prism-react-renderer").themes.dracula,
-      additionalLanguages: [
-        "bash",
-        "diff",
-        "json",
-        "go",
-        "csharp",
-        "groovy",
-        "http",
-        "ini",
-        "java",
-        "powershell",
-        "properties",
-        "protobuf",
-        "yaml",
-      ],
-    },
-    algolia: {
-      appId: "WK2YL0SALL",
-      apiKey: "42d24d221fbd8eb59804a078208aaec0",
-      indexName: "apache_pulsar",
-    },
-  }),
-
-  presets: [
-    [
-      "@docusaurus/preset-classic",
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      {
-        docs: {
-          path: "docs",
-          sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: `${githubSiteUrl}/edit/main`,
-          remarkPlugins: [remarkMath],
-          rehypePlugins: [rehypeKatex],
-          versions: versionsMap,
-          onlyIncludeVersions: buildVersions || ["current"],
         },
-        blog: {
-          blogSidebarCount: 0,
-          showReadingTime: true,
-          editUrl: `${githubSiteUrl}/edit/main/`,
-          onInlineAuthors: 'ignore',
-        },
-        theme: {
-          customCss: [
-            require.resolve("./src/css/custom.css"),
-            require.resolve("./src/css/docs.css"),
-            require.resolve("./src/css/base-table.css"),
-            require.resolve("./src/css/typography.css"),
-            require.resolve("./src/css/image-zoom.css"),
-            require.resolve("./src/css/announcement-bar.css"),
-            require.resolve("./src/css/navbar.css"),
-            require.resolve("./src/css/footer.css"),
-            require.resolve("./src/css/variables.css"),
-            require.resolve("./src/css/blog.css"),
+        prism: {
+          theme: require("prism-react-renderer").themes.dracula,
+          additionalLanguages: [
+            "bash",
+            "diff",
+            "json",
+            "go",
+            "csharp",
+            "groovy",
+            "http",
+            "ini",
+            "java",
+            "powershell",
+            "properties",
+            "protobuf",
+            "yaml",
           ],
         },
-        //googleAnalytics: {
-        //  trackingID: "UA-102219959-1",
-        //},
-      },
-    ],
-  ],
-  plugins: [
-    [
-      '@docusaurus/plugin-client-redirects',
-      {
-        redirects: [
-          {
-            from: '/contribute/setup-mergetool',
-            to: '/contribute/setup-git',
-          },
-        ],
-      },
-    ],    
-    'docusaurus-plugin-image-zoom',
-    [
-      "content-docs",
-      /** @type {import('@docusaurus/plugin-content-docs').Options} */
-      ({
-        id: "contribute",
-        path: "contribute",
-        routeBasePath: "contribute",
-        showLastUpdateAuthor: true,
-        showLastUpdateTime: true,
-        sidebarPath: require.resolve("./sidebarsDevelopment.js"),
-        editUrl: `${githubSiteUrl}/edit/main`,
+        algolia: {
+          appId: "WK2YL0SALL",
+          apiKey: "42d24d221fbd8eb59804a078208aaec0",
+          indexName: "apache_pulsar",
+        },
       }),
-    ],
-    [
-      "content-docs",
-      /** @type {import('@docusaurus/plugin-content-docs').Options} */
-      ({
-        id: "release-notes",
-        path: "release-notes",
-        routeBasePath: "release-notes",
-        editUrl: `${githubSiteUrl}/edit/main`,
-        sidebarPath: require.resolve("./sidebarsReleaseNotes.js"),
-      }),
-    ],
-    [
-      "content-docs",
-      /** @type {import('@docusaurus/plugin-content-docs').Options} */
-      ({
-        id: "security",
-        path: "security",
-        routeBasePath: "security",
-        sidebarPath: false,
-      }),
-    ],
-    [
-      "content-docs",
-      /** @type {import('@docusaurus/plugin-content-docs').Options} */
-      ({
-        id: "client-feature-matrix",
-        path: "client-feature-matrix",
-        routeBasePath: "client-feature-matrix",
-        sidebarPath: false,
-      }),
-    ]
-  ],
-  scripts: [
-    { src: "/js/sine-waves.min.js", async: true },
-    "/js/matomo-agent.js",
-  ],
-  clientModules: [require.resolve("./matomoClientModule.ts")],
-  stylesheets: [
-    {
-      href: "/css/katex-0.13.24.min.css",
-      type: "text/css",
-      media: "print", // load CSS asynchronously to increase performance of page first load
-      onload: "this.media='all'", // load CSS asynchronously to increase performance of page first load
-    },
-  ],
-};
 
+    presets: [
+      [
+        "@docusaurus/preset-classic",
+        /** @type {import('@docusaurus/preset-classic').Options} */
+        {
+          docs: {
+            path: "docs",
+            sidebarPath: require.resolve("./sidebars.js"),
+            editUrl: `${githubSiteUrl}/edit/main`,
+            remarkPlugins: [(await import('remark-math')).default],
+            rehypePlugins: [(await import('rehype-katex')).default],
+            versions: versionsMap,
+            onlyIncludeVersions: buildVersions || ["current"],
+          },
+          blog: {
+            blogSidebarCount: 0,
+            showReadingTime: true,
+            editUrl: `${githubSiteUrl}/edit/main/`,
+            onInlineAuthors: 'ignore',
+          },
+          theme: {
+            customCss: [
+              require.resolve("./src/css/custom.css"),
+              require.resolve("./src/css/docs.css"),
+              require.resolve("./src/css/base-table.css"),
+              require.resolve("./src/css/typography.css"),
+              require.resolve("./src/css/image-zoom.css"),
+              require.resolve("./src/css/announcement-bar.css"),
+              require.resolve("./src/css/navbar.css"),
+              require.resolve("./src/css/footer.css"),
+              require.resolve("./src/css/variables.css"),
+              require.resolve("./src/css/blog.css"),
+            ],
+          },
+          //googleAnalytics: {
+          //  trackingID: "UA-102219959-1",
+          //},
+        },
+      ],
+    ],
+    plugins: [
+      [
+        '@docusaurus/plugin-client-redirects',
+        {
+          redirects: [
+            {
+              from: '/contribute/setup-mergetool',
+              to: '/contribute/setup-git',
+            },
+          ],
+        },
+      ],
+      'docusaurus-plugin-image-zoom',
+      [
+        "content-docs",
+        /** @type {import('@docusaurus/plugin-content-docs').Options} */
+        ({
+          id: "contribute",
+          path: "contribute",
+          routeBasePath: "contribute",
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
+          sidebarPath: require.resolve("./sidebarsDevelopment.js"),
+          editUrl: `${githubSiteUrl}/edit/main`,
+        }),
+      ],
+      [
+        "content-docs",
+        /** @type {import('@docusaurus/plugin-content-docs').Options} */
+        ({
+          id: "release-notes",
+          path: "release-notes",
+          routeBasePath: "release-notes",
+          editUrl: `${githubSiteUrl}/edit/main`,
+          sidebarPath: require.resolve("./sidebarsReleaseNotes.js"),
+        }),
+      ],
+      [
+        "content-docs",
+        /** @type {import('@docusaurus/plugin-content-docs').Options} */
+        ({
+          id: "security",
+          path: "security",
+          routeBasePath: "security",
+          sidebarPath: false,
+        }),
+      ],
+      [
+        "content-docs",
+        /** @type {import('@docusaurus/plugin-content-docs').Options} */
+        ({
+          id: "client-feature-matrix",
+          path: "client-feature-matrix",
+          routeBasePath: "client-feature-matrix",
+          sidebarPath: false,
+        }),
+      ]
+    ],
+    scripts: [
+      { src: "/js/sine-waves.min.js", async: true },
+      "/js/matomo-agent.js",
+    ],
+    clientModules: [require.resolve("./matomoClientModule.ts")],
+    stylesheets: [
+      {
+        href: "/css/katex-0.13.24.min.css",
+        type: "text/css",
+        media: "print", // load CSS asynchronously to increase performance of page first load
+        onload: "this.media='all'", // load CSS asynchronously to increase performance of page first load
+      },
+    ],
+  };
+};

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,28 +27,21 @@ try {
   //do nothing
 }
 
-const oldUrl = "https://pulsar.apache.org";
-const url = "https://pulsar.apache.org";
-const javadocUrl = url + "/api";
-const restApiUrl = url + "/admin-rest-api";
-const functionsApiUrl = url + "/functions-rest-api";
-const sourceApiUrl = url + "/source-rest-api";
-const sinkApiUrl = url + "/sink-rest-api";
-const packagesApiUrl = url + "/packages-rest-api";
-const transactionsApiUrl = url + "/transactions-rest-api";
-const lookupApiUrl = url + "/lookup-rest-api";
-const githubUrl = "https://github.com/apache/pulsar";
-const githubSiteUrl = "https://github.com/apache/pulsar-site";
-const baseUrl = "/";
-const restApiBaseUrlMapping = {
-  default: restApiUrl,
-  functions: functionsApiUrl,
-  source: sourceApiUrl,
-  sink: sinkApiUrl,
-  packages: packagesApiUrl,
-  transactions: transactionsApiUrl,
-  lookup: lookupApiUrl
-};
+const {
+  siteUrl,
+  javadocUrl,
+  restApiUrl,
+  functionsApiUrl,
+  sourceApiUrl,
+  sinkApiUrl,
+  packagesApiUrl,
+  transactionsApiUrl,
+  lookupApiUrl,
+  githubUrl,
+  githubSiteUrl,
+  baseUrl,
+  restApiBaseUrlMapping
+} = require("./site-baseurls");
 
 const injectLinkParse = (prefix, name, path) => {
   if (prefix == "javadoc") {
@@ -139,10 +132,6 @@ module.exports = async function createConfigAsync() {
     favicon: "img/favicon.ico",
     organizationName: "apache",
     projectName: "pulsar",
-    customFields: {
-      githubUrl,
-      oldUrl,
-    },
     trailingSlash: true,
     markdown: {
       preprocessor: ({ filePath, fileContent }) => {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -152,7 +152,8 @@ module.exports = async function createConfigAsync() {
             // @ts-ignore
             ({ link, text } = injectLinkParseForEndpoint(p1Trimmed.substring(endpointPrefix.length)));
           } else {
-            ({ link, text } = injectLinkParse(...p1Trimmed.split(':')));
+            const [prefix, name, path] = p1Trimmed.split(':');
+            ({ link, text } = injectLinkParse(prefix, name, path));
           }
           return `[${text}](${link})`; // Format as a markdown link
         });

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "autoprefixer": "^10.4.20",
     "highlight.js": "^11.10.0",
     "marked": "^14.1.3",
+    "null-loader": "^4.0.1",
     "postcss": "^8.4.47",
     "postcss-cli": "^11.0.0",
     "postcss-import": "^16.1.0",

--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -2,7 +2,7 @@ const replace = require("replace-in-file");
 
 const semver = require("semver");
 const CWD = process.cwd();
-const siteConfig = {url: "https://pulsar.apache.org", baseUrl: "/"};
+const urlConfig = require("../site-baseurls.js");
 const nextDocsDir = `${CWD}/docs`;
 const docsDir = `${CWD}/versioned_docs`;
 const restApiVersions = require("../static/swagger/restApiVersions.json");
@@ -30,7 +30,7 @@ function getRealVersion(version) {
 }
 
 function downloadPageUrl() {
-  return `${siteConfig.baseUrl}download`;
+  return `${urlConfig.baseUrl}download`;
 }
 
 function binaryReleaseUrl(version) {
@@ -115,33 +115,33 @@ function clientPythonVersion(version) {
 
 function clientPythonVersionUrl(version) {
   if (version === "2.6.4") {
-    return `${siteConfig.url}/api/python/2.6.3`;
+    return `${urlConfig.siteUrl}/api/python/2.6.3`;
   }
   let v = semver.coerce(version);
   if (v.compareMain("2.8.0") < 0) {
-    return `${siteConfig.url}/api/python/${version}`;
+    return `${urlConfig.siteUrl}/api/python/${version}`;
   }
   if (v.compareMain("2.11.0") < 0) {
-    return `${siteConfig.url}/api/python/${v.major}.${v.minor}.x`;
+    return `${urlConfig.siteUrl}/api/python/${v.major}.${v.minor}.x`;
   }
   let versions = require(`${CWD}/data/release-python`);
-  return `${siteConfig.url}/api/python/${versions[0].vtag}`;
+  return `${urlConfig.siteUrl}/api/python/${versions[0].vtag}`;
 }
 
 function clientCPPVersionUrl(version) {
   let v = semver.coerce(version);
   if (v.compareMain("2.8.0") < 0) {
-    return `${siteConfig.url}/api/cpp/${version}`;
+    return `${urlConfig.siteUrl}/api/cpp/${version}`;
   }
   if (v.compareMain("2.11.0") < 0) {
-    return `${siteConfig.url}/api/cpp/${v.major}.${v.minor}.x`;
+    return `${urlConfig.siteUrl}/api/cpp/${v.major}.${v.minor}.x`;
   }
   let versions = require(`${CWD}/data/release-cpp`);
-  return `${siteConfig.url}/api/cpp/${versions[0].vtag}`;
+  return `${urlConfig.siteUrl}/api/cpp/${versions[0].vtag}`;
 }
 
 function javadocVersionUrl(version, type) {
-  return `(${siteConfig.url}/api/${type}/${version}`
+  return `(${urlConfig.siteUrl}/api/${type}/${version}`
 }
 
 function referenceVersion(version) {

--- a/site-baseurls.js
+++ b/site-baseurls.js
@@ -1,0 +1,35 @@
+const siteUrl = "https://pulsar.apache.org";
+
+const config = {
+  siteUrl,
+  javadocUrl: `${siteUrl}/api`,
+  restApiUrl: `${siteUrl}/admin-rest-api`,
+  functionsApiUrl: `${siteUrl}/functions-rest-api`,
+  sourceApiUrl: `${siteUrl}/source-rest-api`,
+  sinkApiUrl: `${siteUrl}/sink-rest-api`,
+  packagesApiUrl: `${siteUrl}/packages-rest-api`,
+  transactionsApiUrl: `${siteUrl}/transactions-rest-api`,
+  lookupApiUrl: `${siteUrl}/lookup-rest-api`,
+  githubUrl: "https://github.com/apache/pulsar",
+  githubSiteUrl: "https://github.com/apache/pulsar-site",
+  baseUrl: "/",
+};
+
+config.restApiBaseUrlMapping = {
+  default: config.restApiUrl,
+  functions: config.functionsApiUrl,
+  source: config.sourceApiUrl,
+  sink: config.sinkApiUrl,
+  packages: config.packagesApiUrl,
+  transactions: config.transactionsApiUrl,
+  lookup: config.lookupApiUrl
+};
+
+// CommonJS export
+module.exports = config;
+
+// Also support ES modules
+if (typeof exports === 'object' && typeof module !== 'undefined') {
+  Object.defineProperty(exports, '__esModule', { value: true });
+  exports.default = config;
+} 

--- a/src/server/remarkPlugins/swagger/index.ts
+++ b/src/server/remarkPlugins/swagger/index.ts
@@ -1,0 +1,235 @@
+// after modifying this file, run `npm run docusaurus clear` to clear the cache
+import path from 'path';
+import type {Transformer} from 'unified';
+import type {Parent} from 'unist';
+import type {Link} from 'mdast';
+import fs from 'fs';
+
+// Define available swagger file types
+type SwaggerApiType = 'default' | 'functions' | 'lookup' | 'packages' | 'sink' | 'source' | 'transactions';
+
+type PluginOptions = {
+  baseDir: string;
+  restApiBaseUrlMapping: Record<SwaggerApiType, string>;
+  swaggerDir?: string;
+};
+
+// Add new return type for getSwaggerJson
+type SwaggerResult = {
+  version: string;
+  json: any;
+};
+
+type Context = PluginOptions & {
+  filePath: string;
+  cache: {
+    getSwaggerResult: (docPath: string, type?: SwaggerApiType) => SwaggerResult;
+  };
+};
+
+type Target = [node: Link, index: number, parent: Parent];
+
+function findLatestVersion(swaggerDir: string, majorMinor: string): string {
+  try {
+    const dirs = fs.readdirSync(swaggerDir)
+      .filter(dir => dir.startsWith(majorMinor))
+      .sort((a, b) => {
+        // Sort versions in descending order
+        const verA = a.split('.').map(Number);
+        const verB = b.split('.').map(Number);
+        for (let i = 0; i < 3; i++) {
+          if (verA[i] !== verB[i]) return verB[i] - verA[i];
+        }
+        return 0;
+      });
+    
+    return dirs[0] || majorMinor + '.0'; // Return latest or fallback
+  } catch (error) {
+    console.warn(`Failed to read swagger directory for ${majorMinor}:`, error);
+    return majorMinor + '.0';
+  }
+}
+
+function getSwaggerFileName(type: SwaggerApiType = 'default'): string {
+  const fileNames: Record<SwaggerApiType, string> = {
+    default: 'swagger.json',
+    functions: 'swaggerfunctions.json',
+    lookup: 'swaggerlookup.json',
+    packages: 'swaggerpackages.json',
+    sink: 'swaggersink.json',
+    source: 'swaggersource.json',
+    transactions: 'swaggertransactions.json'
+  };
+  return fileNames[type];
+}
+
+function createSwaggerCache(swaggerDir: string): {
+  getSwaggerResult: (docPath: string, type?: SwaggerApiType) => SwaggerResult;
+} {
+  const versionCache: {
+    [key: string]: {
+      latestVersion: string;
+      jsonCache: Map<string, SwaggerResult>;
+    };
+  } = {};
+
+  return {
+    getSwaggerResult: (docPath: string, type: SwaggerApiType = 'default') => {
+      const versionMatch = docPath.match(/version-(\d+\.\d+\.x)/);
+      const majorMinor = versionMatch ? versionMatch[1].replace('.x', '') : 'master';
+      const cache = versionCache[majorMinor]?.jsonCache;
+      
+      const cacheKey = `${type}`;
+      if (cache?.has(cacheKey)) {
+        return cache.get(cacheKey)!;
+      }
+
+      try {
+        const fileName = getSwaggerFileName(type);
+        const version = majorMinor === 'master' ? 'master' : versionCache[majorMinor]?.latestVersion || findLatestVersion(swaggerDir, majorMinor);
+        const filePath = path.join(swaggerDir, version, fileName);
+        const jsonContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        
+        const result: SwaggerResult = {
+          version,
+          json: jsonContent
+        };
+
+        if (!versionCache[majorMinor]) {
+          versionCache[majorMinor] = {
+            latestVersion: version,
+            jsonCache: new Map()
+          };
+        }
+        versionCache[majorMinor].jsonCache.set(cacheKey, result);
+        
+        return result;
+      } catch (error) {
+        console.error(`Failed to load swagger JSON for ${docPath} type ${type}:`, error);
+        throw error;
+      }
+    }
+  };
+}
+
+async function processLinkNode(target: Target, context: Context) {
+  const [node] = target;
+  if (!node.url || !node.url.startsWith("swagger:")) {
+    return;
+  }
+  const pathname = node.url.split('?')[0].slice("swagger:".length);
+  const queryString = node.url.split('?')[1];
+  const queryParams = queryString 
+    ? new Map(queryString.split('&').map(param => {
+        const [key, value = ''] = param.split('=');
+        return [decodeURIComponent(key).replace(/\+/g, ' '), decodeURIComponent(value).replace(/\+/g, ' ')] as const;
+      }))
+    : new Map();
+  const relativePath = path.relative(context.baseDir, context.filePath);
+
+  // Split the path into segments
+  const segments = pathname.split('/').filter(Boolean);
+  
+  // Parse the path segments
+  const isAdmin = segments[0] === 'admin';
+  if (!isAdmin || segments.length < 2) {
+    throw new Error(`Invalid swagger URL format: ${pathname}`);
+  }
+
+  // Extract components
+  let apiVersion = segments[1];
+  let apiType: SwaggerApiType = 'default';
+  let operationName: string;
+
+  if (segments.length === 3) {
+    operationName = segments[2];
+  } else {
+    apiType = segments[2] as SwaggerApiType;
+    operationName = segments[3];
+  }
+
+  const position = node.position ? ` ${relativePath} at position ${node.position.start.line}:${node.position.start.column}` : '';
+
+  // Validate the subContext is a valid SwaggerFileType
+  if (apiType !== 'default' && !getSwaggerFileName(apiType)) {
+    throw new Error(`Invalid swagger sub-context: ${apiType}${position}`);
+  }
+
+  const swaggerResult = context.cache.getSwaggerResult(relativePath, apiType);
+  const swaggerJson = swaggerResult.json;
+
+  // Search through all paths in the swagger JSON
+  let matches: { path: string; method: string; tags: string[]; summary?: string }[] = [];
+  
+  const tagParam = queryParams.get('tag') || 
+    (operationName.startsWith('PersistentTopics_') ? '^persistent' : undefined);
+  const summaryParam = queryParams.get('summary');
+
+  // Handle negation separately from regex pattern
+  const isTagNegated = tagParam?.startsWith('!') || false;
+  const isSummaryNegated = summaryParam?.startsWith('!') || false;
+
+  // Convert params to regex patterns without negation
+  const tagRegex = tagParam && new RegExp(isTagNegated ? tagParam.slice(1) : tagParam);
+  const summaryRegex = summaryParam && new RegExp(isSummaryNegated ? summaryParam.slice(1) : summaryParam);
+
+  for (const [path, methods] of Object.entries(swaggerJson.paths || {})) {
+    for (const [method, operation] of Object.entries(methods as Record<string, {
+      operationId: string;
+      tags: string[];
+      summary?: string;
+    }>)) {
+      const tagMatches = !tagRegex || (operation.tags &&operation.tags.some(t => tagRegex.test(t)) !== isTagNegated);
+      const summaryMatches = !summaryRegex || (operation.summary && summaryRegex.test(operation.summary) !== isSummaryNegated);
+      if (operation.operationId === operationName && tagMatches && summaryMatches) {
+        matches.push({ path, method, tags: operation.tags, summary: operation.summary });
+      }
+    }
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`Operation ${operationName} tag:${tagParam} summary:${summaryParam} not found in swagger JSON${position}`);
+  }
+
+  if (matches.length > 1) {
+    console.warn(`Multiple operations found for ${operationName} tag:${tagParam} summary:${summaryParam}:\n${matches.map(m => `${m.method} ${m.path} tags:${m.tags.join(',')} summary:${m.summary}`).join('\n')}${position}`);
+  }
+
+  // Select the match with the longest path since there are duplicates
+  const longestMatch = matches.reduce((longest, current) => 
+    current.path.length > longest.path.length ? current : longest
+  );
+
+  const foundPath = swaggerJson.basePath + longestMatch.path;
+  const foundMethod = longestMatch.method.toUpperCase();
+
+  const restApiBaseUrl = context.restApiBaseUrlMapping[apiType];
+
+  const swaggerVersion = swaggerResult.version;
+
+  node.url = `${restApiBaseUrl}?version=${swaggerVersion}&apiVersion=${apiVersion}#operation/${operationName}`;
+
+  node.children = [{
+    type: "text",
+    value: `${foundMethod} ${foundPath}`
+  }];
+}
+
+export default function plugin(options: PluginOptions): Transformer {
+  const swaggerDir = options.swaggerDir || path.join(options.baseDir, 'static/swagger');
+  const cache = createSwaggerCache(swaggerDir);
+
+  return async (root, vfile) => {
+    const {visit} = await import('unist-util-visit');
+    const context: Context = {
+      ...options,
+      filePath: vfile.path,
+      cache,
+    };
+    const promises: Promise<void>[] = [];
+    visit(root, 'link', (node: Link, index, parent) => {
+      promises.push(processLinkNode([node, index, parent!], context));
+    });
+    await Promise.all(promises);
+  };
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,39 +5,34 @@ import users from '../../data/powered-by';
 // featuredUsers.sort((a, b) => (a.featured > b.featured ? 1 : -1));
 import versions from '../../versions.json';
 import restApiVersions from '../../static/swagger/restApiVersions.json';
-import siteConfig from '../../docusaurus.config';
+import urlConfig from '../../site-baseurls.js';
+
+const {
+  baseUrl,
+} = urlConfig;
 
 export const latestStableVersion = versions[0];
 
 export function imgUrl(img) {
-  return siteConfig.baseUrl + "img/" + img;
+  return baseUrl + "img/" + img;
 }
 
 export function docUrl(doc, language, version) {
-  // if (version == "" || version == "next") {
   return (
-    siteConfig.baseUrl +
+    baseUrl +
     (language ? language + "/" : "") +
     "docs/" +
     (version ? version + "/" : "") +
     (doc ? doc : "")
   );
-  // }
-  // return (
-  //   siteConfig.customFields.oldUrl +
-  //   "/docs/" +
-  //   (language ? language + "/" : "en/") +
-  //   (version ? version + "/" : "") +
-  //   (doc ? doc : "standalone/")
-  // );
 }
 
 export function pageUrl(page, language) {
-  return siteConfig.baseUrl + (language ? language + "/" : "") + page;
+  return baseUrl + (language ? language + "/" : "") + page;
 }
 
 export function githubUrl() {
-  return siteConfig.customFields.githubUrl;
+  return urlConfig.githubUrl;
 }
 
 export function getCache() {

--- a/versioned_docs/version-3.0.x/admin-api-brokers.md
+++ b/versioned_docs/version-3.0.x/admin-api-brokers.md
@@ -44,7 +44,7 @@ localhost:8080
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getActiveBrokers?summary=in+the+cluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -89,7 +89,7 @@ public/default/0x80000000_0xc0000000    [broker_assignment=shared is_controlled=
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getOwnedNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ admin.brokers().getOwnedNamespaces(cluster,brokerUrl);
 </Tabs>
 ````
 
-## Update broker conf 
+## Update broker conf
 
 You can update broker configurations using one of the following ways:
 
@@ -143,7 +143,7 @@ resourceUsageTransportPublishIntervalInSecs
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getDynamicConfigurationName)
 
 </TabItem>
 <TabItem value="Java">
@@ -174,7 +174,7 @@ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --va
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_updateDynamicConfiguration)
 
 </TabItem>
 <TabItem value="Java">
@@ -210,7 +210,7 @@ brokerShutdownTimeoutMs    100
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getAllDynamicConfigurations)
 
 </TabItem>
 <TabItem value="Java">
@@ -249,7 +249,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/leaderBroker|operation/getLeaderBroker?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getLeaderBroker)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-clusters.md
+++ b/versioned_docs/version-3.0.x/admin-api-clusters.md
@@ -52,7 +52,7 @@ pulsar-admin clusters create cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_createCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -102,7 +102,7 @@ Output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -139,7 +139,7 @@ pulsar-admin clusters update cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_updateCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -178,7 +178,7 @@ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_setPeerClusterNames)
 
 </TabItem>
 <TabItem value="Java">
@@ -217,7 +217,7 @@ cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -249,7 +249,7 @@ pulsar-admin clusters delete cluster-1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_deleteCluster)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-functions.md
+++ b/versioned_docs/version-3.0.x/admin-api-functions.md
@@ -51,7 +51,7 @@ pulsar-admin functions create \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName|operation/registerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_registerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ pulsar-admin functions update \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName|operation/updateFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_updateFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -152,7 +152,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -190,7 +190,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -233,7 +233,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -271,7 +271,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -314,7 +314,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -352,7 +352,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -389,7 +389,7 @@ pulsar-admin functions list \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace|operation/listFunctions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_listFunctions)
 
 </TabItem>
 <TabItem value="Java">
@@ -427,7 +427,7 @@ pulsar-admin functions delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName|operation/deregisterFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_deregisterFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -465,7 +465,7 @@ pulsar-admin functions get \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName|operation/getFunctionInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInfo)
 
 </TabItem>
 <TabItem value="Java">
@@ -507,7 +507,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status|operation/getFunctionInstanceStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -545,7 +545,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status|operation/getFunctionStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -587,7 +587,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats|operation/getFunctionInstanceStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -625,7 +625,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats|operation/getFunctionStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -666,7 +666,7 @@ pulsar-admin functions trigger \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger|operation/triggerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_triggerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -707,7 +707,7 @@ pulsar-admin functions putstate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/putFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_putFunctionState)
 
 </TabItem>
 <TabItem value="Java">
@@ -748,7 +748,7 @@ pulsar-admin functions querystate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/getFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionState)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-namespaces.md
+++ b/versioned_docs/version-3.0.x/admin-api-namespaces.md
@@ -51,7 +51,7 @@ pulsar-admin namespaces create test-tenant/test-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -110,7 +110,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -150,7 +150,7 @@ test-tenant/namespace2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getTenantNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -183,7 +183,7 @@ pulsar-admin namespaces delete test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_deleteNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -216,7 +216,7 @@ pulsar-admin namespaces set-clusters test-tenant/namespace1 --clusters cl1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -253,7 +253,7 @@ cluster2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -297,7 +297,7 @@ pulsar-admin namespaces set-backlog-quota --limit 10G \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -334,7 +334,7 @@ destination_storage    BacklogQuotaImpl(limit=10737418240, limitSize=10737418240
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -365,7 +365,7 @@ pulsar-admin namespaces remove-backlog-quota test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -409,7 +409,7 @@ pulsar-admin namespaces set-persistence \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -451,7 +451,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -486,7 +486,7 @@ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff --destinationBroke
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/unload|operation/unloadNamespaceBundle?version=@pulsar:version_number@&destinationBroker=broker1.use.org.com:8080}
+[](swagger:/admin/v2/Namespaces_unloadNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -517,7 +517,7 @@ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-tenant/
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/split|operation/splitNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_splitNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -550,7 +550,7 @@ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -586,7 +586,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -621,7 +621,7 @@ pulsar-admin namespaces remove-message-ttl test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -655,7 +655,7 @@ pulsar-admin namespaces clear-backlog --sub my-subscription test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -689,7 +689,7 @@ pulsar-admin namespaces clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/:bundle/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBundleBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -724,7 +724,7 @@ pulsar-admin namespaces set-retention --size 100M --time 10m test-tenant/namespa
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -762,7 +762,7 @@ pulsar-admin namespaces get-retention test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -807,7 +807,7 @@ pulsar-admin namespaces set-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -849,7 +849,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -886,7 +886,7 @@ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -928,7 +928,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -964,7 +964,7 @@ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1003,7 +1003,7 @@ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1036,7 +1036,7 @@ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1067,7 +1067,7 @@ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1098,7 +1098,7 @@ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1137,7 +1137,7 @@ pulsar-admin namespaces unload my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_unloadNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -1173,8 +1173,7 @@ pulsar-admin namespaces set-entry-filters \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/setEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1205,8 +1204,7 @@ pulsar-admin namespaces get-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/getEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1237,8 +1235,7 @@ pulsar-admin namespaces remove-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/removeEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceEntryFilters)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-packages.md
+++ b/versioned_docs/version-3.0.x/admin-api-packages.md
@@ -102,7 +102,7 @@ bin/pulsar-admin packages upload function://public/default/example@v0.1 --path p
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/upload?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_upload)
 
 </TabItem>
 <TabItem value="Java">
@@ -141,7 +141,7 @@ bin/pulsar-admin packages download function://public/default/example@v0.1 --path
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/download?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_download)
 
 </TabItem>
 <TabItem value="Java">
@@ -182,7 +182,7 @@ bin/pulsar-admin packages delete functions://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/delete?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_delete)
 
 </TabItem>
 <TabItem value="Java">
@@ -221,7 +221,7 @@ bin/pulsar-admin packages get-metadata function://public/default/test@v1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/getMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_getMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -260,7 +260,7 @@ bin/pulsar-admin packages update-metadata function://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/updateMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_updateMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -299,7 +299,7 @@ bin/pulsar-admin packages list-versions type://tenant/namespace/packageName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName|operation/listPackageVersion?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackageVersion)
 
 </TabItem>
 <TabItem value="Java">
@@ -339,7 +339,7 @@ bin/pulsar-admin packages list --type function public/default
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace|operation/listPackages?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackages)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-permissions.md
+++ b/versioned_docs/version-3.0.x/admin-api-permissions.md
@@ -88,7 +88,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_grantPermissionOnNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -127,7 +127,7 @@ my.role.*    [produce, consume]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPermissions)
 
 </TabItem>
 <TabItem value="Java">
@@ -161,7 +161,7 @@ pulsar-admin namespaces revoke-permission test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_revokePermissionsOnNamespace)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-schemas.md
+++ b/versioned_docs/version-3.0.x/admin-api-schemas.md
@@ -54,7 +54,7 @@ The `schema-definition-file` is in JSON format.
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v2/SchemasResource_postSchema)
 
 The post payload is in JSON format.
 
@@ -147,7 +147,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=!version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -200,7 +200,7 @@ pulsar-admin schemas get <topic-name> --version <version>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=@pulsar:version_number@}
+Send a `GET` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -280,7 +280,7 @@ pulsar-admin schemas delete <topic-name>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=@pulsar:version_number@}
+Send a `DELETE` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_deleteSchema)
 
 Here is an example of a response returned in JSON format.
 
@@ -331,7 +331,7 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --enable tenant/name
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/isAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
@@ -380,7 +380,7 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --disable tenant/nam
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/isAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
@@ -427,7 +427,7 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --enable tenant/namesp
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/schemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
@@ -470,7 +470,7 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --disable tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/schemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
@@ -521,7 +521,7 @@ pulsar-admin topicPolicies set-schema-compatibility-strategy <strategy> <topicNa
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -562,7 +562,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/Namespaces_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -609,7 +609,7 @@ pulsar-admin topicPolicies get-schema-compatibility-strategy <topicName>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -654,7 +654,7 @@ pulsar-admin namespaces get-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/schemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/Namespaces_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-tenants.md
+++ b/versioned_docs/version-3.0.x/admin-api-tenants.md
@@ -55,7 +55,7 @@ my-tenant-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenants)
 
 </TabItem>
 <TabItem value="Java">
@@ -104,7 +104,7 @@ pulsar-admin tenants create my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/tenants/:tenant|operation/createTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_createTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -150,7 +150,7 @@ pulsar-admin tenants get my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants/:tenant|operation/getTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenantAdmin)
 
 </TabItem>
 <TabItem value="Java">
@@ -183,7 +183,7 @@ pulsar-admin tenants delete my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:tenant|operation/deleteTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_deleteTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -218,7 +218,7 @@ pulsar-admin tenants update my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/updateTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_updateTenant)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-topics.md
+++ b/versioned_docs/version-3.0.x/admin-api-topics.md
@@ -40,7 +40,7 @@ Whether it is a persistent or non-persistent topic, you can obtain the topic res
 :::note
 
 In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.
-Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+Take [](swagger:/admin/v2/PersistentTopics_getList) as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 :::
 
@@ -61,7 +61,7 @@ pulsar-admin topics list my-tenant/my-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -96,7 +96,7 @@ pulsar-admin topics grant-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_grantPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -136,7 +136,7 @@ application1    [consume, produce]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -170,7 +170,7 @@ pulsar-admin topics revoke-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_revokePermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -203,7 +203,7 @@ pulsar-admin topics delete persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -235,7 +235,7 @@ pulsar-admin topics unload persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_unloadTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -365,7 +365,7 @@ pulsar-admin topics stats persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -461,7 +461,7 @@ pulsar-admin topics stats-internal persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -508,7 +508,7 @@ Event time: 0
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_peekNthMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -543,7 +543,7 @@ pulsar-admin topics get-message-by-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageById)
 
 </TabItem>
 <TabItem value="Java">
@@ -578,7 +578,7 @@ pulsar-admin topics examine-messages \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/examinemessage?initialPosition=:initialPosition&messagePosition=:messagePosition|operation/examineMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_examineMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -612,7 +612,7 @@ pulsar-admin topics get-message-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/messageid/:timestamp|operation/getMessageIdByTimestamp?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageIdByTimestamp)
 
 </TabItem>
 <TabItem value="Java">
@@ -648,7 +648,7 @@ pulsar-admin topics skip \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -684,7 +684,7 @@ pulsar-admin topics clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipAllMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -719,7 +719,7 @@ pulsar-admin topics reset-cursor \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_resetCursor)
 
 </TabItem>
 <TabItem value="Java">
@@ -761,7 +761,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic-domain/:tenant/:namespace/:topic|operation/lookupTopicAsync?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_lookupTopicAsync)
 
 </TabItem>
 <TabItem value="Java">
@@ -848,7 +848,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|operation/getNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_getNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -886,7 +886,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -928,7 +928,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId|operation/getLastMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getLastMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -962,7 +962,7 @@ pulsar-admin topics get-backlog-size \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getBacklogSizeByMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -998,7 +998,7 @@ pulsar-admin topics get-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1031,7 +1031,7 @@ pulsar-admin topics set-deduplication-snapshot-interval my-topic -i 1000
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 ```json
 {
@@ -1068,7 +1068,7 @@ pulsar-admin topics remove-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1102,7 +1102,7 @@ pulsar-admin topics get-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/getInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1133,7 +1133,7 @@ pulsar-admin topics set-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/setInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setInactiveTopicPolicies?summary=inactive)
 
 </TabItem>
 <TabItem value="Java">
@@ -1164,7 +1164,7 @@ pulsar-admin topics remove-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/removeInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1198,7 +1198,7 @@ pulsar-admin topics get-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/getOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1229,7 +1229,7 @@ pulsar-admin topics set-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/setOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1260,7 +1260,7 @@ pulsar-admin topics remove-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/removeOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1309,7 +1309,7 @@ When you create a non-partitioned topic with the suffix '-partition-' followed b
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createNonPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1342,7 +1342,7 @@ pulsar-admin topics delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1380,7 +1380,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1414,7 +1414,7 @@ pulsar-admin topics stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1520,7 +1520,7 @@ pulsar-admin topics stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1574,7 +1574,7 @@ If a non-partitioned topic with the suffix '-partition-' followed by a numeric v
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_createPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1610,7 +1610,7 @@ pulsar-admin topics create-missed-partitions \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createMissedPartitions)
 
 </TabItem>
 <TabItem value="Java">
@@ -1658,7 +1658,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -1696,7 +1696,7 @@ pulsar-admin topics update-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_updatePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1727,7 +1727,7 @@ pulsar-admin topics delete-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deletePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1765,7 +1765,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedTopicList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1798,7 +1798,7 @@ pulsar-admin topics partitioned-stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1926,7 +1926,7 @@ pulsar-admin topics partitioned-stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedStatsInternal)
 
 </TabItem>
 <TabItem value="Java">
@@ -1965,7 +1965,7 @@ pulsar-admin topics create-subscription \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subscription|operation/createSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -2005,7 +2005,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -2040,7 +2040,7 @@ pulsar-admin topics unsubscribe \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteSubscription)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/admin-api-transactions.md
+++ b/versioned_docs/version-3.0.x/admin-api-transactions.md
@@ -41,7 +41,7 @@ pulsar-admin transactions slow-transactions -c 1 -t 1s
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/slowTransactions/:timeout|operation/getSlowTransactions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getSlowTransactions)
 
 </TabItem>
 <TabItem value="Java">
@@ -161,7 +161,7 @@ pulsar-admin transactions scale-transactionCoordinators -r 17
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionCoordinator/:replicas|operation/scaleTransactionCoordinators?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_scaleTransactionCoordinators)
 
 </TabItem>
 <TabItem value="Java">
@@ -202,7 +202,7 @@ pulsar-admin transactions transaction-metadata -m 1 -l 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionMetadata/:mostSigBits/:leastSigBits|operation/getTransactionMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -260,7 +260,7 @@ pulsar-admin transactions transaction-in-pending-ack-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInPendingAckStats/:tenant/:namespace/:topic/:subName/:mostSigBits/:leastSigBits|operation/getTransactionInPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -303,7 +303,7 @@ pulsar-admin transactions transaction-in-buffer-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInBufferStats/:tenant/:namespace/:topic/:mostSigBits/:leastSigBits|operation/getTransactionInBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInBufferStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -354,7 +354,7 @@ pulsar-admin transactions coordinator-stats -c 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorStats|operation/getCoordinatorStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -404,7 +404,7 @@ pulsar-admin transactions coordinator-internal-stats -c 1 -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorInternalStats/:coordinatorId|operation/getCoordinatorInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -495,7 +495,7 @@ pulsar-admin.transactions()s pending-ack-stats -t my-topic -s mysubName -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -545,7 +545,7 @@ pulsar-admin transactions pending-ack-internal-stats -t my-topic -s mysubName -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckInternalStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -639,8 +639,7 @@ pulsar-admin transactions position-stats-in-pending-ack -t my-topic -s mysubName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats
-/:tenant/:namespace:/:topic:/:subName/:ledgerId/:entryId?batchIndex=batchIndex|operation/getPositionStatsInPendingAck?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPositionStatsInPendingAck)
 
 </TabItem>
 <TabItem value="Java">
@@ -693,7 +692,7 @@ pulsar-admin transactions transaction-buffer-stats -t my-topic -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionBufferStats/:tenant/:namespace:/:topic:/:subName|operation/getTransactionBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionBufferStats)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/administration-geo.md
+++ b/versioned_docs/version-3.0.x/administration-geo.md
@@ -183,7 +183,7 @@ bin/pulsar-admin topics stats persistent://my-tenant/my-namespace/my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 

--- a/versioned_docs/version-3.0.x/administration-isolation-bookie.md
+++ b/versioned_docs/version-3.0.x/administration-isolation-bookie.md
@@ -173,7 +173,7 @@ In addition, you can also group bookies across racks or regions to serve broker-
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/bookies/racks-info/:bookie|operation/updateBookieRackInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Bookies_updateBookieRackInfo)
 
 </TabItem>
 
@@ -256,7 +256,7 @@ For the bookie rack name restrictions, see [pulsar-admin bookies set-bookie-rack
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence/bookieAffinity|operation/setBookieAffinityGroup?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-3.0.x/administration-isolation-broker.md
+++ b/versioned_docs/version-3.0.x/administration-isolation-broker.md
@@ -40,7 +40,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:namespace/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-3.0.x/administration-upgrade.md
+++ b/versioned_docs/version-3.0.x/administration-upgrade.md
@@ -193,7 +193,7 @@ pulsar-admin brokers healthcheck
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/brokers/health|operation/healthCheck?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/BrokersBase_healthCheck)
 
 </TabItem>
 

--- a/versioned_docs/version-3.0.x/administration-zk-bk.md
+++ b/versioned_docs/version-3.0.x/administration-zk-bk.md
@@ -307,7 +307,7 @@ pulsar-admin namespaces set-persistence my-tenant/my-ns -e 3 -w 3 -a 3
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 #### Java
 
@@ -345,7 +345,7 @@ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 #### Java
 

--- a/versioned_docs/version-3.0.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-3.0.x/cookbooks-retention-expiry.md
@@ -119,7 +119,7 @@ pulsar-admin namespaces set-retention my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 :::note
 
@@ -167,7 +167,7 @@ pulsar-admin namespaces get-retention my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -240,7 +240,7 @@ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns/my-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -283,7 +283,7 @@ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -315,7 +315,7 @@ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -372,7 +372,7 @@ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -406,7 +406,7 @@ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -439,7 +439,7 @@ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-3.0.x/io-use.md
+++ b/versioned_docs/version-3.0.x/io-use.md
@@ -193,7 +193,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_registerSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -278,7 +278,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_registerSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/versioned_docs/version-3.0.x/io-use.md
+++ b/versioned_docs/version-3.0.x/io-use.md
@@ -369,11 +369,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=!all)
 
 </TabItem>
 
@@ -404,11 +404,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=!all)
 
 </TabItem>
 

--- a/versioned_docs/version-3.0.x/io-use.md
+++ b/versioned_docs/version-3.0.x/io-use.md
@@ -193,7 +193,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -278,7 +278,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -369,11 +369,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 
@@ -404,11 +404,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
 
 </TabItem>
 
@@ -510,7 +510,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -615,7 +615,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -717,7 +717,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace|operation/listSources?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_listSources)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -770,7 +770,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace|operation/listSinks?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_listSinks)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -829,11 +829,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** source connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -919,11 +919,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** sink connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkStatus)
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInstanceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1013,7 +1013,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_updateSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1102,7 +1102,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_updateSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1199,11 +1199,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=all)
 
 * Stop a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1289,11 +1289,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=all)
 
 * Stop a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1385,11 +1385,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1475,11 +1475,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1571,7 +1571,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete al Pulsar source connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1633,7 +1633,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete a sink connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/versioned_docs/version-4.0.x/admin-api-brokers.md
+++ b/versioned_docs/version-4.0.x/admin-api-brokers.md
@@ -45,7 +45,7 @@ localhost:8080
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getActiveBrokers?summary=in+the+cluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -90,7 +90,7 @@ public/default/0x80000000_0xc0000000    [broker_assignment=shared is_controlled=
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getOwnedNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -104,7 +104,7 @@ admin.brokers().getOwnedNamespaces(cluster,brokerUrl);
 </Tabs>
 ````
 
-## Update broker conf 
+## Update broker conf
 
 You can update broker configurations using one of the following ways:
 
@@ -144,7 +144,7 @@ resourceUsageTransportPublishIntervalInSecs
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getDynamicConfigurationName)
 
 </TabItem>
 <TabItem value="Java">
@@ -175,7 +175,7 @@ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --va
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_updateDynamicConfiguration)
 
 </TabItem>
 <TabItem value="Java">
@@ -211,7 +211,7 @@ brokerShutdownTimeoutMs    100
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getAllDynamicConfigurations)
 
 </TabItem>
 <TabItem value="Java">
@@ -250,7 +250,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/brokers/leaderBroker|operation/getLeaderBroker?version=@pulsar:version_number@}
+[](swagger:/admin/v2/BrokersBase_getLeaderBroker)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-clusters.md
+++ b/versioned_docs/version-4.0.x/admin-api-clusters.md
@@ -53,7 +53,7 @@ pulsar-admin clusters create cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_createCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ Output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -140,7 +140,7 @@ pulsar-admin clusters update cluster-1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_updateCluster)
 
 </TabItem>
 <TabItem value="Java">
@@ -179,7 +179,7 @@ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_setPeerClusterNames)
 
 </TabItem>
 <TabItem value="Java">
@@ -218,7 +218,7 @@ cluster-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_getClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -250,7 +250,7 @@ pulsar-admin clusters delete cluster-1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=@pulsar:version_number@}
+[](swagger:/admin/v2/ClustersBase_deleteCluster)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-functions.md
+++ b/versioned_docs/version-4.0.x/admin-api-functions.md
@@ -52,7 +52,7 @@ pulsar-admin functions create \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName|operation/registerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_registerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -104,7 +104,7 @@ pulsar-admin functions update \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName|operation/updateFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_updateFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -153,7 +153,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -191,7 +191,7 @@ pulsar-admin functions start \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start|operation/startFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_startFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -234,7 +234,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -272,7 +272,7 @@ pulsar-admin functions stop \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop|operation/stopFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_stopFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -315,7 +315,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=an+instance)
 
 </TabItem>
 <TabItem value="Java">
@@ -353,7 +353,7 @@ pulsar-admin functions restart \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart|operation/restartFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_restartFunction?summary=all)
 
 </TabItem>
 <TabItem value="Java">
@@ -390,7 +390,7 @@ pulsar-admin functions list \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace|operation/listFunctions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_listFunctions)
 
 </TabItem>
 <TabItem value="Java">
@@ -428,7 +428,7 @@ pulsar-admin functions delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName|operation/deregisterFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_deregisterFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -466,7 +466,7 @@ pulsar-admin functions get \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName|operation/getFunctionInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInfo)
 
 </TabItem>
 <TabItem value="Java">
@@ -508,7 +508,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status|operation/getFunctionInstanceStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -546,7 +546,7 @@ pulsar-admin functions status \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status|operation/getFunctionStatus?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStatus)
 
 </TabItem>
 <TabItem value="Java">
@@ -588,7 +588,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats|operation/getFunctionInstanceStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionInstanceStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -626,7 +626,7 @@ pulsar-admin functions stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats|operation/getFunctionStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -667,7 +667,7 @@ pulsar-admin functions trigger \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger|operation/triggerFunction?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_triggerFunction)
 
 </TabItem>
 <TabItem value="Java">
@@ -708,7 +708,7 @@ pulsar-admin functions putstate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/putFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_putFunctionState)
 
 </TabItem>
 <TabItem value="Java">
@@ -749,7 +749,7 @@ pulsar-admin functions querystate \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key|operation/getFunctionState?version=@pulsar:version_number@}
+[](swagger:/admin/v3/functions/FunctionsBase_getFunctionState)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-namespaces.md
+++ b/versioned_docs/version-4.0.x/admin-api-namespaces.md
@@ -52,7 +52,7 @@ pulsar-admin namespaces create test-tenant/test-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -111,7 +111,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -151,7 +151,7 @@ test-tenant/namespace2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getTenantNamespaces)
 
 </TabItem>
 <TabItem value="Java">
@@ -184,7 +184,7 @@ pulsar-admin namespaces delete test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_deleteNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -217,7 +217,7 @@ pulsar-admin namespaces set-clusters test-tenant/namespace1 --clusters cl1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -254,7 +254,7 @@ cluster2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceReplicationClusters)
 
 </TabItem>
 <TabItem value="Java">
@@ -298,7 +298,7 @@ pulsar-admin namespaces set-backlog-quota --limit 10G \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -335,7 +335,7 @@ destination_storage    BacklogQuotaImpl(limit=10737418240, limitSize=10737418240
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -366,7 +366,7 @@ pulsar-admin namespaces remove-backlog-quota test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -410,7 +410,7 @@ pulsar-admin namespaces set-persistence \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -452,7 +452,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 </TabItem>
 <TabItem value="Java">
@@ -487,7 +487,7 @@ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff --destinationBroke
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/unload|operation/unloadNamespaceBundle?version=@pulsar:version_number@&destinationBroker=broker1.use.org.com:8080}
+[](swagger:/admin/v2/Namespaces_unloadNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -518,7 +518,7 @@ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-tenant/
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/:bundle/split|operation/splitNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_splitNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -551,7 +551,7 @@ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -587,7 +587,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -622,7 +622,7 @@ pulsar-admin namespaces remove-message-ttl test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -656,7 +656,7 @@ pulsar-admin namespaces clear-backlog --sub my-subscription test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -690,7 +690,7 @@ pulsar-admin namespaces clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/:bundle/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_clearNamespaceBundleBacklogForSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -725,7 +725,7 @@ pulsar-admin namespaces set-retention --size 100M --time 10m test-tenant/namespa
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -763,7 +763,7 @@ pulsar-admin namespaces get-retention test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -808,7 +808,7 @@ pulsar-admin namespaces set-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -850,7 +850,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -887,7 +887,7 @@ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -929,7 +929,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getSubscriptionDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getSubscriptionDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -965,7 +965,7 @@ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1004,7 +1004,7 @@ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDispatchRate)
 
 </TabItem>
 <TabItem value="Java">
@@ -1037,7 +1037,7 @@ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1068,7 +1068,7 @@ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/namespac
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1099,7 +1099,7 @@ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1138,7 +1138,7 @@ pulsar-admin namespaces unload my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_unloadNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -1174,8 +1174,7 @@ pulsar-admin namespaces set-entry-filters \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/setEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1206,8 +1205,7 @@ pulsar-admin namespaces get-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/getEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getEntryFiltersPerTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1238,8 +1236,7 @@ pulsar-admin namespaces remove-entry-filters test-tenant/namespace1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/entryFilters|operation/removeEntryFilters?
-version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceEntryFilters)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-packages.md
+++ b/versioned_docs/version-4.0.x/admin-api-packages.md
@@ -103,7 +103,7 @@ bin/pulsar-admin packages upload function://public/default/example@v0.1 --path p
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/upload?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_upload)
 
 </TabItem>
 <TabItem value="Java">
@@ -142,7 +142,7 @@ bin/pulsar-admin packages download function://public/default/example@v0.1 --path
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/download?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_download)
 
 </TabItem>
 <TabItem value="Java">
@@ -183,7 +183,7 @@ bin/pulsar-admin packages delete functions://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version|operation/delete?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_delete)
 
 </TabItem>
 <TabItem value="Java">
@@ -222,7 +222,7 @@ bin/pulsar-admin packages get-metadata function://public/default/test@v1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/getMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_getMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -261,7 +261,7 @@ bin/pulsar-admin packages update-metadata function://public/default/example@v0.1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata|operation/updateMeta?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_updateMeta)
 
 </TabItem>
 <TabItem value="Java">
@@ -300,7 +300,7 @@ bin/pulsar-admin packages list-versions type://tenant/namespace/packageName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/packages/:type/:tenant/:namespace/:packageName|operation/listPackageVersion?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackageVersion)
 
 </TabItem>
 <TabItem value="Java">
@@ -340,7 +340,7 @@ bin/pulsar-admin packages list --type function public/default
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace|operation/listPackages?version=@pulsar:version_number@}
+[](swagger:/admin/v3/packages/Packages_listPackages)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-permissions.md
+++ b/versioned_docs/version-4.0.x/admin-api-permissions.md
@@ -89,7 +89,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_grantPermissionOnNamespace)
 
 </TabItem>
 <TabItem value="Java">
@@ -128,7 +128,7 @@ my.role.*    [produce, consume]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPermissions)
 
 </TabItem>
 <TabItem value="Java">
@@ -162,7 +162,7 @@ pulsar-admin namespaces revoke-permission test-tenant/namespace1 \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_revokePermissionsOnNamespace)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-schemas.md
+++ b/versioned_docs/version-4.0.x/admin-api-schemas.md
@@ -55,7 +55,7 @@ The `schema-definition-file` is in JSON format.
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to the endpoint documented here: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_postSchema?version=@pulsar:version_number@}
+Send a `POST` request to the endpoint documented here: [](swagger:/admin/v2/SchemasResource_postSchema)
 
 Below is an example with CURL with a payload stored on the `schema.json` file, Pulsar broker running on `localhost` and the topic `my-tenant/my-ns/my-topic`:
 
@@ -155,7 +155,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_getSchema?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=!version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -208,7 +208,7 @@ pulsar-admin schemas get <topic-name> --version <version>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/SchemasResource_getSchema?version=@pulsar:version_number@}
+Send a `GET` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_getSchema?summary=version)
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -288,7 +288,7 @@ pulsar-admin schemas delete <topic-name>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/SchemasResource_deleteSchema?version=@pulsar:version_number@}
+Send a `DELETE` request to a schema endpoint: [](swagger:/admin/v2/SchemasResource_deleteSchema)
 
 Here is an example of a response returned in JSON format.
 
@@ -339,13 +339,13 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --enable tenant/name
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/Namespaces_setIsAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
 ```json
 {
-“isAllowAutoUpdateSchema”: “true”
+"isAllowAutoUpdateSchema": "true"
 }
 ```
 
@@ -388,13 +388,13 @@ bin/pulsar-admin namespaces set-is-allow-auto-update-schema --disable tenant/nam
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/isAllowAutoUpdateSchema|operation/Namespaces_setIsAllowAutoUpdateSchema?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setIsAllowAutoUpdateSchema)
 
 The post payload is in JSON format.
 
 ```json
 {
-“isAllowAutoUpdateSchema”: “false”
+"isAllowAutoUpdateSchema": "false"
 }
 ```
 
@@ -435,13 +435,13 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --enable tenant/namesp
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/Namespaces_setSchemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
 ```json
 {
-“schemaValidationEnforced”: “true”
+"schemaValidationEnforced": "true"
 }
 ```
 
@@ -478,13 +478,13 @@ bin/pulsar-admin namespaces set-schema-validation-enforce --disable tenant/names
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to a namespace endpoint: {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/schemaValidationEnforced|operation/Namespaces_setSchemaValidationEnforced?version=@pulsar:version_number@}
+Send a `POST` request to a namespace endpoint: [](swagger:/admin/v2/Namespaces_setSchemaValidationEnforced)
 
 The post payload is in JSON format.
 
 ```json
 {
-“schemaValidationEnforced”: “false”
+"schemaValidationEnforced": "false"
 }
 ```
 
@@ -529,7 +529,7 @@ pulsar-admin topicPolicies set-schema-compatibility-strategy <strategy> <topicNa
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/topics/:tenant/:namespace/:topic|operation/PersistentTopics_setSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -570,7 +570,7 @@ pulsar-admin namespaces set-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/schemaCompatibilityStrategy|operation/Namespaces_setSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v2/Namespaces_setSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -617,7 +617,7 @@ pulsar-admin topicPolicies get-schema-compatibility-strategy <topicName>
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/schemaCompatibilityStrategy|operation/PersistentTopics_getSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/PersistentTopics_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">
@@ -662,7 +662,7 @@ pulsar-admin namespaces get-schema-compatibility-strategy options
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/schemaCompatibilityStrategy|operation/Namespaces_getSchemaCompatibilityStrategy?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/Namespaces_getSchemaCompatibilityStrategy)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-tenants.md
+++ b/versioned_docs/version-4.0.x/admin-api-tenants.md
@@ -56,7 +56,7 @@ my-tenant-2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenants)
 
 </TabItem>
 <TabItem value="Java">
@@ -105,7 +105,7 @@ pulsar-admin tenants create my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/tenants/:tenant|operation/createTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_createTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -151,7 +151,7 @@ pulsar-admin tenants get my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/tenants/:tenant|operation/getTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_getTenantAdmin)
 
 </TabItem>
 <TabItem value="Java">
@@ -184,7 +184,7 @@ pulsar-admin tenants delete my-tenant
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:tenant|operation/deleteTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_deleteTenant)
 
 </TabItem>
 <TabItem value="Java">
@@ -219,7 +219,7 @@ pulsar-admin tenants update my-tenant \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/updateTenant?version=@pulsar:version_number@}
+[](swagger:/admin/v2/TenantsBase_updateTenant)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-topics.md
+++ b/versioned_docs/version-4.0.x/admin-api-topics.md
@@ -47,7 +47,7 @@ Whether it is a persistent or non-persistent topic, you can obtain the topic res
 :::note
 
 In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.
-Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+Take [](swagger:/admin/v2/PersistentTopics_getList) as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 :::
 
@@ -68,7 +68,7 @@ pulsar-admin topics list my-tenant/my-namespace
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -103,7 +103,7 @@ pulsar-admin topics grant-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_grantPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -143,7 +143,7 @@ application1    [consume, produce]
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -177,7 +177,7 @@ pulsar-admin topics revoke-permission \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_revokePermissionsOnTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -210,7 +210,7 @@ pulsar-admin topics delete persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -242,7 +242,7 @@ pulsar-admin topics unload persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_unloadTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -372,7 +372,7 @@ pulsar-admin topics stats persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -468,7 +468,7 @@ pulsar-admin topics stats-internal persistent://test-tenant/ns1/tp1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -515,7 +515,7 @@ Event time: 0
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_peekNthMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -550,7 +550,7 @@ pulsar-admin topics get-message-by-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageById)
 
 </TabItem>
 <TabItem value="Java">
@@ -585,7 +585,7 @@ pulsar-admin topics examine-messages \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/examinemessage?initialPosition=:initialPosition&messagePosition=:messagePosition|operation/examineMessage?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_examineMessage)
 
 </TabItem>
 <TabItem value="Java">
@@ -619,7 +619,7 @@ pulsar-admin topics get-message-id \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/messageid/:timestamp|operation/getMessageIdByTimestamp?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getMessageIdByTimestamp)
 
 </TabItem>
 <TabItem value="Java">
@@ -655,7 +655,7 @@ pulsar-admin topics skip \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -691,7 +691,7 @@ pulsar-admin topics clear-backlog \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_skipAllMessages)
 
 </TabItem>
 <TabItem value="Java">
@@ -726,7 +726,7 @@ pulsar-admin topics reset-cursor \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_resetCursor)
 
 </TabItem>
 <TabItem value="Java">
@@ -768,7 +768,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic-domain/:tenant/:namespace/:topic|operation/lookupTopicAsync?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_lookupTopicAsync)
 
 </TabItem>
 <TabItem value="Java">
@@ -855,7 +855,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|operation/getNamespaceBundle?version=@pulsar:version_number@}
+[](swagger:/admin/v2/lookup/TopicLookup_getNamespaceBundle)
 
 </TabItem>
 <TabItem value="Java">
@@ -893,7 +893,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -935,7 +935,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId|operation/getLastMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getLastMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -969,7 +969,7 @@ pulsar-admin topics get-backlog-size \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getBacklogSizeByMessageId)
 
 </TabItem>
 <TabItem value="Java">
@@ -1005,7 +1005,7 @@ pulsar-admin topics get-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/getDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1038,7 +1038,7 @@ pulsar-admin topics set-deduplication-snapshot-interval my-topic -i 1000
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/setDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setDeduplicationSnapshotInterval)
 
 ```json
 {
@@ -1075,7 +1075,7 @@ pulsar-admin topics remove-deduplication-snapshot-interval my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/deduplicationSnapshotInterval|operation/deleteDeduplicationSnapshotInterval?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteDeduplicationSnapshotInterval)
 
 </TabItem>
 <TabItem value="Java">
@@ -1109,7 +1109,7 @@ pulsar-admin topics get-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/getInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1140,7 +1140,7 @@ pulsar-admin topics set-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/setInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1171,7 +1171,7 @@ pulsar-admin topics remove-inactive-topic-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/inactiveTopicPolicies|operation/removeInactiveTopicPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeInactiveTopicPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1205,7 +1205,7 @@ pulsar-admin topics get-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/getOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1236,7 +1236,7 @@ pulsar-admin topics set-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/setOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1267,7 +1267,7 @@ pulsar-admin topics remove-offload-policies my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/topics/:tenant/:namespace/:topic/offloadPolicies|operation/removeOffloadPolicies?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeOffloadPolicies)
 
 </TabItem>
 <TabItem value="Java">
@@ -1316,7 +1316,7 @@ When you create a non-partitioned topic with the suffix '-partition-' followed b
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createNonPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1349,7 +1349,7 @@ pulsar-admin topics delete \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1387,7 +1387,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1421,7 +1421,7 @@ pulsar-admin topics stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1527,7 +1527,7 @@ pulsar-admin topics stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1581,7 +1581,7 @@ If a non-partitioned topic with the suffix '-partition-' followed by a numeric v
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_createPartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1617,7 +1617,7 @@ pulsar-admin topics create-missed-partitions \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createMissedPartitions)
 
 </TabItem>
 <TabItem value="Java">
@@ -1665,7 +1665,7 @@ Example output:
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -1703,7 +1703,7 @@ pulsar-admin topics update-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_updatePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1734,7 +1734,7 @@ pulsar-admin topics delete-partitioned-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deletePartitionedTopic)
 
 </TabItem>
 <TabItem value="Java">
@@ -1772,7 +1772,7 @@ persistent://tenant/namespace/topic2
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedTopicList)
 
 </TabItem>
 <TabItem value="Java">
@@ -1805,7 +1805,7 @@ pulsar-admin topics partitioned-stats \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/NonPersistentTopics_getPartitionedStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -1933,7 +1933,7 @@ pulsar-admin topics partitioned-stats-internal \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-internalStats|operation/getPartitionedInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getPartitionedStatsInternal)
 
 </TabItem>
 <TabItem value="Java">
@@ -1972,7 +1972,7 @@ pulsar-admin topics create-subscription \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subscription|operation/createSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_createSubscription)
 
 </TabItem>
 <TabItem value="Java">
@@ -2012,7 +2012,7 @@ my-subscription
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getSubscriptions)
 
 </TabItem>
 <TabItem value="Java">
@@ -2047,7 +2047,7 @@ pulsar-admin topics unsubscribe \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_deleteSubscription)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/admin-api-transactions.md
+++ b/versioned_docs/version-4.0.x/admin-api-transactions.md
@@ -42,7 +42,7 @@ pulsar-admin transactions slow-transactions -c 1 -t 1s
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/slowTransactions/:timeout|operation/getSlowTransactions?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getSlowTransactions)
 
 </TabItem>
 <TabItem value="Java">
@@ -162,7 +162,7 @@ pulsar-admin transactions scale-transactionCoordinators -r 17
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionCoordinator/:replicas|operation/scaleTransactionCoordinators?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_scaleTransactionCoordinators)
 
 </TabItem>
 <TabItem value="Java">
@@ -203,7 +203,7 @@ pulsar-admin transactions transaction-metadata -m 1 -l 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionMetadata/:mostSigBits/:leastSigBits|operation/getTransactionMetadata?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionMetadata)
 
 </TabItem>
 <TabItem value="Java">
@@ -261,7 +261,7 @@ pulsar-admin transactions transaction-in-pending-ack-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInPendingAckStats/:tenant/:namespace/:topic/:subName/:mostSigBits/:leastSigBits|operation/getTransactionInPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -304,7 +304,7 @@ pulsar-admin transactions transaction-in-buffer-stats -m 1 -l 1 -t my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionInBufferStats/:tenant/:namespace/:topic/:mostSigBits/:leastSigBits|operation/getTransactionInBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionInBufferStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -355,7 +355,7 @@ pulsar-admin transactions coordinator-stats -c 1
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorStats|operation/getCoordinatorStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -405,7 +405,7 @@ pulsar-admin transactions coordinator-internal-stats -c 1 -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/coordinatorInternalStats/:coordinatorId|operation/getCoordinatorInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getCoordinatorInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -496,7 +496,7 @@ pulsar-admin.transactions()s pending-ack-stats -t my-topic -s mysubName -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -546,7 +546,7 @@ pulsar-admin transactions pending-ack-internal-stats -t my-topic -s mysubName -m
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckInternalStats/:tenant/:namespace:/:topic:/:subName|operation/getPendingAckInternalStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPendingAckInternalStats)
 
 </TabItem>
 <TabItem value="Java">
@@ -640,8 +640,7 @@ pulsar-admin transactions position-stats-in-pending-ack -t my-topic -s mysubName
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/pendingAckStats
-/:tenant/:namespace:/:topic:/:subName/:ledgerId/:entryId?batchIndex=batchIndex|operation/getPositionStatsInPendingAck?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getPositionStatsInPendingAck)
 
 </TabItem>
 <TabItem value="Java">
@@ -694,7 +693,7 @@ pulsar-admin transactions transaction-buffer-stats -t my-topic -l
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v3/transactions/transactionBufferStats/:tenant/:namespace:/:topic:/:subName|operation/getTransactionBufferStats?version=@pulsar:version_number@}
+[](swagger:/admin/v3/transactions/Transactions_getTransactionBufferStats)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/administration-geo.md
+++ b/versioned_docs/version-4.0.x/administration-geo.md
@@ -180,7 +180,7 @@ bin/pulsar-admin topics stats persistent://my-tenant/my-namespace/my-topic
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=@pulsar:version_number@}
+[](swagger:/admin/v2/PersistentTopics_getStats)
 
 </TabItem>
 

--- a/versioned_docs/version-4.0.x/administration-isolation-bookie.md
+++ b/versioned_docs/version-4.0.x/administration-isolation-bookie.md
@@ -174,7 +174,7 @@ In addition, you can also group bookies across racks or regions to serve broker-
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/bookies/racks-info/:bookie|operation/updateBookieRackInfo?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Bookies_updateBookieRackInfo)
 
 </TabItem>
 
@@ -257,7 +257,7 @@ For the bookie rack name restrictions, see [pulsar-admin bookies set-bookie-rack
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence/bookieAffinity|operation/setBookieAffinityGroup?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setBookieAffinityGroup)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-4.0.x/administration-isolation-broker.md
+++ b/versioned_docs/version-4.0.x/administration-isolation-broker.md
@@ -41,7 +41,7 @@ bin/pulsar-admin ns-isolation-policy set \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|PUT|/admin/v2/:namespace/:tenant/:namespace|operation/createNamespace?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_createNamespace)
 
 </TabItem>
 <TabItem value="Java admin API">

--- a/versioned_docs/version-4.0.x/administration-upgrade.md
+++ b/versioned_docs/version-4.0.x/administration-upgrade.md
@@ -194,7 +194,7 @@ pulsar-admin brokers healthcheck
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/brokers/health|operation/healthCheck?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v2/BrokersBase_healthCheck)
 
 </TabItem>
 

--- a/versioned_docs/version-4.0.x/administration-zk-bk.md
+++ b/versioned_docs/version-4.0.x/administration-zk-bk.md
@@ -319,7 +319,7 @@ pulsar-admin namespaces set-persistence my-tenant/my-ns -e 3 -w 3 -a 3
 
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setPersistence)
 
 </TabItem>
 
@@ -372,7 +372,7 @@ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getPersistence)
 
 </TabItem>
 

--- a/versioned_docs/version-4.0.x/cookbooks-retention-expiry.md
+++ b/versioned_docs/version-4.0.x/cookbooks-retention-expiry.md
@@ -120,7 +120,7 @@ pulsar-admin namespaces set-retention my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setRetention)
 
 :::note
 
@@ -168,7 +168,7 @@ pulsar-admin namespaces get-retention my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getRetention)
 
 </TabItem>
 <TabItem value="Java">
@@ -240,7 +240,7 @@ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns/my-topic \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -283,7 +283,7 @@ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getBacklogQuotaMap)
 
 </TabItem>
 <TabItem value="Java">
@@ -321,7 +321,7 @@ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeBacklogQuota)
 
 </TabItem>
 <TabItem value="Java">
@@ -378,7 +378,7 @@ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_setNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -412,7 +412,7 @@ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_getNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">
@@ -445,7 +445,7 @@ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 </TabItem>
 <TabItem value="REST API">
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=@pulsar:version_number@}
+[](swagger:/admin/v2/Namespaces_removeNamespaceMessageTTL)
 
 </TabItem>
 <TabItem value="Java">

--- a/versioned_docs/version-4.0.x/io-use.md
+++ b/versioned_docs/version-4.0.x/io-use.md
@@ -194,7 +194,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_registerSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -279,7 +279,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_registerSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/versioned_docs/version-4.0.x/io-use.md
+++ b/versioned_docs/version-4.0.x/io-use.md
@@ -194,7 +194,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -279,7 +279,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=@pulsar:version_number@}
+Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -370,11 +370,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 
@@ -405,11 +405,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
 
 </TabItem>
 
@@ -511,7 +511,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -616,7 +616,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInfo)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -718,7 +718,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace|operation/listSources?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_listSources)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -771,7 +771,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace|operation/listSinks?version=@pulsar:version_number@}
+Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_listSinks)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -830,11 +830,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** source connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_getSourceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -920,11 +920,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Get the current status of **all** sink connectors.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkStatus)
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=@pulsar:version_number@}
+  Send a `GET` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_getSinkInstanceStatus)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1014,7 +1014,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_updateSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1103,7 +1103,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 </TabItem>
 <TabItem value="REST API">
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=@pulsar:version_number@}
+Send a `PUT` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_updateSink)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1200,11 +1200,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=all)
 
 * Stop a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_stopSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1290,11 +1290,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Stop **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=all)
 
 * Stop a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_stopSink?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1386,11 +1386,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** source connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** source connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1476,11 +1476,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Restart **all** sink connectors.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
 
 * Restart a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=@pulsar:version_number@}
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1572,7 +1572,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete al Pulsar source connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_deregisterSource)
 
 </TabItem>
 <TabItem value="Java Admin API">
@@ -1634,7 +1634,7 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 Delete a sink connector.
 
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=@pulsar:version_number@}
+Send a `DELETE` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_deregisterSink)
 
 </TabItem>
 <TabItem value="Java Admin API">

--- a/versioned_docs/version-4.0.x/io-use.md
+++ b/versioned_docs/version-4.0.x/io-use.md
@@ -370,11 +370,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** source connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=all)
 
 * Start a **specified** source connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_restartSource?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/source/SourcesBase_startSource?summary=!all)
 
 </TabItem>
 
@@ -405,11 +405,11 @@ For the latest and complete information, see [Pulsar admin docs](pathname:///ref
 
 * Start **all** sink connectors.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=all)
 
 * Start a **specified** sink connector.
 
-  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_restartSink?summary=!all)
+  Send a `POST` request to this endpoint: [](swagger:/admin/v3/sink/SinksBase_startSink?summary=!all)
 
 </TabItem>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11490,6 +11490,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"null-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "null-loader@npm:4.0.1"
+  dependencies:
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: eeb4c4dd2f8f41e46f5665e4500359109e95ec1028a178a60e0161984906572da7dd87644bcc3cb29f0125d77e2b2508fb4f3813cfb1c6604a15865beb4b987b
+  languageName: node
+  linkType: hard
+
 "object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
@@ -16135,6 +16147,7 @@ __metadata:
     mkdirp: ^3.0.1
     moment: ^2.30.1
     npm: ^10.9.0
+    null-loader: ^4.0.1
     postcss: ^8.4.47
     postcss-cli: ^11.0.0
     postcss-import: ^16.1.0


### PR DESCRIPTION
Fixes apache/pulsar#21573

All REST API urls are incorrect in the documentation. This PR fixes the URLs for next, 4.0.x and 3.0.x.

This PR adds a custom Remark plugin that handles logic to lookup the correct URL from the Swagger JSON file so that it's always correct. The plugin is written in Typescript and to do that, the docusaurus config was converted to `.ts` extension and made compatible.

There's a remaining problem that the Swagger files contain a lot of duplicate operations even after apache/pulsar#19193. The links to Swagger documentation won't work when there are duplicates, which is very common. A replacement will be needed in apache/pulsar for the Swagger generation to fix it. The duplicate operation names required adding ways to find the correct operation in the custom Remark plugin.

This PR replaces the previous draft PR #866.

