### PR TITLE
Docs: document cursor persist truncation OpenTelemetry metrics

### DIFF
--- a/docs/reference-metrics-opentelemetry.md
+++ b/docs/reference-metrics-opentelemetry.md
@@ -632,6 +632,22 @@ The total amount of data read from the ledger.
   * `pulsar.managed_ledger.name` - The name of the managed ledger.
   * `pulsar.managed_ledger.cursor.name` - The name of the managed cursor.
 
+#### pulsar.broker.managed_ledger.cursor.persist.unacked_ranges.truncated
+The number of times a cursor exceeded `managedLedgerMaxUnackedRangesToPersist`, causing ack state to be truncated at persistence. Ack state beyond the limit is lost on broker restart.
+* Type: Counter
+* Unit: `{truncation}`
+* Attributes:
+  * `managedLedger` - The name of the managed ledger.
+  * `cursor` - The name of the managed cursor.
+
+#### pulsar.broker.managed_ledger.cursor.persist.batch_deleted_indexes.truncated
+The number of times a cursor exceeded `managedLedgerMaxBatchDeletedIndexToPersist`, causing batch deleted index state to be truncated at persistence. State beyond the limit is lost on broker restart.
+* Type: Counter
+* Unit: `{truncation}`
+* Attributes:
+  * `managedLedger` - The name of the managed ledger.
+  * `cursor` - The name of the managed cursor.
+
 ### Managed Ledger Cache metrics
 
 #### pulsar.broker.managed_ledger.count

--- a/docs/reference-metrics-opentelemetry.md
+++ b/docs/reference-metrics-opentelemetry.md
@@ -637,16 +637,18 @@ The number of times a cursor exceeded `managedLedgerMaxUnackedRangesToPersist`, 
 * Type: Counter
 * Unit: `{truncation}`
 * Attributes:
-  * `managedLedger` - The name of the managed ledger.
-  * `cursor` - The name of the managed cursor.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.managed_ledger.name` - The name of the managed ledger.
+  * `pulsar.managed_ledger.cursor.name` - The name of the managed cursor.
 
 #### pulsar.broker.managed_ledger.cursor.persist.batch_deleted_indexes.truncated
 The number of times a cursor exceeded `managedLedgerMaxBatchDeletedIndexToPersist`, causing batch deleted index state to be truncated at persistence. State beyond the limit is lost on broker restart.
 * Type: Counter
 * Unit: `{truncation}`
 * Attributes:
-  * `managedLedger` - The name of the managed ledger.
-  * `cursor` - The name of the managed cursor.
+  * `pulsar.namespace` - The topic namespace.
+  * `pulsar.managed_ledger.name` - The name of the managed ledger.
+  * `pulsar.managed_ledger.cursor.name` - The name of the managed cursor.
 
 ### Managed Ledger Cache metrics
 


### PR DESCRIPTION
### ✅ Contribution Checklist

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [ ] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs) — not applicable, these metrics are new and only exist on `master` (not in any released version yet).

## Summary

Document two new OpenTelemetry counters introduced in apache/pulsar#25548:

- `pulsar.broker.managed_ledger.cursor.persist.unacked_ranges.truncated` — emitted when a cursor exceeds `managedLedgerMaxUnackedRangesToPersist` and ack state is truncated at persistence.
- `pulsar.broker.managed_ledger.cursor.persist.batch_deleted_indexes.truncated` — emitted when a cursor exceeds `managedLedgerMaxBatchDeletedIndexToPersist` and batch deleted index state is truncated at persistence.

Both counters are tagged with the cursor's standard attributes (pulsar.namespace, pulsar.managed_ledger.name, pulsar.managed_ledger.cursor.name)  — the same set used by the other cursor metrics in this section.

Added under the existing `### Managed Ledger Cursor metrics` section of `reference-metrics-opentelemetry.md`, following the format used by the surrounding metrics in that section.

See apache/pulsar#25548.