### PR TITLE
docs(getting-started-docker-compose): clarify macOS/Windows data-dir step

### DIFF
--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -126,13 +126,26 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-As preparation, create data directories and change the data directory ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
+As preparation, create the data directories that the `compose.yml` file will bind-mount into the Pulsar containers.
+
+On Linux, the mounted directories need to be owned by uid `10000` -- the default user inside the Pulsar Docker container -- so the containers can write to them:
 
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
-# this step might not be necessary on other than Linux platforms
 sudo chown -R 10000 data
 ```
+
+:::note macOS and Windows (Docker Desktop)
+
+On macOS and Windows, Docker Desktop runs containers inside a Linux VM and handles uid remapping for bind mounts for you, so the `chown -R 10000` step is not required and running it with `sudo` will typically fail or leave the files in a state that prevents `docker compose up` from starting cleanly (the bookie/zookeeper containers fail with permission errors on `./data/...`).
+
+If you see permission errors on startup, remove the `./data` directory (or reset its ownership to your user) and create it without `chown`:
+
+```bash
+mkdir -p ./data/zookeeper ./data/bookkeeper
+```
+
+:::
 
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 

--- a/versioned_docs/version-3.3.x/getting-started-docker-compose.md
+++ b/versioned_docs/version-3.3.x/getting-started-docker-compose.md
@@ -113,13 +113,26 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-As preparation, create data directories and change the data directory ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
+As preparation, create the data directories that the `compose.yml` file will bind-mount into the Pulsar containers.
+
+On Linux, the mounted directories need to be owned by uid `10000` -- the default user inside the Pulsar Docker container -- so the containers can write to them:
 
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
-# this step might not be necessary on other than Linux platforms
 sudo chown -R 10000 data
 ```
+
+:::note macOS and Windows (Docker Desktop)
+
+On macOS and Windows, Docker Desktop runs containers inside a Linux VM and handles uid remapping for bind mounts for you, so the `chown -R 10000` step is not required and running it with `sudo` will typically fail or leave the files in a state that prevents `docker compose up` from starting cleanly (the bookie/zookeeper containers fail with permission errors on `./data/...`).
+
+If you see permission errors on startup, remove the `./data` directory (or reset its ownership to your user) and create it without `chown`:
+
+```bash
+mkdir -p ./data/zookeeper ./data/bookkeeper
+```
+
+:::
 
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 

--- a/versioned_docs/version-4.1.x/getting-started-docker-compose.md
+++ b/versioned_docs/version-4.1.x/getting-started-docker-compose.md
@@ -126,13 +126,26 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-As preparation, create data directories and change the data directory ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
+As preparation, create the data directories that the `compose.yml` file will bind-mount into the Pulsar containers.
+
+On Linux, the mounted directories need to be owned by uid `10000` -- the default user inside the Pulsar Docker container -- so the containers can write to them:
 
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
-# this step might not be necessary on other than Linux platforms
 sudo chown -R 10000 data
 ```
+
+:::note macOS and Windows (Docker Desktop)
+
+On macOS and Windows, Docker Desktop runs containers inside a Linux VM and handles uid remapping for bind mounts for you, so the `chown -R 10000` step is not required and running it with `sudo` will typically fail or leave the files in a state that prevents `docker compose up` from starting cleanly (the bookie/zookeeper containers fail with permission errors on `./data/...`).
+
+If you see permission errors on startup, remove the `./data` directory (or reset its ownership to your user) and create it without `chown`:
+
+```bash
+mkdir -p ./data/zookeeper ./data/bookkeeper
+```
+
+:::
 
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 

--- a/versioned_docs/version-4.2.x/getting-started-docker-compose.md
+++ b/versioned_docs/version-4.2.x/getting-started-docker-compose.md
@@ -126,13 +126,26 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
-As preparation, create data directories and change the data directory ownership to uid(10000) which is the default user id used in the Pulsar Docker container.
+As preparation, create the data directories that the `compose.yml` file will bind-mount into the Pulsar containers.
+
+On Linux, the mounted directories need to be owned by uid `10000` -- the default user inside the Pulsar Docker container -- so the containers can write to them:
 
 ```bash
 sudo mkdir -p ./data/zookeeper ./data/bookkeeper
-# this step might not be necessary on other than Linux platforms
 sudo chown -R 10000 data
 ```
+
+:::note macOS and Windows (Docker Desktop)
+
+On macOS and Windows, Docker Desktop runs containers inside a Linux VM and handles uid remapping for bind mounts for you, so the `chown -R 10000` step is not required and running it with `sudo` will typically fail or leave the files in a state that prevents `docker compose up` from starting cleanly (the bookie/zookeeper containers fail with permission errors on `./data/...`).
+
+If you see permission errors on startup, remove the `./data` directory (or reset its ownership to your user) and create it without `chown`:
+
+```bash
+mkdir -p ./data/zookeeper ./data/bookkeeper
+```
+
+:::
 
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 


### PR DESCRIPTION
﻿## Motivation

Fixes #23137.

The docker-compose quickstart currently tells users to run:

```bash
sudo mkdir -p ./data/zookeeper ./data/bookkeeper
# this step might not be necessary on other than Linux platforms
sudo chown -R 10000 data
```

On macOS/Windows (Docker Desktop) the `chown -R 10000` step is both unnecessary -- Docker Desktop's VM handles uid remapping for bind mounts -- **and** actively breaks the stack: `docker compose up` fails with permission errors on `./data/...` because the mounted directory ends up in a state the in-container user can't write.

The existing one-line comment (*"this step might not be necessary on other than Linux platforms"*) is too easy to miss and doesn't tell the user what to do when it already broke.

## Modifications

- Rewrite the Linux instruction so the Linux path is unchanged.
- Add a `:::note macOS and Windows (Docker Desktop)` admonition that:
  - explains *why* chown isn't needed on Desktop hosts,
  - warns that running `sudo chown -R 10000` will typically break `docker compose up`,
  - gives the recovery recipe (delete `./data`, recreate without `chown`, retry).
- Applied to the unversioned `docs/` and the 3 most recent LTS versioned docs (`3.3.x`, `4.1.x`, `4.2.x`). Older versioned docs (2.x, 3.0-3.2, 4.0.x) are intentionally not touched.

## Verifying this change

Render `docs/getting-started-docker-compose.md` &mdash; the Linux snippet must be unchanged; a new admonition should appear after the Linux block explaining the Desktop scenario.

## Does this pull request potentially affect one of the following parts:

- [x] `The docs`

## Documentation

- [x] `doc`