### PR TITLE
docs(node-client): document missing Client configs and defaults

### DIFF
--- a/client-libraries/node-configs.md
+++ b/client-libraries/node-configs.md
@@ -18,11 +18,16 @@ The following configurable parameters are available for Pulsar Node.js clients:
 | `ioThreads` | The number of threads to use for handling connections to Pulsar [brokers](pathname:///docs/reference-terminology#broker). | 1 |
 | `messageListenerThreads` | The number of threads used by message listeners ([consumers](#consumers) and [readers](#readers)). | 1 |
 | `concurrentLookupRequest` | The number of concurrent lookup requests that can be sent on each broker connection. Setting a maximum helps to keep from overloading brokers. You should set values over the default of 50000 only if the client needs to produce and/or subscribe to thousands of Pulsar topics. | 50000 |
-| `tlsTrustCertsFilePath` | The file path for the trusted TLS certificate. | |
+| `tlsTrustCertsFilePath` | The file path for the trusted TLS certificate. If unset, the client falls back to a `cert.pem` file bundled with the package that is seeded from the Node.js runtime's root CAs at install time. | Bundled `cert.pem` |
+| `tlsCertificateFilePath` | The file path for the client TLS certificate used for mTLS. | |
+| `tlsPrivateKeyFilePath` | The file path for the client TLS private key used for mTLS. | |
 | `tlsValidateHostname` | The boolean value of setup whether to enable TLS hostname verification. | `false` |
 | `tlsAllowInsecureConnection` | The boolean value of setup whether the Pulsar client accepts untrusted TLS certificate from broker. | `false` |
 | `statsIntervalInSeconds` | Interval between each stat info. Stats is activated with positive statsInterval. The value should be set to 1 second at least | 600 |
-| `log` | A function that is used for logging. | `console.log` |
+| `listenerName` | The listener name the client will use when connecting to the broker. Useful when [advertising multiple endpoints](pathname:///docs/concepts-multi-tenancy). | |
+| `log` | A function that is used for logging. Receives `(level, file, line, message)` arguments. | `console.log` |
+| `logLevel` | The log level for client-emitted logs. Accepts `LogLevel.DEBUG` (0), `LogLevel.INFO` (1), `LogLevel.WARN` (2), or `LogLevel.ERROR` (3). | `LogLevel.INFO` |
+| `connectionTimeoutMs` | Duration (in milliseconds) to wait for a broker connection to establish before failing. | |
 
 
 ## Producer configs


### PR DESCRIPTION
## Summary

Closes apache/pulsar#24362.

The Node.js client config table in `client-libraries-node-configs.md` was missing several fields that are exposed by `ClientConfig` in [`apache/pulsar-client-node/index.d.ts`](https://github.com/apache/pulsar-client-node/blob/master/index.d.ts). This PR adds rows for:

- `tlsCertificateFilePath` / `tlsPrivateKeyFilePath` -- client-side mTLS material.
- `listenerName` -- picks an advertised listener when the broker exposes more than one.
- `logLevel` -- defaults to `LogLevel.INFO` per [`src/Client.h`](https://github.com/apache/pulsar-client-node/blob/master/src/Client.h) (`pulsar_logger_level_t::pulsar_INFO`).
- `connectionTimeoutMs`.

It also surfaces the previously-undocumented default for `tlsTrustCertsFilePath`: when left unset, the JS wrapper in [`src/Client.js`](https://github.com/apache/pulsar-client-node/blob/master/src/Client.js) falls back to a bundled `cert.pem` seeded from Node.js's `tls.rootCertificates` at install time via `Client.genCertFile()`. Callers who hit certificate errors in restricted environments often rediscover this the hard way; documenting it should save a few debugging cycles.

### Note on `useTLS`

The filing issue mentioned `useTLS` as undocumented, but `useTLS` is not present in the current `ClientConfig` interface on master, so I've not added a row for it. Happy to add one if it's still accepted by the native binding under a different name.

## Scope

- `docs/client-libraries-node-configs.md` (tip / unreleased).
- `versioned_docs/version-4.2.x/client-libraries-node-configs.md` (latest stable).

Older versioned copies are left untouched -- some of the newly-documented fields (`connectionTimeoutMs`, `listenerName`) may not have existed in every older release; happy to backport on request once a maintainer confirms the earliest version.

## Test Plan

- Table columns rendered manually against docusaurus `yarn start` locally.
- Field names + defaults cross-checked against [`index.d.ts`](https://github.com/apache/pulsar-client-node/blob/master/index.d.ts) and [`src/Client.h`](https://github.com/apache/pulsar-client-node/blob/master/src/Client.h) on `pulsar-client-node@master`.