### PR TITLE
docs(tableview): clarify tombstone behaviour for forEach and forEachAndListen

### DIFF
--- a/docs/client-libraries-tableviews.md
+++ b/docs/client-libraries-tableviews.md
@@ -69,6 +69,15 @@ You can use the available parameters in the `loadConf` configuration or the API 
 </Tabs>
 ````
 
+:::note Tombstone (null-value) messages
+
+`TableView` treats a message with a `null` payload as a **tombstone** - the key is removed from the map.
+
+- `forEach(action)` iterates over the current map snapshot only, so it **does not** surface keys that have been tombstoned.
+- `forEachAndListen(action)` first runs `forEach` over the current non-tombstoned entries, then registers the action as a live listener. Every subsequent update - **including tombstones** - is delivered to the listener as `action.accept(key, null)`. If you need to react to deletions (for example, to clean up downstream state), check for `value == null` in your listener.
+
+:::
+
 ## Register listeners
 
 You can register listeners for both existing messages on a topic and new messages coming into the topic by using `forEachAndListen`, and specify to perform operations for all existing messages by using `forEach`.

--- a/versioned_docs/version-3.3.x/client-libraries-tableviews.md
+++ b/versioned_docs/version-3.3.x/client-libraries-tableviews.md
@@ -69,6 +69,15 @@ You can use the available parameters in the `loadConf` configuration or the API 
 </Tabs>
 ````
 
+:::note Tombstone (null-value) messages
+
+`TableView` treats a message with a `null` payload as a **tombstone** - the key is removed from the map.
+
+- `forEach(action)` iterates over the current map snapshot only, so it **does not** surface keys that have been tombstoned.
+- `forEachAndListen(action)` first runs `forEach` over the current non-tombstoned entries, then registers the action as a live listener. Every subsequent update - **including tombstones** - is delivered to the listener as `action.accept(key, null)`. If you need to react to deletions (for example, to clean up downstream state), check for `value == null` in your listener.
+
+:::
+
 ## Register listeners
 
 You can register listeners for both existing messages on a topic and new messages coming into the topic by using `forEachAndListen`, and specify to perform operations for all existing messages by using `forEach`.

--- a/versioned_docs/version-4.1.x/client-libraries-tableviews.md
+++ b/versioned_docs/version-4.1.x/client-libraries-tableviews.md
@@ -69,6 +69,15 @@ You can use the available parameters in the `loadConf` configuration or the API 
 </Tabs>
 ````
 
+:::note Tombstone (null-value) messages
+
+`TableView` treats a message with a `null` payload as a **tombstone** - the key is removed from the map.
+
+- `forEach(action)` iterates over the current map snapshot only, so it **does not** surface keys that have been tombstoned.
+- `forEachAndListen(action)` first runs `forEach` over the current non-tombstoned entries, then registers the action as a live listener. Every subsequent update - **including tombstones** - is delivered to the listener as `action.accept(key, null)`. If you need to react to deletions (for example, to clean up downstream state), check for `value == null` in your listener.
+
+:::
+
 ## Register listeners
 
 You can register listeners for both existing messages on a topic and new messages coming into the topic by using `forEachAndListen`, and specify to perform operations for all existing messages by using `forEach`.

--- a/versioned_docs/version-4.2.x/client-libraries-tableviews.md
+++ b/versioned_docs/version-4.2.x/client-libraries-tableviews.md
@@ -69,6 +69,15 @@ You can use the available parameters in the `loadConf` configuration or the API 
 </Tabs>
 ````
 
+:::note Tombstone (null-value) messages
+
+`TableView` treats a message with a `null` payload as a **tombstone** - the key is removed from the map.
+
+- `forEach(action)` iterates over the current map snapshot only, so it **does not** surface keys that have been tombstoned.
+- `forEachAndListen(action)` first runs `forEach` over the current non-tombstoned entries, then registers the action as a live listener. Every subsequent update - **including tombstones** - is delivered to the listener as `action.accept(key, null)`. If you need to react to deletions (for example, to clean up downstream state), check for `value == null` in your listener.
+
+:::
+
 ## Register listeners
 
 You can register listeners for both existing messages on a topic and new messages coming into the topic by using `forEachAndListen`, and specify to perform operations for all existing messages by using `forEach`.


### PR DESCRIPTION
### Motivation

Fixes apache/pulsar#24007.

The `TableView` documentation shows `forEach` and `forEachAndListen` side-by-side but does not describe how a tombstone (a message with a `null` payload) flows through either API. The reporter asked specifically whether `forEach` sees tombstoned keys, and whether the listener registered via `forEachAndListen` is invoked for tombstones.

The Java implementation at `pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java` is the source of truth:

```java
if (null == cur) {
    data.remove(key);
} else {
    data.put(key, cur);
}

for (BiConsumer<String, T> listener : listeners) {
    try {
        listener.accept(key, cur);
    } catch (Throwable t) {
        log.error().exception(t).log("Table view listener raised an exception");
    }
}
```

So the behaviour is:

* `forEach(action)` iterates only over the current map snapshot -- tombstoned keys are not surfaced.
* `forEachAndListen(action)` first runs `forEach` over the non-tombstoned entries, then registers the action. Every subsequent update (tombstones included) is delivered to the listener as `accept(key, null)`.

### Modifications

Added a `:::note Tombstone (null-value) messages` block under the **Register listeners** section in:

* `docs/client-libraries-tableviews.md`
* `versioned_docs/version-4.2.x/client-libraries-tableviews.md`
* `versioned_docs/version-4.1.x/client-libraries-tableviews.md`
* `versioned_docs/version-3.3.x/client-libraries-tableviews.md`

The note names the backing behaviour and tells users to check `value == null` inside their listener if they need to react to deletions.

### Verifying this change

* Manual review of the added Markdown renders as the intended note block.
* No code paths changed.

### Does this pull request potentially affect one of the following parts:

- [x] Documentation

### Documentation

- [x] `doc-label-required` -- Your PR contains documentation changes.

### Matching PR in forked repository

PR in forked repository: singhvishalkr/pulsar-site#1