### PR TITLE
docs: clarify primitive schema byte order

### DIFF
--- a/docs/schema-understand.md
+++ b/docs/schema-understand.md
@@ -69,6 +69,8 @@ The following table outlines the primitive types that Pulsar schema supports, an
 
 Pulsar does not store any schema data in `SchemaInfo` for primitive types. Some of the primitive schema implementations can use the `properties` parameter to store implementation-specific tunable settings. For example, a string schema can use `properties` to store the encoding charset to serialize and deserialize strings.
 
+Fixed-width numeric primitive schemas use big-endian byte order in Java clients. `INT8` is a single byte. `INT16`, `INT32`, and `INT64` encode the most significant byte first. `FLOAT` and `DOUBLE` encode the IEEE 754 bit pattern in the same byte order. `BYTES` payloads are passed through unchanged, so their internal byte order is defined by the application.
+
 :::
 
 For more instructions and examples, see [Construct a string schema](schema-get-started.md#string).

--- a/versioned_docs/version-4.0.x/schema-understand.md
+++ b/versioned_docs/version-4.0.x/schema-understand.md
@@ -69,6 +69,8 @@ The following table outlines the primitive types that Pulsar schema supports, an
 
 Pulsar does not store any schema data in `SchemaInfo` for primitive types. Some of the primitive schema implementations can use the `properties` parameter to store implementation-specific tunable settings. For example, a string schema can use `properties` to store the encoding charset to serialize and deserialize strings.
 
+Fixed-width numeric primitive schemas use big-endian byte order in Java clients. `INT8` is a single byte. `INT16`, `INT32`, and `INT64` encode the most significant byte first. `FLOAT` and `DOUBLE` encode the IEEE 754 bit pattern in the same byte order. `BYTES` payloads are passed through unchanged, so their internal byte order is defined by the application.
+
 :::
 
 For more instructions and examples, see [Construct a string schema](schema-get-started.md#string).

--- a/versioned_docs/version-4.2.x/schema-understand.md
+++ b/versioned_docs/version-4.2.x/schema-understand.md
@@ -69,6 +69,8 @@ The following table outlines the primitive types that Pulsar schema supports, an
 
 Pulsar does not store any schema data in `SchemaInfo` for primitive types. Some of the primitive schema implementations can use the `properties` parameter to store implementation-specific tunable settings. For example, a string schema can use `properties` to store the encoding charset to serialize and deserialize strings.
 
+Fixed-width numeric primitive schemas use big-endian byte order in Java clients. `INT8` is a single byte. `INT16`, `INT32`, and `INT64` encode the most significant byte first. `FLOAT` and `DOUBLE` encode the IEEE 754 bit pattern in the same byte order. `BYTES` payloads are passed through unchanged, so their internal byte order is defined by the application.
+
 :::
 
 For more instructions and examples, see [Construct a string schema](schema-get-started.md#string).


### PR DESCRIPTION
### Motivation

Primitive schema docs list the supported types, but they do not state how fixed-width numeric values are ordered on the wire. That leaves client implementers to infer byte order when producers and consumers are not using the same client library.

### Modifications

- Clarify that Java primitive schemas encode fixed-width numeric values in big-endian byte order.
- Note that `INT8` is a single byte, `FLOAT` and `DOUBLE` use IEEE 754 bit patterns, and `BYTES` payloads keep application-defined ordering.
- Apply the same clarification to the current docs and supported versioned docs (`4.0.x` and `4.2.x`).

### Verifying this change

- `corepack yarn install --immutable`
- `git diff --check`
- `corepack yarn typecheck` fails on existing non-doc TypeScript issues in `matomoClientModule.ts` and `src/theme/Blog*` files.
- `$env:NODE_OPTIONS='--max_old_space_size=16000'; corepack yarn docusaurus build` passes; it emits existing site-wide broken-link and SSG warnings outside the changed schema docs.

### Contribution Checklist

- [x] I read the [contribution guide](https://pulsar.apache.org/contribute/document-contribution/)
- [x] I updated the [versioned docs](https://pulsar.apache.org/contribute/document-contribution/#update-versioned-docs)

Fixes #1142