### PR TITLE
Fix tag rendering in Card component for resource entries

### DIFF
--- a/data/resources.ts
+++ b/data/resources.ts
@@ -24,6 +24,14 @@ export type Resource = {
 export const resources: Record<Category, Resource[]> = {
   articles: [
     {
+      forum: 'Attentive Blog',
+      forum_link: 'https://tech.attentive.com/',
+      date: 'April 2025',
+      title: "Goodbye Distributed Locks: Message Orchestration at Scale with Apache Pulsar",
+      link: 'https://tech.attentive.com/articles/goodbye-distributed-locks',
+      tags: ['Pulsar', 'distributed lock', 'subscription types', 'tradeoffs']
+    },
+    {
       forum: 'StreamNative Blog',
       forum_link: 'https://streamnative.io/blogs/',
       date: 'August 2022',

--- a/data/resources.ts
+++ b/data/resources.ts
@@ -24,14 +24,6 @@ export type Resource = {
 export const resources: Record<Category, Resource[]> = {
   articles: [
     {
-      forum: 'Attentive Blog',
-      forum_link: 'https://tech.attentive.com/',
-      date: 'April 2025',
-      title: "Goodbye Distributed Locks: Message Orchestration at Scale with Apache Pulsar",
-      link: 'https://tech.attentive.com/articles/goodbye-distributed-locks',
-      tags: ['Pulsar', 'distributed lock', 'subscription types', 'tradeoffs']
-    },
-    {
       forum: 'StreamNative Blog',
       forum_link: 'https://streamnative.io/blogs/',
       date: 'August 2022',

--- a/src/components/pages/ResourcesPage/Cards/Cards.tsx
+++ b/src/components/pages/ResourcesPage/Cards/Cards.tsx
@@ -33,7 +33,6 @@ const Card: React.FC<data.Resource> = (props) => {
   );
 };
 
-
 export type CardsProps = {
   resources: data.Resource[]
   search: string

--- a/src/components/pages/ResourcesPage/Cards/Cards.tsx
+++ b/src/components/pages/ResourcesPage/Cards/Cards.tsx
@@ -28,7 +28,7 @@ const Card: React.FC<data.Resource> = (props) => {
         )}
       </div>
       {props.presenter && <p>Presented by <strong>{props.presenter}</strong></p>}
-      <a href={props.link} target="_blank" rel="noopener noreferrer">Learn more</a>
+      <a href={props.link} target="_blank">Learn more</a>
     </div>
   );
 };

--- a/src/components/pages/ResourcesPage/Cards/Cards.tsx
+++ b/src/components/pages/ResourcesPage/Cards/Cards.tsx
@@ -6,18 +6,33 @@ const Card: React.FC<data.Resource> = (props) => {
   return (
     <div className={s.Card}>
       <p>
-        <a className={s.ForumLink} target="_blank" href={props.forum_link}><strong>{props.forum}</strong></a>
+        <a className={s.ForumLink} target="_blank" href={props.forum_link} rel="noopener noreferrer">
+          <strong>{props.forum}</strong>
+        </a>
       </p>
       <h3><a href={props.link}>{props.title}</a></h3>
       <div className={s.AdditionalInfo}>
         {props.date && <div><small className={s.Date}>{props.date}</small></div>}
-        {props.tags && <div><small>Tags: {props.tags}</small></div>}
+        {props.tags && props.tags.length > 0 && (
+          <div>
+            <small>
+              Tags:&nbsp;
+              {props.tags.map((tag, index) => (
+                <span key={index}>
+                  {tag}
+                  {index < props.tags.length - 1 && ', '}
+                </span>
+              ))}
+            </small>
+          </div>
+        )}
       </div>
       {props.presenter && <p>Presented by <strong>{props.presenter}</strong></p>}
-      <a href={props.link} target="_blank">Learn more</a>
+      <a href={props.link} target="_blank" rel="noopener noreferrer">Learn more</a>
     </div>
   );
 };
+
 
 export type CardsProps = {
   resources: data.Resource[]


### PR DESCRIPTION
### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [X] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [X] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)

### Description
This PR updates the Card component to properly render the tags array as a comma-separated list instead of displaying it as a raw array.

### Changes:
Replaced direct rendering of props.tags with a .map() function for clean, readable tag output.

### Before the fix:
Tags appeared as : `Tags: Pulsartroubleshootingoptimizationbest practices`

<img width="1277" alt="Screenshot 2025-04-16 at 12 12 08 AM" src="https://github.com/user-attachments/assets/d76cb1b0-bca2-46e7-8f03-0c034113ef8b" />


### After the fix:
Tags are displayed as : `Tags: Pulsar, troubleshooting, optimization, best practices`

<img width="1286" alt="Screenshot 2025-04-16 at 12 13 18 AM" src="https://github.com/user-attachments/assets/530eb31d-abb9-49f3-b272-4dd9c03b0ef9" />
