### PR TITLE
Add Golang NACK Backoff support icon in client matrix

### DIFF
--- a/data/matrix.js
+++ b/data/matrix.js
@@ -445,7 +445,7 @@ module.exports = {
           Feature: "NACK Backoff",
           Java: 2,
           "C++": 0,
-          Go: 0,
+          Go: 2,
           Python: 0,
           Nodejs: 0,
           "C#/DotPulsar": 0,


### PR DESCRIPTION
# ✅ Contribution Checklist

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)

# Motivation
Currently pulsar-client-go has been supported nack backoff policy since version [0.8.0](https://github.com/apache/pulsar-client-go/pull/660). Maybe we should set related support icon in the client matrix.

# Preview
## before
<img width="3840" height="1758" alt="image" src="https://github.com/user-attachments/assets/29e6a248-aabd-40ca-9d87-e25e423660a2" />


## after
<img width="3840" height="1758" alt="WXWorkCapture_1752463724394" src="https://github.com/user-attachments/assets/978cfdb3-0399-49c3-861f-7a85fb58d9b4" />
