### PR TITLE
Add description of option to specify Athenz ZTS proxy

### DIFF
--- a/docs/security-athenz.md
+++ b/docs/security-athenz.md
@@ -85,6 +85,7 @@ You can also set an optional `keyId`. The following is an example.
 ```java
 Map<String, String> authParams = new HashMap();
 authParams.put("ztsUrl", "http://localhost:9998");
+// authParams.put("ztsProxyUrl", "http://localhost:9999"); // Proxy for accessing ZTS (optional, since v3.0.10/v4.0.3/v4.1.0)
 authParams.put("tenantDomain", "shopping"); // Tenant domain name
 authParams.put("tenantService", "some_app"); // Tenant service name
 authParams.put("providerDomain", "pulsar"); // Provider domain name
@@ -162,6 +163,7 @@ const client = new Pulsar.Client({
 ```go
 provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
+	// "ztsProxyUrl":    "http://localhost:9999", // Proxy for accessing ZTS (optional, since v0.16.0)
 	"providerDomain": "pulsar",
 	"tenantDomain":   "shopping",
 	"tenantService":  "some_app",
@@ -200,6 +202,7 @@ In this case, `tenantDomain`, `tenantService` and `keyId` are ignored.
 ```java
 Map<String, String> authParams = new HashMap();
 authParams.put("ztsUrl", "http://localhost:9998");
+// authParams.put("ztsProxyUrl", "http://localhost:9999"); // Proxy for accessing ZTS (optional, since v3.0.10/v4.0.3/v4.1.0)
 authParams.put("providerDomain", "pulsar"); // Provider domain name
 authParams.put("x509CertChain", "file:///path/to/x509cert.pem"); // Distributed X.509 certificate path
 authParams.put("privateKey", "file:///path/to/private.pem"); // Distributed private key path
@@ -276,6 +279,7 @@ const client = new Pulsar.Client({
 ```go
 provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
+	// "ztsProxyUrl":    "http://localhost:9999", // Proxy for accessing ZTS (optional, since v0.16.0)
 	"providerDomain": "pulsar",
 	"x509CertChain":  "file:///path/to/x509cert.pem",
 	"privateKey":     "file:///path/to/private.pem",

--- a/versioned_docs/version-4.0.x/security-athenz.md
+++ b/versioned_docs/version-4.0.x/security-athenz.md
@@ -85,6 +85,7 @@ You can also set an optional `keyId`. The following is an example.
 ```java
 Map<String, String> authParams = new HashMap();
 authParams.put("ztsUrl", "http://localhost:9998");
+// authParams.put("ztsProxyUrl", "http://localhost:9999"); // Proxy for accessing ZTS (optional, since v3.0.10/v4.0.3/v4.1.0)
 authParams.put("tenantDomain", "shopping"); // Tenant domain name
 authParams.put("tenantService", "some_app"); // Tenant service name
 authParams.put("providerDomain", "pulsar"); // Provider domain name
@@ -162,6 +163,7 @@ const client = new Pulsar.Client({
 ```go
 provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
+	// "ztsProxyUrl":    "http://localhost:9999", // Proxy for accessing ZTS (optional, since v0.16.0)
 	"providerDomain": "pulsar",
 	"tenantDomain":   "shopping",
 	"tenantService":  "some_app",
@@ -200,6 +202,7 @@ In this case, `tenantDomain`, `tenantService` and `keyId` are ignored.
 ```java
 Map<String, String> authParams = new HashMap();
 authParams.put("ztsUrl", "http://localhost:9998");
+// authParams.put("ztsProxyUrl", "http://localhost:9999"); // Proxy for accessing ZTS (optional, since v3.0.10/v4.0.3/v4.1.0)
 authParams.put("providerDomain", "pulsar"); // Provider domain name
 authParams.put("x509CertChain", "file:///path/to/x509cert.pem"); // Distributed X.509 certificate path
 authParams.put("privateKey", "file:///path/to/private.pem"); // Distributed private key path
@@ -276,6 +279,7 @@ const client = new Pulsar.Client({
 ```go
 provider := pulsar.NewAuthenticationAthenz(map[string]string{
 	"ztsUrl":         "http://localhost:9998",
+	// "ztsProxyUrl":    "http://localhost:9999", // Proxy for accessing ZTS (optional, since v0.16.0)
 	"providerDomain": "pulsar",
 	"x509CertChain":  "file:///path/to/x509cert.pem",
 	"privateKey":     "file:///path/to/private.pem",


### PR DESCRIPTION
The Athenz auth plugin for each client library obtains a token for authentication from ZTS. In Java and Go, it is now possible to specify a proxy URL for accessing ZTS as an option, so I have added a description of this.
- https://github.com/apache/pulsar/pull/23947
- https://github.com/apache/pulsar-client-go/pull/1360

### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
