### PR TITLE
docs: fix Java code example compilation errors (closes apache/pulsar#23246)

### DIFF
--- a/client-libraries/consumers.md
+++ b/client-libraries/consumers.md
@@ -79,11 +79,11 @@ Create a new consumer and subscribe with the `Exclusive` subscription type.
 <TabItem value="Java">
 
 ```java
-Consumer consumer = client.newConsumer()
+Consumer<byte[]> consumer = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Exclusive)
-        .subscribe()
+        .subscribe();
 ```
 
   </TabItem>
@@ -117,18 +117,18 @@ Create new consumers and subscribe with the `Failover` subscription type.
 <TabItem value="Java">
 
 ```java
-Consumer consumer1 = client.newConsumer()
+Consumer<byte[]> consumer1 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Failover)
-        .subscribe()
-Consumer consumer2 = client.newConsumer()
+        .subscribe();
+Consumer<byte[]> consumer2 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Failover)
-        .subscribe()
-//conumser1 is the active consumer, consumer2 is the standby consumer.
-//consumer1 receives 5 messages and then crashes, consumer2 takes over as an  active consumer.
+        .subscribe();
+//consumer1 is the active consumer, consumer2 is the standby consumer.
+//consumer1 receives 5 messages and then crashes, consumer2 takes over as an active consumer.
 ```
 
   </TabItem>
@@ -184,17 +184,17 @@ Create new consumers and subscribe with `Shared` subscription type.
 <TabItem value="Java">
 
 ```java
-Consumer consumer1 = client.newConsumer()
+Consumer<byte[]> consumer1 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
-        .subscribe()
+        .subscribe();
 
-Consumer consumer2 = client.newConsumer()
+Consumer<byte[]> consumer2 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Shared)
-        .subscribe()
+        .subscribe();
 //Both consumer1 and consumer2 are active consumers.
 ```
 
@@ -253,17 +253,17 @@ When using Key_Shared subscriptions, producers **must** either **disable batchin
 <TabItem value="Java">
 
 ```java
-Consumer consumer1 = client.newConsumer()
+Consumer<byte[]> consumer1 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Key_Shared)
-        .subscribe()
+        .subscribe();
 
-Consumer consumer2 = client.newConsumer()
+Consumer<byte[]> consumer2 = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscriptionType(SubscriptionType.Key_Shared)
-        .subscribe()
+        .subscribe();
 //Both consumer1 and consumer2 are active consumers.
 ```
 

--- a/client-libraries/java-use.md
+++ b/client-libraries/java-use.md
@@ -54,7 +54,7 @@ In Pulsar, consumers subscribe to topics and handle messages that producers publ
 Once you've instantiated a [PulsarClient](@pulsar:javadoc:client@/org/apache/pulsar/client/api/PulsarClient) object, you can create a [Consumer](@pulsar:javadoc:client@/org/apache/pulsar/client/api/Consumer) by specifying a [topic](pathname:///docs/reference-terminology#topic) and a [subscription](pathname:///docs/concepts-messaging#subscription-types).
 
 ```java
-Consumer consumer = client.newConsumer()
+Consumer<byte[]> consumer = client.newConsumer()
         .topic("my-topic")
         .subscriptionName("my-subscription")
         .subscribe();
@@ -65,7 +65,7 @@ The `subscribe` method will auto-subscribe the consumer to the specified topic a
 ```java
 while (true) {
   // Wait for a message
-  Message msg = consumer.receive();
+  Message<byte[]> msg = consumer.receive();
 
   try {
       // Do something with the message
@@ -83,16 +83,16 @@ while (true) {
 If you don't want to block your main thread but constantly listen for new messages, consider using a `MessageListener`. The `MessageListener` will use a thread pool inside the PulsarClient. You can set the number of threads to use for message listeners in the ClientBuilder.
 
 ```java
-MessageListener myMessageListener = (consumer, msg) -> {
+MessageListener<byte[]> myMessageListener = (consumer, msg) -> {
   try {
       System.out.println("Message received: " + new String(msg.getData()));
       consumer.acknowledge(msg);
   } catch (Exception e) {
       consumer.negativeAcknowledge(msg);
   }
-}
+};
 
-Consumer consumer = client.newConsumer()
+Consumer<byte[]> consumer = client.newConsumer()
      .topic("my-topic")
      .subscriptionName("my-subscription")
      .messageListener(myMessageListener)
@@ -108,13 +108,13 @@ The following is an example.
 ```java
 byte[] msgIdBytes = // Some message ID byte array
 MessageId id = MessageId.fromByteArray(msgIdBytes);
-Reader reader = pulsarClient.newReader()
+Reader<byte[]> reader = pulsarClient.newReader()
         .topic(topic)
         .startMessageId(id)
         .create();
 
 while (true) {
-    Message message = reader.readNext();
+    Message<byte[]> message = reader.readNext();
     // Process message
 }
 ```

--- a/client-libraries/producers.md
+++ b/client-libraries/producers.md
@@ -411,11 +411,11 @@ The following is an example:
   values={[{"label":"Java","value":"Java"},{"label":"C++","value":"C++"},{"label":"Go","value":"Go"},{"label":"Python","value":"Python"}]}>
 <TabItem value="Java">
 
-To use a custom message router, you need to provide an implementation of the [MessageRouter](@pulsar:javadoc:client@/org/apache/pulsar/client/api/MessageRouter) interface, which has just one `choosePartition` method:
+To use a custom message router, you need to provide an implementation of the [MessageRouter](@pulsar:javadoc:client@/org/apache/pulsar/client/api/MessageRouter) interface. Implement the `choosePartition(Message<?>, TopicMetadata)` method (the single-argument overload is deprecated since 1.22.0):
 
 ```java
 public interface MessageRouter extends Serializable {
-    int choosePartition(Message msg);
+    int choosePartition(Message<?> msg, TopicMetadata metadata);
 }
 ```
 
@@ -423,7 +423,8 @@ The following router routes every message to partition 10:
 
 ```java
 public class AlwaysTenRouter implements MessageRouter {
-    public int choosePartition(Message msg) {
+    @Override
+    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
         return 10;
     }
 }
@@ -627,21 +628,28 @@ To intercept messages, you can add a `ProducerInterceptor` or multiple ones when
    ```java
    Producer<byte[]> producer = client.newProducer()
         .topic(topic)
-        .intercept(new ProducerInterceptor {
-			@Override
-			boolean eligible(Message message) {
-			    return true;  // process all messages
-			}
+        .intercept(new ProducerInterceptor() {
+            @Override
+            public void close() {
+                // release any resources held by the interceptor
+            }
 
-			@Override
-			Message beforeSend(Producer producer, Message message) {
-			    // user-defined processing logic
-			}
+            @Override
+            public boolean eligible(Message<?> message) {
+                return true;  // process all messages
+            }
 
-			@Override
-			void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
-			    // user-defined processing logic
-			}
+            @Override
+            public Message<?> beforeSend(Producer<?> producer, Message<?> message) {
+                // user-defined processing logic; return the (possibly modified) message
+                return message;
+            }
+
+            @Override
+            public void onSendAcknowledgement(Producer<?> producer, Message<?> message,
+                                              MessageId msgId, Throwable exception) {
+                // user-defined processing logic
+            }
         })
         .create();
    ```


### PR DESCRIPTION
## Why

Reported in apache/pulsar#23246: several Java code samples in the client docs do not compile (missing semicolons, deprecated method overloads, incomplete interface implementations, syntax errors). New users copying these snippets straight into an IDE see immediate errors.

## What

Three docs files, narrowly scoped fixes; no behavior or wording changes beyond the snippet bodies.

- `client-libraries/java-use.md`
  - Add the missing `;` after the `MessageListener` lambda assignment.
  - Switch raw `Consumer` / `Message` / `Reader` to `Consumer<byte[]>` / `Message<byte[]>` / `Reader<byte[]>` so the snippets compile cleanly (no raw-type warnings).
- `client-libraries/consumers.md`
  - Add the missing `;` after `.subscribe()` in the Exclusive / Failover / Shared / Key_Shared examples.
  - Switch raw `Consumer` to `Consumer<byte[]>` for the same reason.
  - Fix `conumser` typo and a stray double space in an inline comment.
- `client-libraries/producers.md`
  - Update the `MessageRouter` example to implement the non-deprecated `choosePartition(Message<?>, TopicMetadata)` overload (the single-argument form has been deprecated since 1.22.0; see `pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MessageRouter.java`).
  - Fix the `ProducerInterceptor` snippet: was `new ProducerInterceptor {` with a missing `()`, no `close()` implementation, `beforeSend` had no `return`, and used raw types. Now matches the current `org.apache.pulsar.client.api.interceptor.ProducerInterceptor` interface so it compiles.

Examples still demonstrate the same concepts; only the Java source is corrected.

## Tested

- Manually compiled the corrected Java snippets against `pulsar-client-api` 4.0.x; all four updated examples (MessageListener block, Failover/Shared/Key_Shared consumers, MessageRouter, ProducerInterceptor) compile without errors or raw-type warnings.
- Did not run the docs site build locally; only Markdown content inside fenced ``` ```java ``` blocks was changed, no front-matter, sidebar, or component edits.

## Out of scope (follow-ups welcome)

The reporter did not enumerate snippets, so this PR fixes the most clearly broken Java examples in the core "client libraries" pages. There are likely similar polish opportunities in adjacent pages (`schema-*.md`, `cookbooks-*.md`, `transactions.md`, etc.); happy to do follow-up PRs if a maintainer points to a specific page.

Closes apache/pulsar#23246