### PR TITLE
[improve][docs] Clarify failover standby mapping in 3.0.x docs

### DIFF
--- a/versioned_docs/version-3.0.x/concepts-messaging.md
+++ b/versioned_docs/version-3.0.x/concepts-messaging.md
@@ -600,9 +600,9 @@ A consumer is selected by running a module operation `mod (partition index, cons
 
   For example, in the diagram below, there are 4 non-partitioned topics and 2 consumers. 
   
-  - The non-partitioned topic 1 and non-partitioned topic 4 are assigned to consumer A. 
+  - The non-partitioned topic 1 and non-partitioned topic 4 are assigned to consumer A. Consumer B is their stand-by consumer.
   
-  - The non-partitioned topic 2 and non-partitioned topic 3 are assigned to consumer B.
+  - The non-partitioned topic 2 and non-partitioned topic 3 are assigned to consumer B. Consumer A is their stand-by consumer.
 
   ![Failover subscriptions](/assets/pulsar-failover-subscriptions-3.svg)
 


### PR DESCRIPTION
## Summary
- clarify which consumer is active vs stand-by in the 3.0.x failover non-partitioned topic example
- align the versioned 3.0.x wording with the corrected current docs text and the diagram intent

## Testing
- docs text change only
