### PR TITLE
docs(admin-api-topics): document topic truncate operation

### DIFF
--- a/docs/admin-api-topics.md
+++ b/docs/admin-api-topics.md
@@ -257,6 +257,38 @@ admin.topics().unload(topic);
 </Tabs>
 ````
 
+### Truncate topic
+
+You can truncate a topic in the following ways. The truncate operation moves all cursors to the end of the topic and deletes all inactive ledgers, freeing the storage used by messages that have already been consumed.
+
+````mdx-code-block
+<Tabs groupId="api-choice"
+  defaultValue="pulsar-admin"
+  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+pulsar-admin topics truncate persistent://test-tenant/ns1/tp1
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+[](swagger:/admin/v2/PersistentTopics_truncateTopic)
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+String topic = "persistent://my-tenant/my-namespace/my-topic";
+admin.topics().truncate(topic);
+```
+
+</TabItem>
+
+</Tabs>
+````
+
 ### Get stats
 
 For the detailed statistics of a topic, see [Pulsar statistics](administration-stats.md#topic-stats).


### PR DESCRIPTION
﻿## Motivation

Fixes #24086.

`pulsar-admin topics truncate` has been shipping for years, but the operator-facing docs page [admin-api-topics](https://pulsar.apache.org/docs/4.2.x/admin-api-topics/) doesn't mention it anywhere. This leaves users to discover the command only via `pulsar-admin topics --help` or by reading source code, and the companion Java admin API (`Topics#truncate`) / REST endpoint (`DELETE .../truncate`) get no exposure either.

## Modifications

Add a new `### Truncate topic` subsection in `docs/admin-api-topics.md`, slotted between the existing **Unload topic** and **Get stats** sections, with the same three-tab layout (`pulsar-admin` / `REST API` / `Java`) used by the rest of the page.

The description is taken verbatim from the canonical sources so it stays accurate as the impl evolves:

- CLI: [`CmdTopics.TruncateCmd`](https://github.com/apache/pulsar/blob/master/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java) &mdash; `"Truncate a topic. The truncate operation will move all cursors to the end of the topic and delete all inactive ledgers."`
- REST: [`PersistentTopics#truncateTopic`](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java) &mdash; same notes string.
- Java: [`Topics#truncate(String)`](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java).

I rephrased the docs line slightly from _"will move ... and delete"_ to _"moves ... and deletes ... freeing the storage used by messages that have already been consumed"_ so it reads like the rest of the page (present tense, user-facing).

## Verifying this change

This change is a docs-only addition and should be verified by docs preview:

- [ ] `### Truncate topic` renders between **Unload topic** and **Get stats** on `docs/admin-api-topics`.
- [ ] Swagger block resolves to `PersistentTopics_truncateTopic`.
- [ ] All three tabs (pulsar-admin / REST / Java) show the expected snippet.

No code paths changed; no tests affected.

## Does this pull request potentially affect one of the following parts:

- [x] `The docs`
- [ ] Dependencies (does it add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

## Documentation

- [ ] `doc-required`
- [x] `doc-not-needed` &mdash; this PR **is** the docs change.
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repository

PR in forked repository: apache/pulsar-site#_(filled automatically)_