### PR TITLE
Avoid link to apache archive server directly

### DIFF
--- a/docs/administration-pulsar-shell.md
+++ b/docs/administration-pulsar-shell.md
@@ -21,10 +21,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+Download the tarball from the [download page](pathname:///download#shell) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz?action=download"
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/docs/administration-pulsar-shell.md
+++ b/docs/administration-pulsar-shell.md
@@ -21,9 +21,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
+Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/docs/administration-pulsar-shell.md
+++ b/docs/administration-pulsar-shell.md
@@ -21,10 +21,9 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
 
 ```shell
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/docs/administration-pulsar-shell.md
+++ b/docs/administration-pulsar-shell.md
@@ -24,7 +24,7 @@ It's great for quickly switching between different clusters, and can modify clus
 Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/docs/client-libraries-cpp.md
+++ b/docs/client-libraries-cpp.md
@@ -35,7 +35,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 The new version of the Pulsar C++ client starts from 3.0.0 and has been no longer consistent with Pulsar since 2.10.x. For the latest releases, see the [Download](/download/) page.
 
-Take the [3.0.0 release](https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.0.0/) for example, there are following subdirectories:
+Take the [3.0.0 release](pathname:///download#pulsar-c-client) for example, there are following subdirectories:
 - apk-arm64: the Alpine Linux packages for ARM64 architectures
 - apk-x86_64: the Alpine Linux packages for x64 architectures
 - deb-arm64: the Debian-based Linux packages for ARM64 architectures

--- a/docs/getting-started-standalone.md
+++ b/docs/getting-started-standalone.md
@@ -26,7 +26,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
 ```
 
 Once downloaded, unpack the tar file:

--- a/docs/getting-started-standalone.md
+++ b/docs/getting-started-standalone.md
@@ -26,7 +26,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
 ```
 
 Once downloaded, unpack the tar file:

--- a/docs/getting-started-standalone.md
+++ b/docs/getting-started-standalone.md
@@ -23,7 +23,13 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Step 1: Download Pulsar distribution
 
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
+Download the official Apache Pulsar distribution:
+
+```bash
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+```
+
+Once downloaded, unpack the tar file:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/docs/getting-started-standalone.md
+++ b/docs/getting-started-standalone.md
@@ -23,13 +23,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Step 1: Download Pulsar distribution
 
-Download the official Apache Pulsar distribution:
-
-```bash
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
-```
-
-Once downloaded, unpack the tar file:
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/docs/io-canal-source.md
+++ b/docs/io-canal-source.md
@@ -121,8 +121,8 @@ Here is an example of storing MySQL data using the configuration file as above.
 7. Start Pulsar standalone.
 
    ```bash
-   docker pull apachepulsar/pulsar:2.3.0
-   docker run -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:2.3.0 bin/pulsar standalone
+   docker pull apachepulsar/pulsar:@pulsar:version@
+   docker run --user 0 -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
    ```
 
 8. Modify the configuration file `canal-mysql-source-config.yaml`.
@@ -167,9 +167,9 @@ Here is an example of storing MySQL data using the configuration file as above.
 
    ```bash
    docker exec -it pulsar-standalone /bin/bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-2.3.0/connectors/pulsar-io-canal-2.3.0.nar -P connectors
+   curl -LO --output-dir connectors "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-canal-@pulsar:version@.nar?action=download"
    ./bin/pulsar-admin source localrun \
-      --archive $PWD/connectors/pulsar-io-canal-2.3.0.nar \
+      --archive $PWD/connectors/pulsar-io-canal-@pulsar:version@.nar \
       --classname org.apache.pulsar.io.canal.CanalStringSource \
       --tenant public \
       --namespace default \

--- a/docs/io-rabbitmq-source.md
+++ b/docs/io-rabbitmq-source.md
@@ -98,19 +98,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. Get a Pulsar package and start Pulsar in standalone mode.
+1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
 
    ```bash
-   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/docs/io-rabbitmq-source.md
+++ b/docs/io-rabbitmq-source.md
@@ -110,7 +110,7 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://downloads.apache.org/pulsar/pulsar@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
+    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/docs/io-rabbitmq-source.md
+++ b/docs/io-rabbitmq-source.md
@@ -101,17 +101,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](pathname:///download#connectors) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
-    cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
+    cd connectors
+    curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar?action=download"
     ```
 
 3. Messages published to a topic lacking at least one durable subscription are automatically marked as ready for deletion by default. We can set a retention policy at the namespace level to prevent this.

--- a/docs/io-rabbitmq-source.md
+++ b/docs/io-rabbitmq-source.md
@@ -98,17 +98,19 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
+1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
+   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
+    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/docs/io-rabbitmq-source.md
+++ b/docs/io-rabbitmq-source.md
@@ -101,16 +101,16 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
+    wget https://downloads.apache.org/pulsar/pulsar@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/src/components/ConnectorTable.js
+++ b/src/components/ConnectorTable.js
@@ -11,7 +11,7 @@ export default function VersionsTable(props) {
     <Table size="small">
       <TableBody>
         <TableRow key="header">
-          {["IO connector", "Archive", "Crypto files"].map((header) => (
+          {["IO connector", "Archive", "Checksum & Signature"].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
               sx={{ border: 1, color: "inherit" }}

--- a/src/components/ReleaseTable.js
+++ b/src/components/ReleaseTable.js
@@ -11,7 +11,7 @@ export default function VersionsTable(props) {
     <Table size="small">
       <TableBody>
         <TableRow key="header">
-          {["Release", "Link", "Crypto files"].map((header) => (
+          {["Release", "Link", "Checksum & Signature"].map((header) => (
             <TableCell
               className="border-gray-300 font-bold"
               sx={{ border: 1, color: "inherit" }}

--- a/versioned_docs/version-3.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-3.0.x/administration-pulsar-shell.md
@@ -20,10 +20,9 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
 
 ```shell
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 ```

--- a/versioned_docs/version-3.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-3.0.x/administration-pulsar-shell.md
@@ -23,7 +23,7 @@ It's great for quickly switching between different clusters, and can modify clus
 Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 ```

--- a/versioned_docs/version-3.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-3.0.x/administration-pulsar-shell.md
@@ -20,9 +20,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
+Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 ```

--- a/versioned_docs/version-3.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-3.0.x/administration-pulsar-shell.md
@@ -20,10 +20,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+Download the tarball from the [download page](pathname:///download#shell) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz?action=download"
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 ```

--- a/versioned_docs/version-3.0.x/client-libraries-cpp.md
+++ b/versioned_docs/version-3.0.x/client-libraries-cpp.md
@@ -35,7 +35,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 The new version of the Pulsar C++ client starts from 3.0.0 and has been no longer consistent with Pulsar since 2.10.x. For the latest releases, see the [Download](/download/) page.
 
-Take the [3.0.0 release](https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.0.0/) for example, there are following subdirectories:
+Take the [3.0.0 release](pathname:///download#pulsar-c-client) for example, there are following subdirectories:
 - apk-arm64: the Alpine Linux packages for ARM64 architectures
 - apk-x86_64: the Alpine Linux packages for x64 architectures
 - deb-arm64: the Debian-based Linux packages for ARM64 architectures

--- a/versioned_docs/version-3.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-3.0.x/getting-started-standalone.md
@@ -23,7 +23,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
 ```
 
 Once downloaded, unpack the tar file:

--- a/versioned_docs/version-3.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-3.0.x/getting-started-standalone.md
@@ -20,13 +20,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Download Pulsar distribution
 
-Download the official Apache Pulsar distribution:
-
-```bash
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
-```
-
-Once downloaded, unpack the tar file:
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/versioned_docs/version-3.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-3.0.x/getting-started-standalone.md
@@ -23,7 +23,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
 ```
 
 Once downloaded, unpack the tar file:

--- a/versioned_docs/version-3.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-3.0.x/getting-started-standalone.md
@@ -20,7 +20,13 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Download Pulsar distribution
 
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
+Download the official Apache Pulsar distribution:
+
+```bash
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+```
+
+Once downloaded, unpack the tar file:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/versioned_docs/version-3.0.x/io-canal-source.md
+++ b/versioned_docs/version-3.0.x/io-canal-source.md
@@ -121,8 +121,8 @@ Here is an example of storing MySQL data using the configuration file as above.
 7. Start Pulsar standalone.
 
    ```bash
-   docker pull apachepulsar/pulsar:2.3.0
-   docker run -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:2.3.0 bin/pulsar standalone
+   docker pull apachepulsar/pulsar:@pulsar:version@
+   docker run --user 0 -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
    ```
 
 8. Modify the configuration file `canal-mysql-source-config.yaml`.
@@ -167,9 +167,9 @@ Here is an example of storing MySQL data using the configuration file as above.
 
    ```bash
    docker exec -it pulsar-standalone /bin/bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-2.3.0/connectors/pulsar-io-canal-2.3.0.nar -P connectors
+   curl -LO --output-dir connectors "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-canal-@pulsar:version@.nar?action=download"
    ./bin/pulsar-admin source localrun \
-      --archive $PWD/connectors/pulsar-io-canal-2.3.0.nar \
+      --archive $PWD/connectors/pulsar-io-canal-@pulsar:version@.nar \
       --classname org.apache.pulsar.io.canal.CanalStringSource \
       --tenant public \
       --namespace default \

--- a/versioned_docs/version-3.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-3.0.x/io-rabbitmq-source.md
@@ -98,19 +98,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. Get a Pulsar package and start Pulsar in standalone mode.
+1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
 
    ```bash
-   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/versioned_docs/version-3.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-3.0.x/io-rabbitmq-source.md
@@ -101,17 +101,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](pathname:///download#connectors) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
-    cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
+    cd connectors
+    curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar?action=download"
     ```
 
 3. Set the retention of the namespace, otherwise the messages into the Pulsar's topic which have not the subscription have been immediately deleted.

--- a/versioned_docs/version-3.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-3.0.x/io-rabbitmq-source.md
@@ -101,16 +101,16 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
+    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/versioned_docs/version-3.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-3.0.x/io-rabbitmq-source.md
@@ -98,17 +98,19 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
+1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
+   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
+    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/versioned_docs/version-4.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-4.0.x/administration-pulsar-shell.md
@@ -21,10 +21,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+Download the tarball from the [download page](pathname:///download#shell) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz?action=download"
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/versioned_docs/version-4.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-4.0.x/administration-pulsar-shell.md
@@ -21,9 +21,10 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
+Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/versioned_docs/version-4.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-4.0.x/administration-pulsar-shell.md
@@ -21,10 +21,9 @@ It's great for quickly switching between different clusters, and can modify clus
 
 
 ## Install Pulsar Shell
-Download the tarball from the [download page](pathname:///download) and extract it.
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest release and extract it.
 
 ```shell
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/versioned_docs/version-4.0.x/administration-pulsar-shell.md
+++ b/versioned_docs/version-4.0.x/administration-pulsar-shell.md
@@ -24,7 +24,7 @@ It's great for quickly switching between different clusters, and can modify clus
 Download the tarball from the [download page](pathname:///download) and extract it.
 
 ```shell
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 tar xzvf apache-pulsar-shell-@pulsar:version@-bin.tar.gz
 cd apache-pulsar-shell-@pulsar:version@/
 ```

--- a/versioned_docs/version-4.0.x/client-libraries-cpp.md
+++ b/versioned_docs/version-4.0.x/client-libraries-cpp.md
@@ -35,7 +35,7 @@ You can use a Pulsar C++ client to create Pulsar [producers](concepts-clients.md
 
 The new version of the Pulsar C++ client starts from 3.0.0 and has been no longer consistent with Pulsar since 2.10.x. For the latest releases, see the [Download](/download/) page.
 
-Take the [3.0.0 release](https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.0.0/) for example, there are following subdirectories:
+Take the [3.0.0 release](pathname:///download#pulsar-c-client) for example, there are following subdirectories:
 - apk-arm64: the Alpine Linux packages for ARM64 architectures
 - apk-x86_64: the Alpine Linux packages for x64 architectures
 - deb-arm64: the Debian-based Linux packages for ARM64 architectures

--- a/versioned_docs/version-4.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-4.0.x/getting-started-standalone.md
@@ -26,7 +26,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
 ```
 
 Once downloaded, unpack the tar file:

--- a/versioned_docs/version-4.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-4.0.x/getting-started-standalone.md
@@ -26,7 +26,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 Download the official Apache Pulsar distribution:
 
 ```bash
-wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
 ```
 
 Once downloaded, unpack the tar file:

--- a/versioned_docs/version-4.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-4.0.x/getting-started-standalone.md
@@ -23,7 +23,13 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Step 1: Download Pulsar distribution
 
-[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
+Download the official Apache Pulsar distribution:
+
+```bash
+wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+```
+
+Once downloaded, unpack the tar file:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/versioned_docs/version-4.0.x/getting-started-standalone.md
+++ b/versioned_docs/version-4.0.x/getting-started-standalone.md
@@ -23,13 +23,7 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 ## Step 1: Download Pulsar distribution
 
-Download the official Apache Pulsar distribution:
-
-```bash
-wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
-```
-
-Once downloaded, unpack the tar file:
+[Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and extract it:
 
 ```bash
 tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz

--- a/versioned_docs/version-4.0.x/io-canal-source.md
+++ b/versioned_docs/version-4.0.x/io-canal-source.md
@@ -121,8 +121,8 @@ Here is an example of storing MySQL data using the configuration file as above.
 7. Start Pulsar standalone.
 
    ```bash
-   docker pull apachepulsar/pulsar:2.3.0
-   docker run -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:2.3.0 bin/pulsar standalone
+   docker pull apachepulsar/pulsar:@pulsar:version@
+   docker run --user 0 -d -it --link pulsar-canal-server -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data --name pulsar-standalone apachepulsar/pulsar:@pulsar:version@ bin/pulsar standalone
    ```
 
 8. Modify the configuration file `canal-mysql-source-config.yaml`.
@@ -167,9 +167,9 @@ Here is an example of storing MySQL data using the configuration file as above.
 
    ```bash
    docker exec -it pulsar-standalone /bin/bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-2.3.0/connectors/pulsar-io-canal-2.3.0.nar -P connectors
+   curl -LO --output-dir connectors "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-canal-@pulsar:version@.nar?action=download"
    ./bin/pulsar-admin source localrun \
-      --archive $PWD/connectors/pulsar-io-canal-2.3.0.nar \
+      --archive $PWD/connectors/pulsar-io-canal-@pulsar:version@.nar \
       --classname org.apache.pulsar.io.canal.CanalStringSource \
       --tenant public \
       --namespace default \

--- a/versioned_docs/version-4.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-4.0.x/io-rabbitmq-source.md
@@ -98,19 +98,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. Get a Pulsar package and start Pulsar in standalone mode.
+1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
 
    ```bash
-   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/versioned_docs/version-4.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-4.0.x/io-rabbitmq-source.md
@@ -101,16 +101,16 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://downloads.apache.org/pulsar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
+    wget https://downloads.apache.org/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 

--- a/versioned_docs/version-4.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-4.0.x/io-rabbitmq-source.md
@@ -101,17 +101,17 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
-   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
+   curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz?action=download"
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](pathname:///download#connectors) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
-    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
-    cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
+    cd connectors
+    curl -LO "https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar?action=download"
     ```
 
 3. Messages published to a topic lacking at least one durable subscription are automatically marked as ready for deletion by default. We can set a retention policy at the namespace level to prevent this.

--- a/versioned_docs/version-4.0.x/io-rabbitmq-source.md
+++ b/versioned_docs/version-4.0.x/io-rabbitmq-source.md
@@ -98,17 +98,19 @@ This example describes how to use the RabbitMQ source connector to feed data fro
 
 #### Steps
 
-1. [Download](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz) the latest Pulsar release and start in standalone mode.
+1. Get a Pulsar package and start Pulsar in standalone mode.
 
    ```bash
+   wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/apache-pulsar-@pulsar:version@-bin.tar.gz
    tar xvfz apache-pulsar-@pulsar:version@-bin.tar.gz
    cd apache-pulsar-@pulsar:version@
    bin/pulsar standalone
    ```
 
-2. Download the [nar package](https://www.apache.org/dyn/closer.lua/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
+2. Download the [nar package](https://archive.apache.org/dist/pulsar/) corresponding to Pulsar's version and copy the following file to Pulsar's directory.
 
     ```bash
+    wget https://archive.apache.org/dist/pulsar/pulsar-@pulsar:version@/connectors/pulsar-io-rabbitmq-@pulsar:version@.nar
     cp pulsar-io-rabbitmq-@pulsar:version@.nar ./connectors
     ```
 


### PR DESCRIPTION
Fixed https://github.com/apache/pulsar/issues/23710, following [the guide][1] use `closer.lua` link in download instructions.

[1]: https://infra.apache.org/release-download-pages.html#links