### PR TITLE
Add Java client OpenTelemetry metrics documentation

### DIFF
--- a/docs/reference-metrics-opentelemetry.md
+++ b/docs/reference-metrics-opentelemetry.md
@@ -1097,3 +1097,242 @@ Time taken to complete a consistent snapshot operation across clusters.
   * `pulsar.replication.subscription.snapshot.operation.result` - The result of the snapshot operation. Can be one of:
     * `success`
     * `timeout`
+
+## Java Client
+
+### Producer Metrics
+
+#### pulsar.client.producer.message.send.duration
+Publish latency experienced by the application, includes client batching time.
+* Type: Histogram
+* Unit: `s`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.response.status` - The response status. Can be one of:
+    * `success`
+    * `failed`
+
+#### pulsar.client.producer.rpc.send.duration
+Publish RPC latency experienced internally by the client when sending data to receiving an ack.
+* Type: Histogram
+* Unit: `s`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.response.status` - The response status. Can be one of:
+    * `success`
+    * `failed`
+
+#### pulsar.client.producer.message.send.size
+The number of bytes published.
+* Type: Counter
+* Unit: `By`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+
+#### pulsar.client.producer.message.pending.count
+The number of messages in the producer internal send queue, waiting to be sent.
+* Type: UpDownCounter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+
+#### pulsar.client.producer.message.pending.size
+The size of the messages in the producer internal queue, waiting to be sent.
+* Type: UpDownCounter
+* Unit: `By`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+
+#### pulsar.client.producer.opened
+The number of producer sessions opened.
+* Type: Counter
+* Unit: `{session}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+
+#### pulsar.client.producer.closed
+The number of producer sessions closed.
+* Type: Counter
+* Unit: `{session}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+
+### Consumer Metrics
+
+#### pulsar.client.consumer.opened
+The number of consumer sessions opened.
+* Type: Counter
+* Unit: `{session}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.closed
+The number of consumer sessions closed.
+* Type: Counter
+* Unit: `{session}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.received.count
+The number of messages explicitly received by the consumer application.
+* Type: Counter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.received.size
+The number of bytes explicitly received by the consumer application.
+* Type: Counter
+* Unit: `By`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.receive_queue.count
+The number of messages currently sitting in the consumer receive queue.
+* Type: UpDownCounter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.receive_queue.size
+The total size in bytes of messages currently sitting in the consumer receive queue.
+* Type: UpDownCounter
+* Unit: `By`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.ack
+The number of acknowledged messages.
+* Type: Counter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.nack
+The number of negatively acknowledged messages.
+* Type: Counter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.dlq
+The number of messages sent to the dead letter queue.
+* Type: Counter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+#### pulsar.client.consumer.message.ack.timeout
+The number of messages that were not acknowledged in the configured timeout period, hence, were requested by the client to be redelivered.
+* Type: Counter
+* Unit: `{message}`
+* Attributes:
+  * `pulsar.tenant` - The topic tenant.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.topic` - The topic name.
+  * `pulsar.partition` - The partition index of the topic. Present only if the topic is partitioned.
+  * `pulsar.subscription` - The subscription name.
+
+### Connection Metrics
+
+#### pulsar.client.connection.opened
+The number of connections opened.
+* Type: Counter
+* Unit: `{connection}`
+
+#### pulsar.client.connection.closed
+The number of connections closed.
+* Type: Counter
+* Unit: `{connection}`
+
+#### pulsar.client.connection.failed
+The number of failed connection attempts.
+* Type: Counter
+* Unit: `{connection}`
+* Attributes:
+  * `pulsar.failure.type` - The type of connection failure. Can be one of:
+    * `tcp-failed`
+    * `handshake`
+
+### Lookup Service Metrics
+
+#### pulsar.client.lookup.duration
+Duration of lookup operations.
+* Type: Histogram
+* Unit: `s`
+* Attributes:
+  * `pulsar.lookup.transport-type` - The transport type used for the lookup. Can be one of:
+    * `http`
+    * `binary`
+  * `pulsar.response.status` - The response status. Can be one of:
+    * `success`
+    * `failed`
+
+### Memory Buffer Metrics
+
+#### pulsar.client.memory.buffer.usage
+Current memory buffer usage by the client.
+* Type: UpDownCounter
+* Unit: `By`
+
+#### pulsar.client.memory.buffer.limit
+Memory buffer limit configured for the client.
+* Type: UpDownCounter
+* Unit: `By`


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for all Java client OpenTelemetry metrics to the reference documentation (`docs/reference-metrics-opentelemetry.md`).

### What's Added

- **Java Client** section with comprehensive metrics documentation covering:
  - **Producer Metrics** (7 metrics): Message send latency, pending queues, session management
  - **Consumer Metrics** (10 metrics): Message reception, acknowledgments, receive queues  
  - **Connection Metrics** (3 metrics): Connection lifecycle and failures
  - **Lookup Service Metrics** (1 metric): Lookup operation duration
  - **Memory Buffer Metrics** (2 metrics): Usage and limits

### Documentation Features

- **Total of 23 Java client OpenTelemetry metrics** documented
- Follows the same format as existing broker metrics for consistency
- Includes metric name, type, unit, description, and attributes for each metric
- Proper attribute definitions with possible values
- Based on actual implementation in Apache Pulsar Java client source code
- Consistent with OpenTelemetry naming conventions and standards

### Implementation Details

The metrics documentation is based on analysis of the actual Pulsar Java client OpenTelemetry implementation from:
- Producer metrics from `ProducerImpl.java`
- Consumer metrics from `ConsumerImpl.java` 
- Connection metrics from `ClientCnx.java` and `ConnectionPool.java`
- Lookup metrics from `HttpLookupService.java` and `BinaryProtoLookupService.java`
- Memory buffer metrics from `MemoryBufferStats.java`

All metrics use the instrumentation scope `org.apache.pulsar.client` and follow OpenTelemetry semantic conventions.

### Metrics Categories Added

#### Producer Metrics (7 metrics)
- `pulsar.client.producer.message.send.duration` - End-to-end publish latency
- `pulsar.client.producer.rpc.send.duration` - Internal RPC latency  
- `pulsar.client.producer.message.send.size` - Bytes published
- `pulsar.client.producer.message.pending.count` - Messages in send queue
- `pulsar.client.producer.message.pending.size` - Bytes in send queue
- `pulsar.client.producer.opened` - Producer sessions opened
- `pulsar.client.producer.closed` - Producer sessions closed

#### Consumer Metrics (10 metrics)
- `pulsar.client.consumer.opened` - Consumer sessions opened
- `pulsar.client.consumer.closed` - Consumer sessions closed
- `pulsar.client.consumer.message.received.count` - Messages received
- `pulsar.client.consumer.message.received.size` - Bytes received
- `pulsar.client.consumer.receive_queue.count` - Messages in receive queue
- `pulsar.client.consumer.receive_queue.size` - Bytes in receive queue
- `pulsar.client.consumer.message.ack` - Messages acknowledged
- `pulsar.client.consumer.message.nack` - Messages negatively acknowledged
- `pulsar.client.consumer.message.dlq` - Messages sent to DLQ
- `pulsar.client.consumer.message.ack.timeout` - Ack timeout redeliveries

#### Connection Metrics (3 metrics)
- `pulsar.client.connection.opened` - Connections opened
- `pulsar.client.connection.closed` - Connections closed  
- `pulsar.client.connection.failed` - Failed connection attempts

#### Lookup Service Metrics (1 metric)
- `pulsar.client.lookup.duration` - Lookup operation duration

#### Memory Buffer Metrics (2 metrics)
- `pulsar.client.memory.buffer.usage` - Current memory buffer usage
- `pulsar.client.memory.buffer.limit` - Memory buffer limit

## Test Plan

- [x] Documentation syntax verified
- [x] Format matches existing broker metrics documentation
- [x] Metric names and attributes verified against source code implementation
- [x] All metric categories properly organized and documented
- [x] Follows OpenTelemetry semantic conventions

🤖 Generated with [Claude Code](https://claude.ai/code)