### PR TITLE
docs(reference-metrics): rename bookie_DELETED_LEDGER_COUNT to bookie_DELETED_LEDGER_TOTAL

### DIFF
--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -67,7 +67,7 @@ in the `bookkeeper.conf` configuration file.
 | bookie_entries_count | Gauge | The total number of entries stored in the bookie. |
 | bookie_write_cache_size | Gauge | The bookie write cache size (in bytes). |
 | bookie_read_cache_size | Gauge | The bookie read cache size (in bytes). |
-| bookie_DELETED_LEDGER_COUNT | Counter | The total number of ledgers deleted since the bookie has started. |
+| bookie_DELETED_LEDGER_TOTAL | Counter | The total number of ledgers deleted since the bookie has started. |
 | bookie_ledger_writable_dirs | Gauge | The number of writable directories in the bookie. |
 | bookie_flush | Gauge| The table flush latency of bookie memory. |
 | bookie_throttled_write_requests | Counter | The number of write requests to be throttled. |

--- a/versioned_docs/version-3.3.x/reference-metrics.md
+++ b/versioned_docs/version-3.3.x/reference-metrics.md
@@ -67,7 +67,7 @@ in the `bookkeeper.conf` configuration file.
 | bookie_entries_count | Gauge | The total number of entries stored in the bookie. |
 | bookie_write_cache_size | Gauge | The bookie write cache size (in bytes). |
 | bookie_read_cache_size | Gauge | The bookie read cache size (in bytes). |
-| bookie_DELETED_LEDGER_COUNT | Counter | The total number of ledgers deleted since the bookie has started. |
+| bookie_DELETED_LEDGER_TOTAL | Counter | The total number of ledgers deleted since the bookie has started. |
 | bookie_ledger_writable_dirs | Gauge | The number of writable directories in the bookie. |
 | bookie_flush | Gauge| The table flush latency of bookie memory. |
 | bookie_throttled_write_requests | Counter | The number of write requests to be throttled. |

--- a/versioned_docs/version-4.1.x/reference-metrics.md
+++ b/versioned_docs/version-4.1.x/reference-metrics.md
@@ -67,7 +67,7 @@ in the `bookkeeper.conf` configuration file.
 | bookie_entries_count | Gauge | The total number of entries stored in the bookie. |
 | bookie_write_cache_size | Gauge | The bookie write cache size (in bytes). |
 | bookie_read_cache_size | Gauge | The bookie read cache size (in bytes). |
-| bookie_DELETED_LEDGER_COUNT | Counter | The total number of ledgers deleted since the bookie has started. |
+| bookie_DELETED_LEDGER_TOTAL | Counter | The total number of ledgers deleted since the bookie has started. |
 | bookie_ledger_writable_dirs | Gauge | The number of writable directories in the bookie. |
 | bookie_flush | Gauge| The table flush latency of bookie memory. |
 | bookie_throttled_write_requests | Counter | The number of write requests to be throttled. |

--- a/versioned_docs/version-4.2.x/reference-metrics.md
+++ b/versioned_docs/version-4.2.x/reference-metrics.md
@@ -67,7 +67,7 @@ in the `bookkeeper.conf` configuration file.
 | bookie_entries_count | Gauge | The total number of entries stored in the bookie. |
 | bookie_write_cache_size | Gauge | The bookie write cache size (in bytes). |
 | bookie_read_cache_size | Gauge | The bookie read cache size (in bytes). |
-| bookie_DELETED_LEDGER_COUNT | Counter | The total number of ledgers deleted since the bookie has started. |
+| bookie_DELETED_LEDGER_TOTAL | Counter | The total number of ledgers deleted since the bookie has started. |
 | bookie_ledger_writable_dirs | Gauge | The number of writable directories in the bookie. |
 | bookie_flush | Gauge| The table flush latency of bookie memory. |
 | bookie_throttled_write_requests | Counter | The number of write requests to be throttled. |


### PR DESCRIPTION
﻿## Motivation

Fixes #24029.

`BookKeeperServerStats` aliases the counter name so the metric the bookie actually emits is `bookie_DELETED_LEDGER_TOTAL`, not `bookie_DELETED_LEDGER_COUNT`:

```java
// bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
String DELETED_LEDGER_COUNT = "DELETED_LEDGER_TOTAL";
```

Operators who set up scrape rules from `reference-metrics.md` as written today get an empty series back on any Pulsar/BookKeeper version that's shipping the `_TOTAL` name &mdash; which per the linked issue is everything on the 3.0.x line and later.

## Modifications

Rename `bookie_DELETED_LEDGER_COUNT` &rarr; `bookie_DELETED_LEDGER_TOTAL` in:

- `docs/reference-metrics.md` (current)
- `versioned_docs/version-4.2.x/reference-metrics.md`
- `versioned_docs/version-4.1.x/reference-metrics.md`
- `versioned_docs/version-3.3.x/reference-metrics.md`

Description is unchanged; only the metric identifier is corrected. Older versioned docs (2.x, 3.0-3.2) are intentionally not touched since I can't verify when the rename actually landed on each stream &mdash; happy to extend coverage if a maintainer confirms the scope.

## Verifying this change

Grep the rendered docs for either spelling &mdash; only `bookie_DELETED_LEDGER_TOTAL` should remain on the touched versions.

## Does this pull request potentially affect one of the following parts:

- [x] `The docs`
- [ ] Anything else

## Documentation

- [x] `doc` &mdash; this PR is the docs fix.