### PR TITLE
Add go client release notes for 0.16.0

### DIFF
--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -19,6 +19,9 @@ name: CI - Precommit
 on:
   pull_request:
     branches: [main]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/data/release-go.js
+++ b/data/release-go.js
@@ -1,4 +1,5 @@
 module.exports = [
+{tagName: "v0.16.0",releaseNotes:"/release-notes/versioned/pulsar-client-go-0.16.0/",doc:"/docs/client-libraries-go",version:"v0.16.x"},
 {tagName: "v0.15.1",releaseNotes:"/release-notes/versioned/pulsar-client-go-0.15.1/",doc:"/docs/client-libraries-go",version:"v0.15.x"},
 {tagName: "v0.15.0",releaseNotes:"/release-notes/versioned/pulsar-client-go-0.15.0/",doc:"/docs/client-libraries-go",version:""},
 {tagName: "v0.14.0",releaseNotes:"/release-notes/versioned/pulsar-client-go-0.14.0/",doc:"/docs/client-libraries-go",version:"v0.14.x"},

--- a/release-notes/versioned/pulsar-client-go-0.16.0.md
+++ b/release-notes/versioned/pulsar-client-go-0.16.0.md
@@ -1,0 +1,38 @@
+---
+id: pulsar-client-go-0.16.0
+title: Pulsar Client Go
+sidebar_label: Pulsar Client Go
+---
+
+## What's Changed
+
+* [fix][sec] Bump golang.org/x/net to address CVE-2025-22870, requires go 1.23 by @lhotari in https://github.com/apache/pulsar-client-go/pull/1351
+* [chore] Bump github.com/golang-jwt/jwt/v5 from 5.2.1 to 5.2.2 by @dependabot in https://github.com/apache/pulsar-client-go/pull/1349
+* [chore] Bump github.com/containerd/containerd from 1.7.18 to 1.7.27 by @dependabot in https://github.com/apache/pulsar-client-go/pull/1348
+* [fix] Use sha instead of tag for golangci/golangci-lint-action by @nodece in https://github.com/apache/pulsar-client-go/pull/1352
+* [feat] Prefetch role tokens in the background in the Athenz auth plugin by @masahiro-sakamoto in https://github.com/apache/pulsar-client-go/pull/1355
+* [feat] Make ZTS proxy configurable in athenz auth plugin by @masahiro-sakamoto in https://github.com/apache/pulsar-client-go/pull/1360
+* [fix] Fix reader hanging when startMessageId is latest by @RobertIndie in https://github.com/apache/pulsar-client-go/pull/1364
+* [fix] Fix CI can't be failed even the tests are failed by @RobertIndie in https://github.com/apache/pulsar-client-go/pull/1367
+* [improve] Improve perf with level guard in slogWrapper calls by @gareth-murphy in https://github.com/apache/pulsar-client-go/pull/1374
+* [feat] Support update or remove topic properties by @yunze-xu in https://github.com/apache/pulsar-client-go/pull/1381
+* [test] Skip very flaky TestMessageSingleRouter for now by @yunze-xu in https://github.com/apache/pulsar-client-go/pull/1382
+* [improve] Support ClientVersion in 2.x pulsar broker by @zhou-zhuohan in https://github.com/apache/pulsar-client-go/pull/1383
+* [test] Add Testcase to test using keyShared subscription and delayed messages at the same time by @zhou-zhuohan in https://github.com/apache/pulsar-client-go/pull/1361
+* [fix] Support json token file format authentication by @qiang-zhao in https://github.com/apache/pulsar-client-go/pull/1380
+* [chore] Replace deprecated api rand.Seed by @young-xu in https://github.com/apache/pulsar-client-go/pull/1363
+* [fix] Fix namespace schema compatibility strategy by @rui-fu in https://github.com/apache/pulsar-client-go/pull/1386
+* [fix] Fix backoff unit tests by @zhou-zhuohan in https://github.com/apache/pulsar-client-go/pull/1387
+* [improve] Support http lookup getSchema interface by @zhou-zhuohan in https://github.com/apache/pulsar-client-go/pull/1368
+* [fix] Fix the default nack backoff policy by @Gilthoniel in https://github.com/apache/pulsar-client-go/pull/1385
+* [feat] Add pulsar admin namespace properties methods for PUT/GET/DELETE by @thomas-bousquet in https://github.com/apache/pulsar-client-go/pull/1390
+* [fix] Fix sending buffer race by using proper reference counting by @RobertIndie in https://github.com/apache/pulsar-client-go/pull/1394
+* [fix] ZeroQueueConsumer is not supported with RetryEnable by @crossoverJie in https://github.com/apache/pulsar-client-go/pull/1391
+* [fix] Add missing metric tracking of `pulsar_client_consumer_acks` for AckIDList method by @RobertIndie in https://github.com/apache/pulsar-client-go/pull/1396
+* [feat] Align topics level policies admin apis to java restful apis by @rui-fu in https://github.com/apache/pulsar-client-go/pull/1398
+
+## New Contributors
+* @gmurphy-cogito made their first contribution in https://github.com/apache/pulsar-client-go/pull/1374
+* @mattisonchao made their first contribution in https://github.com/apache/pulsar-client-go/pull/1380
+* @xuthus5 made their first contribution in https://github.com/apache/pulsar-client-go/pull/1363
+* @thomas-bousquet made their first contribution in https://github.com/apache/pulsar-client-go/pull/1390

--- a/scripts/release_notes_reorder_script.py
+++ b/scripts/release_notes_reorder_script.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """
 Script to reorder Pulsar release notes based on a reference file structure
 or reorganize a single file using component-based section assignment.


### PR DESCRIPTION
## Modification

- Add go client release notes for 0.16.0
- Fix license isuse introduced by https://github.com/apache/pulsar-site/commit/76575abadab326e9411900e09591a7865bdd14fa
- Add license check for push event

## Preview

<img width="1133" height="480" alt="image" src="https://github.com/user-attachments/assets/08691d14-ded3-400b-b094-5bc60a2568e4" />
<img width="1413" height="1005" alt="image" src="https://github.com/user-attachments/assets/3279df59-34e1-4a77-9288-5c4a52f1b016" />



### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)
