### PR TITLE
Fix CSP blocking GitHub badge images on client libraries page

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,4 +1,4 @@
-SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/"
+SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://*.shields.io/"
 
 RewriteEngine On
 


### PR DESCRIPTION
# Fix CSP blocking GitHub badge images on client libraries page

## Problem Description
GitHub badge images (stars, last commit) are not displaying on the client libraries page (https://pulsar.apache.org/docs/next/client-libraries/) due to Content Security Policy (CSP) restrictions blocking requests to `img.shields.io`.

## Root Cause
The Apache httpd server's CSP policy does not include the `https://*.shields.io/` domain in the allowed image sources, causing all image requests from `img.shields.io` to be blocked by browsers.

## Solution
Add `https://*.shields.io/` to the `CSP_PROJECT_DOMAINS` environment variable in the `static/.htaccess` file:

**Before:**
```apache
SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/"
```

**After:**
```apache
SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://*.shields.io/"
```

## Impact
- Fixes display issues for all GitHub shields.io badges across the website
- Primarily affects client library pages showing repository stars, last commit dates, and license information
- Improves page visual completeness and user experience
- No security impact as shields.io is a trusted service for displaying repository metadata

## Testing
After deployment, the fix can be verified by:
1. Visiting https://pulsar.apache.org/docs/next/client-libraries/
2. Confirming all GitHub badge images display correctly
3. Checking browser developer tools for absence of CSP violation errors

## Files Changed
- `static/.htaccess`: Added `https://*.shields.io/` to CSP allowed domains

This is a minimal, safe change that only allows loading image resources from the trusted shields.io service without affecting other security policies.

### ✅ Contribution Checklist

<!--
Feel free to remove the checklist if it does not apply to your PR
-->

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)