### PR TITLE
Add note about Java sdk 2.x dlq has a default 30s ackTimeout policy

### DIFF
--- a/docs/concepts-messaging.md
+++ b/docs/concepts-messaging.md
@@ -344,6 +344,7 @@ The dead letter producerName uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+- From Pulsar 2.3.x to 2.10.x, Java SDK dead letter policy will set a 30 seconds acknowledgment timeout when there is no user defined acknowledgment timeout. This default timeout policy has been removed since 3.0.x.
 :::
 
 Use the Java client to specify the name of the dead letter topic.

--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -330,6 +330,7 @@ The default dead letter topic uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+- From Pulsar 2.3.x to 2.10.x, Java SDK dead letter policy will set a 30 seconds acknowledgment timeout when there is no user defined acknowledgment timeout. This default timeout policy has been removed since 3.0.x.
 :::
 
 Use the Java client to specify the name of the dead letter topic.

--- a/versioned_docs/version-3.3.x/concepts-messaging.md
+++ b/versioned_docs/version-3.3.x/concepts-messaging.md
@@ -342,6 +342,7 @@ The dead letter producerName uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+- From Pulsar 2.3.x to 2.10.x, Java SDK dead letter policy will set a 30 seconds acknowledgment timeout when there is no user defined acknowledgment timeout. This default timeout policy has been removed since 3.0.x.
 :::
 
 Use the Java client to specify the name of the dead letter topic.

--- a/versioned_docs/version-4.0.x/concepts-messaging.md
+++ b/versioned_docs/version-4.0.x/concepts-messaging.md
@@ -342,6 +342,7 @@ The dead letter producerName uses this format:
 :::note
 - For Pulsar 2.6.x and 2.7.x, the default dead letter topic uses the format of `<subscriptionname>-DLQ`. If you upgrade from 2.6.x~2.7.x to 2.8.x or later, you need to delete historical dead letter topics and retry letter partitioned topics. Otherwise, Pulsar continues to use original topics, which are formatted with `<subscriptionname>-DLQ`.
 - It is not recommended to use `<subscriptionname>-DLQ` because if multiple topics under the same namespace have the same subscription, then dead message topic names for multiple topics might be the same, which will result in mutual consumptions.
+- From Pulsar 2.3.x to 2.10.x, Java SDK dead letter policy will set a 30 seconds acknowledgment timeout when there is no user defined acknowledgment timeout. This default timeout policy has been removed since 3.0.x.
 :::
 
 Use the Java client to specify the name of the dead letter topic.


### PR DESCRIPTION

### ✅ Contribution Checklist
- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)

### Motivation
Add a 30s ackTimeout when using dlq policy: https://github.com/apache/pulsar/pull/3014
Remove this 30s ackTimeout: https://github.com/apache/pulsar/pull/19486
Relative  https://github.com/apache/pulsar/issues/8484  https://github.com/apache/pulsar/issues/19134 

When we are using a Java sdk from 2.3.x to 2.10.x to create a subscription with dlq policy, the subscription will create a 30s ackTimeout policy automatically. This strategy may lead to consuming duplicate messages especially in some long time cost tasks.
According to the comment https://github.com/apache/pulsar/issues/8484#issuecomment-726057120, I think maybe we can add a hint about this 30s ackTimeout policy in concepts-messaging.md dlq section.

### Modification
Current
![image](https://github.com/user-attachments/assets/be8cd6c7-44d2-494e-8b0e-32311d440931)

Preview
![image](https://github.com/user-attachments/assets/c0fbdb6d-9a52-4d78-be18-2a4e107c4859)

