### PR TITLE
Add documentation for scalable topics (Topics v5)

### DIFF
--- a/docs/admin-api-scalable-topics.md
+++ b/docs/admin-api-scalable-topics.md
@@ -1,7 +1,7 @@
 ---
 id: admin-api-scalable-topics
 title: Manage scalable topics
-sidebar_label: "Scalable topics"
+sidebar_label: "Administration"
 description: Create, inspect, migrate, and manage scalable topics with pulsar-admin, the REST API, or the Java admin client.
 ---
 

--- a/docs/admin-api-scalable-topics.md
+++ b/docs/admin-api-scalable-topics.md
@@ -1,0 +1,208 @@
+---
+id: admin-api-scalable-topics
+title: Manage scalable topics
+sidebar_label: "Scalable topics"
+description: Create, inspect, migrate, and manage scalable topics with pulsar-admin, the REST API, or the Java admin client.
+---
+
+:::note
+
+For the concepts behind this feature, see [Scalable topics](concepts-scalable-topics.md).
+
+:::
+
+This page covers administering scalable topics. To **produce and consume**, use a client with [V5 API support](concepts-scalable-topics.md#requirements); this page is about creating and operating the topics themselves.
+
+Every operation is available three ways: the `pulsar-admin scalable-topics` CLI, the REST API under `/admin/v2/scalable`, and the Java admin client (`PulsarAdmin.scalableTopics()`). The examples below lead with the CLI; the [REST API reference](#rest-api-reference) lists every endpoint.
+
+In the commands below, a topic is identified by its `tenant/namespace/topic` name (without a URL scheme).
+
+## Create a scalable topic
+
+A scalable topic is created with an initial number of segments. Start small -- one segment is the default -- and let [auto split/merge](concepts-scalable-topics.md#how-it-works) grow it to fit the load.
+
+```shell
+bin/pulsar-admin scalable-topics create my-tenant/my-namespace/my-topic --segments 1
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-s`, `--segments` | Number of initial segments | `1` |
+| `-p`, `--property` | A `key=value` property; repeat for multiple | -- |
+
+Java admin client:
+
+```java
+admin.scalableTopics().createScalableTopic("my-tenant/my-namespace/my-topic", 1);
+```
+
+## List scalable topics
+
+List every scalable topic in a namespace:
+
+```shell
+bin/pulsar-admin scalable-topics list my-tenant/my-namespace
+```
+
+Filter to topics carrying specific properties (repeat `-p` to AND multiple filters):
+
+```shell
+bin/pulsar-admin scalable-topics list my-tenant/my-namespace -p team=ingest -p tier=gold
+```
+
+## Inspect a scalable topic
+
+Get the topic metadata -- the segment DAG, including each segment's hash range and state:
+
+```shell
+bin/pulsar-admin scalable-topics get-metadata my-tenant/my-namespace/my-topic
+```
+
+Get aggregated runtime stats:
+
+```shell
+bin/pulsar-admin scalable-topics stats my-tenant/my-namespace/my-topic
+```
+
+## Manage subscriptions
+
+Scalable-topic subscriptions span every segment in the DAG. The admin commands operate on the subscription as a whole.
+
+Reset a subscription to a point in the past (the offset is relative to now -- accepts units such as `30m`, `1h`, `5d`):
+
+```shell
+bin/pulsar-admin scalable-topics seek my-tenant/my-namespace/my-topic \
+  --subscription my-sub --time 1h
+```
+
+Skip all undelivered messages on a subscription, across every segment:
+
+```shell
+bin/pulsar-admin scalable-topics clear-backlog my-tenant/my-namespace/my-topic \
+  --subscription my-sub
+```
+
+## Split and merge segments
+
+Splitting a hot segment and merging cold adjacent segments normally happens **automatically** (see [auto split/merge](concepts-scalable-topics.md#how-it-works)). The commands below let you trigger them manually -- for testing, or to pre-scale ahead of a known traffic event.
+
+Split one segment into two halves of its hash range:
+
+```shell
+bin/pulsar-admin scalable-topics split-segment my-tenant/my-namespace/my-topic --segment-id 3
+```
+
+Merge two adjacent segments back into one:
+
+```shell
+bin/pulsar-admin scalable-topics merge-segments my-tenant/my-namespace/my-topic \
+  --segment-id-1 3 --segment-id-2 4
+```
+
+Segment IDs come from `get-metadata`. Merging requires the two segments to own adjacent hash ranges.
+
+## Configure auto split/merge
+
+Auto split/merge is **on by default**: each topic's controller splits any segment whose load crosses the split thresholds and merges adjacent segments that stay cold below the merge thresholds. It is configured at three levels, and the most specific value wins **per setting**:
+
+1. **Broker defaults** in `broker.conf` (cluster-wide).
+2. **Per-namespace override**.
+3. **Per-topic override**.
+
+An override only sets the fields it changes; unset fields inherit from the level above.
+
+### Broker defaults (`broker.conf`)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `scalableTopicAutoScaleEnabled` | Master switch for auto split/merge. When `false`, segments change only via manual `split-segment` / `merge-segments`. | `true` |
+| `scalableTopicMaxSegments` | Hard ceiling on active segments; splits stop once reached. | `64` |
+| `scalableTopicMinSegments` | Hard floor on active segments; merges stop once reached. | `1` |
+| `scalableTopicMaxDagDepth` | Maximum merges in a segment's lineage; bounds split/merge flip-flopping (limits merges only -- splits are unaffected). | `10` |
+| `scalableTopicSplitCooldownSeconds` | Minimum time between automatic splits on a topic (short -- only coalesces a burst of near-simultaneous triggers). | `60` |
+| `scalableTopicMergeCooldownSeconds` | Minimum time between automatic merges on a topic. | `300` |
+| `scalableTopicMergeWindowSeconds` | How long a segment must stay continuously below every merge threshold before it becomes merge-eligible. | `300` |
+| `scalableTopicSplitMsgRateInThreshold` | Inbound messages/second above which a segment is split. | `10000` |
+| `scalableTopicSplitBytesRateInThreshold` | Inbound bytes/second above which a segment is split. | `50000000` (50 MB/s) |
+| `scalableTopicSplitMsgRateOutThreshold` | Outbound (dispatched) messages/second above which a segment is split. | `50000` |
+| `scalableTopicSplitBytesRateOutThreshold` | Outbound bytes/second above which a segment is split. | `250000000` (250 MB/s) |
+| `scalableTopicMergeMsgRateInThreshold` | Inbound messages/second below which a segment counts as cold for merging. | `1000` |
+| `scalableTopicMergeBytesRateInThreshold` | Inbound bytes/second below which a segment counts as cold. | `5000000` (5 MB/s) |
+| `scalableTopicMergeMsgRateOutThreshold` | Outbound messages/second below which a segment counts as cold. | `5000` |
+| `scalableTopicMergeBytesRateOutThreshold` | Outbound bytes/second below which a segment counts as cold. | `25000000` (25 MB/s) |
+| `scalableTopicAutoScaleIntervalSeconds` | Cadence of the controller's periodic traffic-driven evaluation. Consumer-count changes are handled immediately, independent of this interval. | `60` |
+| `scalableTopicLoadReportIntervalSeconds` | How often a segment-owning broker samples segment load for auto-scaling. | `10` |
+| `scalableTopicLoadReportRateChangeThreshold` | Minimum relative change in a segment's rate (`0.25` = 25%) since the last report that triggers a new load record; bounds metadata write volume. | `0.25` |
+
+:::tip
+
+Split thresholds sit well above the corresponding merge thresholds on purpose -- the gap between them is the hysteresis that stops a just-split segment from immediately re-merging. Preserve that ordering when you tune them.
+
+Most of these settings are dynamic: apply them at runtime with `pulsar-admin brokers update-dynamic-config` without restarting. The two read only at broker startup are `scalableTopicAutoScaleIntervalSeconds` and `scalableTopicLoadReportIntervalSeconds`.
+
+:::
+
+### Per-namespace and per-topic overrides
+
+Both override levels use the same fields as the broker settings (each optional; unset means inherit): `enabled`, `maxSegments`, `minSegments`, `maxDagDepth`, `splitCooldownSeconds`, `mergeCooldownSeconds`, `mergeWindowSeconds`, and the eight `split*`/`merge*` rate thresholds.
+
+Overrides are set through the Java admin client or REST -- there is no `pulsar-admin` subcommand for them yet:
+
+```java
+AutoScalePolicyOverride override = AutoScalePolicyOverride.builder()
+        .maxSegments(128)
+        .splitMsgRateInThreshold(20_000.0)
+        .build();
+
+// Namespace level -- applies to every scalable topic in the namespace
+admin.namespaces().setScalableTopicAutoScalePolicy("my-tenant/my-namespace", override);
+
+// Topic level -- narrowest scope, wins over namespace and broker
+admin.scalableTopics().setAutoScalePolicy("my-tenant/my-namespace/my-topic", override);
+```
+
+Read or clear an override with the matching `getScalableTopicAutoScalePolicy` / `removeScalableTopicAutoScalePolicy` (namespace) and `getAutoScalePolicy` / `removeAutoScalePolicy` (topic) methods.
+
+### Disable auto-scaling
+
+To run a topic with manual split/merge only, set `scalableTopicAutoScaleEnabled=false` cluster-wide, or apply an override with `enabled=false` at the namespace or topic level. The controller then leaves the layout untouched and you drive it with `split-segment` / `merge-segments`.
+
+## Migrate a regular topic
+
+An existing partitioned or non-partitioned topic can be migrated in place to a scalable topic, with no data copy:
+
+```shell
+bin/pulsar-admin scalable-topics migrate my-tenant/my-namespace/my-topic
+```
+
+The migration is rejected if legacy (non-V5) clients are still connected, unless you pass `--force`. Migration is **one-way** -- a scalable topic cannot be converted back. A full walkthrough, including the recommended sequence for upgrading clients first, is covered in the migration guide.
+
+## Delete a scalable topic
+
+```shell
+bin/pulsar-admin scalable-topics delete my-tenant/my-namespace/my-topic
+```
+
+Pass `--force` to delete even when the topic has active subscriptions.
+
+## REST API reference
+
+All endpoints are under `/admin/v2/scalable` and take `tenant`, `namespace`, and (except for list) `topic` as path parameters.
+
+| Method & path | Operation |
+|---------------|-----------|
+| `GET /{tenant}/{namespace}` | List scalable topics in a namespace |
+| `PUT /{tenant}/{namespace}/{topic}` | Create a scalable topic |
+| `GET /{tenant}/{namespace}/{topic}` | Get topic metadata (segment DAG) |
+| `GET /{tenant}/{namespace}/{topic}/stats` | Get aggregated stats |
+| `DELETE /{tenant}/{namespace}/{topic}` | Delete a scalable topic |
+| `POST /{tenant}/{namespace}/{topic}/migrate` | Migrate a regular topic to scalable |
+| `POST /{tenant}/{namespace}/{topic}/split/{segmentId}` | Split a segment |
+| `POST /{tenant}/{namespace}/{topic}/merge/{segmentId1}/{segmentId2}` | Merge two adjacent segments |
+| `GET /{tenant}/{namespace}/{topic}/autoScalePolicy` | Get the topic's auto split/merge override |
+| `POST /{tenant}/{namespace}/{topic}/autoScalePolicy` | Set the topic's auto split/merge override |
+| `DELETE /{tenant}/{namespace}/{topic}/autoScalePolicy` | Remove the topic's auto split/merge override |
+| `PUT /{tenant}/{namespace}/{topic}/subscriptions/{subscription}` | Create a subscription |
+| `DELETE /{tenant}/{namespace}/{topic}/subscriptions/{subscription}` | Delete a subscription |
+| `POST /{tenant}/{namespace}/{topic}/subscriptions/{subscription}/seek` | Seek a subscription to a timestamp |
+| `POST /{tenant}/{namespace}/{topic}/subscriptions/{subscription}/skip-all` | Clear a subscription's backlog |

--- a/docs/concepts-scalable-topics.md
+++ b/docs/concepts-scalable-topics.md
@@ -1,0 +1,76 @@
+---
+id: concepts-scalable-topics
+title: Scalable topics
+sidebar_label: "Scalable topics"
+description: Understand scalable topics (Topics v5), the topic type that grows and shrinks at runtime by splitting and merging key-range segments.
+---
+
+A **scalable topic** is a topic that adjusts its own capacity at runtime. Instead of being created with a fixed number of partitions, it is internally divided into key-range **segments** that the broker splits when load grows and merges when load drops -- with no downtime, no client changes, and no loss of per-key ordering. A scalable topic is addressed with the `topic://` scheme:
+
+```
+topic://tenant/namespace/name
+```
+
+:::note
+
+Scalable topics are the recommended choice for **new applications**. Classic [partitioned and non-partitioned topics](concepts-messaging.md#topics) remain fully supported and are the right choice for existing applications and for clients that do not yet support the V5 API. See [When to use which](#when-to-use-which) below.
+
+:::
+
+## Why scalable topics
+
+Classic partitioned topics scale by fixing a partition count when the topic is created. That model has three structural limits:
+
+- **You must guess the right size upfront.** The partition count is chosen before you know the real traffic, and it bounds the maximum consumer parallelism for the life of the topic.
+- **You cannot scale down.** A partitioned topic's partition count can be increased but never decreased, so a topic provisioned for a traffic spike stays oversized forever.
+- **Resizing breaks key ordering.** Because messages are routed by `hash(key) % partitionCount`, changing the partition count remaps keys to different partitions, breaking the per-key ordering guarantee.
+
+Scalable topics remove all three limits: capacity tracks load automatically in both directions, and per-key ordering is preserved across every resize.
+
+## How it works
+
+Internally, a scalable topic spreads the hash key space across a set of **segments**. Each segment owns a contiguous range of the key space and is backed by its own internal topic. Together the segments form a directed acyclic graph (DAG) that records how ranges have been split and merged over time.
+
+- **Split.** When a segment gets hot, the controller splits its key range in two and hands each half to a new child segment. This raises parallelism for exactly the part of the key space that is under load.
+- **Merge.** When adjacent segments go cold, the controller merges their ranges back into one, reclaiming capacity.
+- **Range-based key routing.** A message key is mapped to whichever segment currently owns its hash range. Because routing is by *range* rather than by `hash(key) % N`, a split or merge only ever moves a key from a parent range to a child range that still contains it -- so the ordering of any individual key is never broken.
+
+This split/merge activity is driven by a per-topic **controller** in the broker and is **automatic by default**; you can also trigger splits and merges manually. The segment topology is managed entirely on the server and pushed to clients as it changes, so applications never see segments or have to react to resizing. To an application, a scalable topic is just a single stream.
+
+## Scalable vs. partitioned topics
+
+| | Partitioned topic (classic) | Scalable topic |
+|---|---|---|
+| Unit of parallelism | Fixed partition count, set at creation | Segments; count changes at runtime |
+| Scale up | Increase partition count (manual) | Automatic split of hot segments |
+| Scale down | Not possible | Automatic merge of cold segments |
+| Key routing | `hash(key) % partitionCount` | Range-based hash assignment |
+| Key ordering when resized | Broken (keys remap across partitions) | Preserved across split and merge |
+| Topology visible to the app | Partition count and indexes are exposed | Opaque; managed by the broker |
+| Client | Any Pulsar client | A client with [V5 API](#requirements) support |
+
+## Consumer model
+
+Scalable topics use the V5 client API, which replaces the four classic subscription types (Exclusive, Failover, Shared, Key_Shared) with three purpose-built consumers:
+
+- **Stream consumer** -- ordered consumption with cumulative acknowledgment, for log-style processing where order matters. Replaces Exclusive and Failover.
+- **Queue consumer** -- parallel consumption with individual acknowledgment, negative acknowledgment, and dead-letter handling, for work-queue style fan-out. Replaces Shared and Key_Shared.
+- **Checkpoint consumer** -- no subscription and no acknowledgment; the application tracks its own position with a serializable checkpoint. Designed for stream-processing engines such as Flink and Spark that manage their own offsets.
+
+Each consumer type is covered in detail in the V5 client documentation.
+
+## When to use which
+
+- **New applications** -- prefer scalable topics. You get automatic right-sizing and you never have to pick a partition count.
+- **Existing applications** -- keep using classic partitioned and non-partitioned topics. They are fully supported, and there is no requirement to migrate. When you are ready, an existing topic can be migrated in place to a scalable topic without copying data.
+- **Clients without V5 support** -- use classic topics. Scalable topics require a client SDK that supports the V5 API (see below).
+
+## Requirements
+
+- **A V5-capable client SDK.** Scalable topics are served through the V5 client API; clients using the classic API are rejected when they address a `topic://`. The Java V5 client supports scalable topics today, with the other language SDKs following.
+- **A metadata store with streaming watch support.** [Oxia](administration-metadata-store.md#use-oxia-as-metadata-store) is recommended, because the controller pushes topology changes to clients through streaming watches that Oxia supports natively. If you are still on ZooKeeper, see [Migrate metadata store](administration-metadata-store-migration.md).
+
+## Next steps
+
+- Configure metadata: [Configure metadata store](administration-metadata-store.md) and [Migrate metadata store from ZooKeeper to Oxia](administration-metadata-store-migration.md).
+- Learn the classic topic model for comparison: [Messaging concepts -- Topics](concepts-messaging.md#topics).

--- a/docs/concepts-scalable-topics.md
+++ b/docs/concepts-scalable-topics.md
@@ -1,7 +1,7 @@
 ---
 id: concepts-scalable-topics
 title: Scalable topics
-sidebar_label: "Scalable topics"
+sidebar_label: "Overview"
 description: Understand scalable topics (Topics v5), the topic type that grows and shrinks at runtime by splitting and merging key-range segments.
 ---
 

--- a/sidebars.json
+++ b/sidebars.json
@@ -52,6 +52,14 @@
     },
     {
       "type": "category",
+      "label": "Scalable Topics",
+      "items": [
+        "concepts-scalable-topics",
+        "admin-api-scalable-topics"
+      ]
+    },
+    {
+      "type": "category",
       "label": "Pulsar Schema",
       "items": [
         "schema-overview",


### PR DESCRIPTION
### Motivation

Scalable topics (Topics v5) are the flagship new feature of Pulsar 5.0 ([PIP-460](https://github.com/apache/pulsar/blob/master/pip/pip-460.md) and its sub-PIPs: 466, 468, 473, 475, 483). A scalable topic is addressed with the `topic://` scheme and scales at runtime by splitting and merging key-range segments, preserving per-key ordering across every resize. There is currently no user-facing documentation for it.

### Modifications

This is the first installment, covering the conceptual foundation and administration:

- **`concepts-scalable-topics.md`** — the mental model: segments, the keyspace DAG, split/merge, range-based routing, and a scalable-vs-partitioned comparison. Frames scalable topics as the recommended choice for new applications, with classic partitioned/non-partitioned topics positioned as the fully-supported alternative for existing apps and clients without V5 support.
- **`admin-api-scalable-topics.md`** — create / list / inspect / manage subscriptions / manual split-merge / migrate / delete via `pulsar-admin scalable-topics`, the Java admin client, and the `/admin/v2/scalable` REST API. Includes a full **Configure auto split/merge** section: all `broker.conf` defaults, the per-namespace/per-topic `AutoScalePolicyOverride` model, and how to disable auto-scaling.
- **`sidebars.json`** — a new "Scalable Topics" category after "Concepts and Architecture".

All commands, REST paths, config keys, and defaults were verified against the implementation on the Pulsar `master` branch rather than the PIP text.

### Notes

- This documents an in-development 5.0 feature; the pages live in the next-version `docs/` and publish at 5.0 GA.
- Still to come (subsequent PRs or additions to this branch): the V5 Java client guide and consumer types, the regular-to-scalable migration walkthrough, transactions on scalable topics, and a metrics reference.