### PR TITLE
Make Oxia the recommended metadata store in the Pulsar 5.0 docs

### DIFF
--- a/docs/administration-metadata-store-migration.md
+++ b/docs/administration-metadata-store-migration.md
@@ -65,7 +65,7 @@ Before starting the migration:
    ```
    oxia://<host>:<port>/<namespace>
    ```
-   For example: `oxia://oxia-1.example.com:6648/pulsar`
+   For example: `oxia://oxia-1.example.com:6648/broker`
 
 :::tip
 
@@ -93,7 +93,7 @@ Expected output:
 Trigger the migration by specifying the target Oxia URL:
 
 ```shell
-bin/pulsar-admin metadata-migration start --target oxia://oxia-1.example.com:6648/pulsar
+bin/pulsar-admin metadata-migration start --target oxia://oxia-1.example.com:6648/broker
 ```
 
 The command returns immediately after initiating the migration. The actual migration runs asynchronously on the broker that received the request.
@@ -111,7 +111,7 @@ You will see the phase progress through `PREPARATION`, `COPYING`, and finally `C
 ```json
 {
   "phase" : "COMPLETED",
-  "targetUrl" : "oxia://oxia-1.example.com:6648/pulsar"
+  "targetUrl" : "oxia://oxia-1.example.com:6648/broker"
 }
 ```
 
@@ -122,8 +122,8 @@ If the status shows `FAILED`, check the broker logs for error details. The clust
 After migration completes, update the broker configuration to use Oxia directly. In `conf/broker.conf`:
 
 ```conf
-metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
-configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+metadataStoreUrl=oxia://oxia-1.example.com:6648/broker
+configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/broker
 ```
 
 Then perform a rolling restart of all brokers. After restarting, brokers connect to Oxia directly without the migration wrapper.
@@ -133,7 +133,7 @@ Then perform a rolling restart of all brokers. After restarting, brokers connect
 Update the BookKeeper configuration to use Oxia. In `conf/bookkeeper.conf`:
 
 ```conf
-metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/pulsar
+metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper
 ```
 
 Then perform a rolling restart of all bookies.
@@ -157,7 +157,7 @@ If the migration fails, the phase is automatically set to `FAILED`. All brokers 
 To retry, simply run the `start` command again:
 
 ```shell
-bin/pulsar-admin metadata-migration start --target oxia://oxia-1.example.com:6648/pulsar
+bin/pulsar-admin metadata-migration start --target oxia://oxia-1.example.com:6648/broker
 ```
 
 ### A broker restarts after migration completes
@@ -172,7 +172,7 @@ The migration is also available through the REST API:
 
 **Start migration:**
 ```shell
-curl -X POST "http://broker:8080/admin/v2/metadata/migration/start?target=oxia://oxia-1.example.com:6648/pulsar"
+curl -X POST "http://broker:8080/admin/v2/metadata/migration/start?target=oxia://oxia-1.example.com:6648/broker"
 ```
 
 **Check status:**

--- a/docs/administration-metadata-store.md
+++ b/docs/administration-metadata-store.md
@@ -18,11 +18,13 @@ If you are using a standalone Pulsar or a single Pulsar cluster, you only need t
 :::
 
 Pulsar supports the following metadata store services:
+* [Oxia](https://github.com/oxia-db/oxia) (recommended)
 * [Apache ZooKeeper](https://zookeeper.apache.org/)
-* [Oxia](https://github.com/oxia-db/oxia)
 * [Etcd](https://etcd.io/)
 * [RocksDB](http://rocksdb.org/)
 * Local memory
+
+For new production clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store. ZooKeeper remains fully supported, and existing ZooKeeper-based clusters can [live-migrate to Oxia](administration-metadata-store-migration.md) without downtime.
 
 :::note
 
@@ -30,20 +32,11 @@ RocksDB and local memory are only applicable to standalone Pulsar or single-node
 
 :::
 
-## Use ZooKeeper as metadata store
-
-Pulsar metadata store can be deployed on a separate ZooKeeper cluster or deployed on an existing ZooKeeper cluster.
-
-To use ZooKeeper as the metadata store, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
-
-```conf
-metadataStoreUrl=zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181
-configurationMetadataStoreUrl=zk:my-global-zk-1:2181,my-global-zk-2:2181,my-global-zk-3:2181
-```
-
 ## Use Oxia as metadata store
 
-To use [Oxia](https://github.com/oxia-db/oxia) as the metadata store, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
+[Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store for new Pulsar clusters. Deploy an Oxia cluster (or use an existing one) and make sure the target namespace exists; see the [Oxia documentation](https://oxia-db.github.io/) for deployment instructions.
+
+To use Oxia as the metadata store, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
 
 ```conf
 metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
@@ -53,6 +46,17 @@ configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
 The URL format is `oxia://<host>:<port>/<namespace>`. The namespace must exist in the Oxia cluster.
 
 To live-migrate an existing cluster from ZooKeeper to Oxia, see [Migrate metadata store](administration-metadata-store-migration.md).
+
+## Use ZooKeeper as metadata store
+
+ZooKeeper is fully supported and ships with the Pulsar binary package. The Pulsar metadata store can be deployed on a separate ZooKeeper cluster or deployed on an existing ZooKeeper cluster.
+
+To use ZooKeeper as the metadata store, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
+
+```conf
+metadataStoreUrl=zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181
+configurationMetadataStoreUrl=zk:my-global-zk-1:2181,my-global-zk-2:2181,my-global-zk-3:2181
+```
 
 ## Use etcd as metadata store
 

--- a/docs/administration-metadata-store.md
+++ b/docs/administration-metadata-store.md
@@ -34,16 +34,23 @@ RocksDB and local memory are only applicable to standalone Pulsar or single-node
 
 ## Use Oxia as metadata store
 
-[Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store for new Pulsar clusters. Deploy an Oxia cluster (or use an existing one) and make sure the target namespace exists; see the [Oxia documentation](https://oxia-db.github.io/) for deployment instructions.
+[Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store for new Pulsar clusters. Deploy an Oxia cluster (or use an existing one); see the [Oxia documentation](https://oxia-db.github.io/) for deployment instructions.
 
-To use Oxia as the metadata store, add the following parameters to the `conf/broker.conf` or `conf/standalone.conf` file.
+Oxia organizes data into [namespaces](https://oxia-db.github.io/docs/features/namespaces). The namespaces you reference must already exist — they are defined in the Oxia coordinator configuration, not created on demand. Use **separate namespaces** for the Pulsar metadata store and for BookKeeper. To stay consistent with the [Pulsar Helm chart](https://github.com/apache/pulsar-helm-chart), this guide uses `broker` for Pulsar and `bookkeeper` for BookKeeper.
+
+To use Oxia as the metadata store, add the following to `conf/broker.conf` (or `conf/standalone.conf`). `configurationMetadataStoreUrl` is optional and defaults to `metadataStoreUrl`, so a single cluster only needs:
 
 ```conf
-metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
-configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+metadataStoreUrl=oxia://oxia-1.example.com:6648/broker
 ```
 
-The URL format is `oxia://<host>:<port>/<namespace>`. The namespace must exist in the Oxia cluster.
+The URL format is `oxia://<host>:<port>/<namespace>`.
+
+BookKeeper connects through a different format: the `metadata-store:` prefix is required, and it should use its own namespace. Set `bookkeeperMetadataServiceUri` in `conf/broker.conf` to match the `metadataServiceUri` configured for the bookies in `conf/bookkeeper.conf`:
+
+```conf
+bookkeeperMetadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper
+```
 
 To live-migrate an existing cluster from ZooKeeper to Oxia, see [Migrate metadata store](administration-metadata-store-migration.md).
 

--- a/docs/administration-proxy.md
+++ b/docs/administration-proxy.md
@@ -54,8 +54,8 @@ Pulsar uses its metadata store for service discovery. To connect the proxy to th
 For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md):
 
 ```properties
-metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
-configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+metadataStoreUrl=oxia://oxia-1.example.com:6648/broker
+configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/broker
 ```
 
 Alternatively, to connect the proxy to a [ZooKeeper](https://zookeeper.apache.org) cluster:
@@ -116,8 +116,8 @@ For new clusters, [Oxia is the recommended metadata store](administration-metada
 ```bash
 cd /path/to/pulsar/directory
 bin/pulsar proxy \
-    --metadata-store oxia://oxia-1.example.com:6648/pulsar \
-    --configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar
+    --metadata-store oxia://oxia-1.example.com:6648/broker \
+    --configuration-metadata-store oxia://oxia-1.example.com:6648/broker
 ```
 
 Alternatively, with ZooKeeper as the metadata store:

--- a/docs/administration-proxy.md
+++ b/docs/administration-proxy.md
@@ -49,7 +49,16 @@ Note that if you do not use functions, you do not need to configure `functionWor
 
 ### Use service discovery
 
-Pulsar uses [ZooKeeper](https://zookeeper.apache.org) for service discovery. To connect the proxy to ZooKeeper, specify the following in `conf/proxy.conf`.
+Pulsar uses its metadata store for service discovery. To connect the proxy to the metadata store, specify it in `conf/proxy.conf`.
+
+For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md):
+
+```properties
+metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+```
+
+Alternatively, to connect the proxy to a [ZooKeeper](https://zookeeper.apache.org) cluster:
 
 ```properties
 metadataStoreUrl=my-zk-0:2181,my-zk-1:2181,my-zk-2:2181
@@ -101,6 +110,17 @@ brokerProxyAllowedIPAddresses=10.10.0.0/16,192.168.1.100-120,172.16.2.*,10.1.2.3
 ## Start the proxy
 
 To start the proxy, run the following commands.
+
+For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md):
+
+```bash
+cd /path/to/pulsar/directory
+bin/pulsar proxy \
+    --metadata-store oxia://oxia-1.example.com:6648/pulsar \
+    --configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar
+```
+
+Alternatively, with ZooKeeper as the metadata store:
 
 ```bash
 cd /path/to/pulsar/directory

--- a/docs/administration-upgrade.md
+++ b/docs/administration-upgrade.md
@@ -12,13 +12,13 @@ import TabItem from '@theme/TabItem';
 
 ## Upgrade guidelines
 
-Apache Pulsar is comprised of multiple components, ZooKeeper, bookies, and brokers. These components are either stateful or stateless. You do not have to upgrade ZooKeeper nodes unless you have special requirements. While you upgrade, you need to pay attention to bookies (stateful), brokers, and proxies (stateless).
+Apache Pulsar is comprised of multiple components, the metadata store (Oxia or ZooKeeper), bookies, and brokers. These components are either stateful or stateless. You do not have to upgrade the metadata store unless you have special requirements. While you upgrade, you need to pay attention to bookies (stateful), brokers, and proxies (stateless).
 
 Read the following guidelines before upgrading a Pulsar cluster.
 
 - Back up all your configuration files before upgrading.
 - Read the guide entirely, make a plan, and then execute the plan. When you make an upgrade plan, you need to take your specific requirements and environment into consideration.
-- Pay attention to the [upgrade sequence of components](#upgrade-sequence). In general, you do not need to upgrade your ZooKeeper or configuration store cluster (the global ZooKeeper cluster). You need to upgrade bookies first, and then upgrade brokers, proxies, and your clients.
+- Pay attention to the [upgrade sequence of components](#upgrade-sequence). In general, you do not need to upgrade your metadata store or configuration store cluster. You need to upgrade bookies first, and then upgrade brokers, proxies, and your clients.
 - If `autorecovery` is enabled, you need to disable `autorecovery` in the upgrade process, and re-enable it after completing the process.
 - Read the release notes carefully for each release. Release notes contain features and configuration changes that might impact your upgrade.
 - Upgrade a small subset of nodes of each type to canary test the new version before upgrading all nodes of that type in the cluster. When you have upgraded the canary nodes, run for a while to ensure that they work correctly.
@@ -34,9 +34,9 @@ Currently, Apache Pulsar is compatible between versions.
 
 To upgrade an Apache Pulsar cluster, follow the upgrade sequence.
 
-1. Upgrade ZooKeeper (optional).
-   - Canary test: test an upgraded version in one or a small set of ZooKeeper nodes.
-   - Rolling upgrade: roll out the upgraded version to all ZooKeeper servers incrementally, one at a time. Monitor your dashboard during the whole rolling upgrade process.
+1. Upgrade the metadata store (optional). The steps below describe a ZooKeeper-based metadata store; if you use Oxia, follow the equivalent procedure in the [Oxia documentation](https://oxia-db.github.io/).
+   - Canary test: test an upgraded version in one or a small set of metadata store nodes.
+   - Rolling upgrade: roll out the upgraded version to all metadata store nodes incrementally, one at a time. Monitor your dashboard during the whole rolling upgrade process.
 2. Upgrade bookies.
    - Canary test: test an upgraded version in one or a small set of bookies.
    - Rolling upgrade:

--- a/docs/administration-zk-bk.md
+++ b/docs/administration-zk-bk.md
@@ -1,8 +1,8 @@
 ---
 id: administration-zk-bk
-title: ZooKeeper and BookKeeper administration
-sidebar_label: "ZooKeeper and BookKeeper"
-description: Get a comprehensive understanding of ZooKeeper and BookKeeper in Pulsar.
+title: Metadata store and BookKeeper administration
+sidebar_label: "Metadata store & BookKeeper"
+description: Get a comprehensive understanding of the metadata store and BookKeeper in Pulsar.
 ---
 
 ````mdx-code-block
@@ -12,20 +12,30 @@ import TabItem from '@theme/TabItem';
 
 Pulsar relies on two external systems for essential tasks:
 
-* [ZooKeeper](https://zookeeper.apache.org/) is responsible for a wide variety of configuration-related and coordination-related tasks.
+* A **metadata store** is responsible for a wide variety of configuration-related and coordination-related tasks. For new clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store; [ZooKeeper](https://zookeeper.apache.org/) is also fully supported and is covered on this page. See [Configure metadata store](administration-metadata-store.md) for all supported backends.
 * [BookKeeper](http://bookkeeper.apache.org/) is responsible for [persistent storage](concepts-architecture-overview.md#persistent-storage) of message data.
 
-ZooKeeper and BookKeeper are both open-source [Apache](https://www.apache.org/) projects.
-This diagram illustrates the role of ZooKeeper and BookKeeper in a Pulsar cluster:
+This diagram illustrates the role of the metadata store and BookKeeper in a Pulsar cluster:
 
-![Role of ZooKeeper and BookKeeper in Pulsar cluster](/assets/pulsar-system-architecture.png)
+![Role of the metadata store and BookKeeper in a Pulsar cluster](/assets/pulsar-system-architecture.svg)
 
 Each Pulsar cluster consists of one or more message brokers. Each broker relies on an ensemble of bookies.
 
 
+## Oxia
+
+[Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store for new Pulsar clusters. It provides the configuration and coordination services that Pulsar needs, with better scalability for large clusters than ZooKeeper.
+
+To use Oxia as the metadata store:
+
+1. Deploy an Oxia cluster and create the target namespace. See the [Oxia documentation](https://oxia-db.github.io/) for deployment instructions.
+2. Configure Pulsar to use it by setting `metadataStoreUrl` and `configurationMetadataStoreUrl`, as described in [Configure metadata store](administration-metadata-store.md#use-oxia-as-metadata-store).
+
+To move an existing ZooKeeper-based cluster to Oxia without downtime, see [Migrate metadata store](administration-metadata-store-migration.md).
+
 ## ZooKeeper
 
-Each Pulsar instance relies on two separate ZooKeeper quorums.
+ZooKeeper is the traditional metadata store option and ships with the Pulsar binary package. When you use ZooKeeper as the metadata store, each Pulsar instance relies on two separate ZooKeeper quorums.
 
 * [Local ZooKeeper](#deploy-local-zookeeper) operates at the cluster level and provides cluster-specific configuration management and coordination. Each Pulsar cluster needs to have a dedicated ZooKeeper cluster.
 * [Configuration Store](#deploy-configuration-store) operates at the instance level and provides configuration management for the entire system (and thus across clusters). An independent cluster of machines or the same machines that local ZooKeeper uses can provide the configuration store quorum.

--- a/docs/bookkeeper-metadata-serviceuri.md
+++ b/docs/bookkeeper-metadata-serviceuri.md
@@ -67,7 +67,12 @@ it ends up internally as:
 
 ### **3\. Metadata Service URI (Preferred)**
 
-From our **OSS Pulsar 4.x tests**, the **correct and working setup** is:
+For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md). Point BookKeeper at Oxia with:
+
+| metadataServiceUri\=metadata-store:oxia://oxia-1.example.com:6648/pulsar |
+| :---- |
+
+Alternatively, with ZooKeeper as the metadata store, the **correct and working setup** (from our **OSS Pulsar 4.x tests**) is:
 
 | metadataServiceUri\=metadata-store:zk:pulsar-mini-zookeeper:2181zkLedgersRootPath\=/ledgerszkServers\= |
 | :---- |
@@ -90,7 +95,12 @@ From our **OSS Pulsar 4.x tests**, the **correct and working setup** is:
 
 ### **Summary :**
 
-Always set **metadataServiceUri** in bookkeeper.conf. Example:
+Always set **metadataServiceUri** in bookkeeper.conf. For new clusters, [Oxia](administration-metadata-store.md) is the recommended metadata store:
+
+| metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/pulsar |
+| :---- |
+
+With ZooKeeper:
 
 | metadataServiceUri=metadata-store:zk:zk1:2181,zk2:2181,zk3:2181/ledgers |
 | :---- |

--- a/docs/bookkeeper-metadata-serviceuri.md
+++ b/docs/bookkeeper-metadata-serviceuri.md
@@ -67,10 +67,12 @@ it ends up internally as:
 
 ### **3\. Metadata Service URI (Preferred)**
 
-For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md). Point BookKeeper at Oxia with:
+For new clusters, [Oxia is the recommended metadata store](administration-metadata-store.md). Point BookKeeper at its own Oxia namespace, separate from the Pulsar metadata store (the [Pulsar Helm chart](https://github.com/apache/pulsar-helm-chart) uses `bookkeeper`):
 
-| metadataServiceUri\=metadata-store:oxia://oxia-1.example.com:6648/pulsar |
+| metadataServiceUri\=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper |
 | :---- |
+
+The `metadata-store:` prefix is required and the format differs from Pulsar's `metadataStoreUrl`. The broker's `bookkeeperMetadataServiceUri` in `conf/broker.conf` should be set to this same value.
 
 Alternatively, with ZooKeeper as the metadata store, the **correct and working setup** (from our **OSS Pulsar 4.x tests**) is:
 
@@ -97,7 +99,7 @@ Alternatively, with ZooKeeper as the metadata store, the **correct and working s
 
 Always set **metadataServiceUri** in bookkeeper.conf. For new clusters, [Oxia](administration-metadata-store.md) is the recommended metadata store:
 
-| metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/pulsar |
+| metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper |
 | :---- |
 
 With ZooKeeper:

--- a/docs/concepts-architecture-overview.md
+++ b/docs/concepts-architecture-overview.md
@@ -11,13 +11,13 @@ A Pulsar cluster consists of the following components:
 
 * One or more [brokers](#brokers) handles and [load balances](administration-load-balance.md) incoming messages from [producers](concepts-clients.md#producer), dispatches messages to [consumers](concepts-clients.md#consumer), communicates with the Pulsar [metadata store](#metadata-store) to handle various coordination tasks, stores messages in [BookKeeper](#apache-bookkeeper) instances (aka bookies), and coordinates cluster operations through the metadata store.
 * A BookKeeper cluster consisting of one or more bookies handles [persistent storage](#persistent-storage) of messages.
-* A metadata store cluster (ZooKeeper, etcd, or other supported backend) handles coordination tasks and cluster-specific metadata storage.
+* A metadata store cluster (Oxia, ZooKeeper, etcd, or other supported backend) handles coordination tasks and cluster-specific metadata storage.
 
 The diagram below illustrates a Pulsar cluster:
 
-![Pulsar architecture diagram](/assets/pulsar-system-architecture.png)
+![Pulsar architecture diagram](/assets/pulsar-system-architecture.svg)
 
-At the broader instance level, an instance-wide ZooKeeper cluster called the [configuration store](#configuration-store) handles coordination tasks involving multiple clusters, for example, [geo-replication](concepts-replication.md).
+At the broader instance level, an instance-wide metadata store cluster called the [configuration store](#configuration-store) handles coordination tasks involving multiple clusters, for example, [geo-replication](concepts-replication.md).
 
 ## Brokers
 
@@ -37,7 +37,7 @@ Finally, to support [geo-replication](concepts-replication.md) on global [topics
 A Pulsar instance consists of one or more Pulsar *clusters*. Clusters, in turn, consist of:
 
 * One or more Pulsar [brokers](#brokers)
-* A ZooKeeper quorum used for cluster-level configuration and coordination
+* A metadata store (Oxia or ZooKeeper) used for cluster-level configuration and coordination
 * An ensemble of [bookies](#apache-bookkeeper) used for [persistent storage](#persistent-storage) of messages
 
 Clusters can replicate among themselves using [geo-replication](concepts-replication.md).
@@ -50,16 +50,19 @@ The Pulsar metadata store maintains all the metadata of a Pulsar cluster, such a
 
 ### Supported Metadata Store Backends
 
-- **[Apache ZooKeeper](https://zookeeper.apache.org/)** - Default option, production-ready metadata store with strong consistency guarantees.
+- **[Oxia](https://github.com/oxia-db/oxia/)** - Recommended for new clusters. A robust, scalable metadata store and coordination system designed for large-scale distributed systems, with built-in support for stream index storage to optimize real-time data management.
+- **[Apache ZooKeeper](https://zookeeper.apache.org/)** - Production-ready metadata store with strong consistency guarantees; ships with the Pulsar binary package.
 - **[etcd](https://etcd.io/)** - Cloud-native distributed key-value store, ideal for Kubernetes environments and cloud deployments.
 - **[RocksDB](http://rocksdb.org/)** - Embedded key-value store for standalone Pulsar deployments, eliminating the need for external coordination services.
-- **[Oxia](https://github.com/oxia-db/oxia/)** - A robust, scalable metadata store and coordination system designed for large-scale distributed systems, with built-in support for stream index storage to optimize real-time data management.
 
 ### Configuration
 
 You can configure the metadata store using the `metadataStoreUrl` parameter:
 
 ```bash
+# Oxia (recommended)
+metadataStoreUrl=oxia://oxia-server:6648/pulsar
+
 # ZooKeeper
 metadataStoreUrl=zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181
 
@@ -68,23 +71,20 @@ metadataStoreUrl=etcd:my-etcd-1:2379,my-etcd-2:2379,my-etcd-3:2379
 
 # RocksDB (standalone)
 metadataStoreUrl=rocksdb:///path/to/data
-
-# Oxia
-metadataStoreUrl=oxia:oxia-server:6648
 ```
 
 ### Deployment Considerations
 
-The Pulsar metadata store can be deployed on a separate cluster or integrated with existing infrastructure. You can use one ZooKeeper cluster for both Pulsar metadata store and BookKeeper metadata store. If you want to deploy Pulsar brokers connected to an existing BookKeeper cluster, you need to deploy separate clusters for Pulsar metadata store and BookKeeper metadata store respectively.
+The Pulsar metadata store can be deployed on a separate cluster or integrated with existing infrastructure. You can use one metadata store cluster for both Pulsar metadata and BookKeeper metadata. If you want to deploy Pulsar brokers connected to an existing BookKeeper cluster, you need to deploy separate clusters for Pulsar metadata store and BookKeeper metadata store respectively.
 
 In a Pulsar instance:
 
 * A configuration store quorum stores configuration for [tenants](concepts-multi-tenancy.md), [namespaces](concepts-messaging.md#namespaces), and other entities that need to be globally consistent.
-* Each cluster has its own local ZooKeeper ensemble that stores cluster-specific configuration and coordination such as which brokers are responsible for which [topics](concepts-messaging.md#topics) as well as ownership metadata, broker load reports, BookKeeper ledger metadata, and more.
+* Each cluster has its own local metadata store ensemble that stores cluster-specific configuration and coordination such as which brokers are responsible for which [topics](concepts-messaging.md#topics) as well as ownership metadata, broker load reports, BookKeeper ledger metadata, and more.
 
 ## Configuration store
 
-The configuration store is a ZooKeeper quorum that is used for configuration-specific tasks and it maintains all the configurations of a Pulsar instance, such as clusters, [tenants](concepts-multi-tenancy.md), [namespaces](concepts-messaging.md#namespaces), partitioned topic-related configurations, and so on. A Pulsar instance can have a single local cluster, multiple local clusters, or multiple cross-region clusters. Consequently, the configuration store can share the configurations across multiple clusters under a Pulsar instance. The configuration store can be deployed on a separate ZooKeeper cluster or deployed on an existing ZooKeeper cluster.
+The configuration store is a metadata store quorum (Oxia or ZooKeeper) that is used for configuration-specific tasks and it maintains all the configurations of a Pulsar instance, such as clusters, [tenants](concepts-multi-tenancy.md), [namespaces](concepts-messaging.md#namespaces), partitioned topic-related configurations, and so on. A Pulsar instance can have a single local cluster, multiple local clusters, or multiple cross-region clusters. Consequently, the configuration store can share the configurations across multiple clusters under a Pulsar instance. The configuration store can be deployed on a separate cluster or share an existing metadata store cluster.
 
 ## Persistent storage
 
@@ -116,7 +116,7 @@ persistent://my-tenant/my-namespace/my-topic
 
 You can see an illustration of how brokers and bookies interact in the diagram below:
 
-![Brokers and bookies in a Pulsar cluster](/assets/broker-bookie.png)
+![Brokers and bookies in a Pulsar cluster](/assets/broker-bookie.svg)
 
 
 ### Ledgers
@@ -156,6 +156,11 @@ Architecturally, the Pulsar proxy gets all the information it requires from the 
 
 ```bash
 cd /path/to/pulsar/directory
+# Using Oxia (recommended)
+bin/pulsar proxy \
+    --metadata-store oxia://oxia-1.example.com:6648/pulsar \
+    --configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar
+
 # Using ZooKeeper
 bin/pulsar proxy \
     --metadata-store zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181 \
@@ -184,7 +189,7 @@ You can use your own service discovery system if you'd like. If you use your own
 
 The diagram below illustrates Pulsar service discovery:
 
-![Service discovery in Pulsar](/assets/pulsar-service-discovery.png)
+![Service discovery in Pulsar](/assets/pulsar-service-discovery.svg)
 
 In this diagram, the Pulsar cluster is addressable via a single DNS name: `pulsar-cluster.acme.com`. A [Python client](/docs/client-libraries/python), for example, could access this Pulsar cluster like this:
 

--- a/docs/concepts-architecture-overview.md
+++ b/docs/concepts-architecture-overview.md
@@ -61,7 +61,7 @@ You can configure the metadata store using the `metadataStoreUrl` parameter:
 
 ```bash
 # Oxia (recommended)
-metadataStoreUrl=oxia://oxia-server:6648/pulsar
+metadataStoreUrl=oxia://oxia-server:6648/broker
 
 # ZooKeeper
 metadataStoreUrl=zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181
@@ -158,8 +158,8 @@ Architecturally, the Pulsar proxy gets all the information it requires from the 
 cd /path/to/pulsar/directory
 # Using Oxia (recommended)
 bin/pulsar proxy \
-    --metadata-store oxia://oxia-1.example.com:6648/pulsar \
-    --configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar
+    --metadata-store oxia://oxia-1.example.com:6648/broker \
+    --configuration-metadata-store oxia://oxia-1.example.com:6648/broker
 
 # Using ZooKeeper
 bin/pulsar proxy \

--- a/docs/cookbooks-bookkeepermetadata.md
+++ b/docs/cookbooks-bookkeepermetadata.md
@@ -5,7 +5,7 @@ description: Get a comprehensive understanding of BookKeeper Ledger Metadata.
 ---
 
 Pulsar stores data on BookKeeper ledgers, you can understand the contents of a ledger by inspecting the metadata attached to the ledger.
-Such metadata are stored on ZooKeeper and they are readable using BookKeeper APIs.
+Such metadata are stored in the configured [metadata store](administration-metadata-store.md) (Oxia, recommended for new clusters, or ZooKeeper) and they are readable using BookKeeper APIs.
 
 Description of current metadata:
 

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -121,6 +121,12 @@ Variable name | Description | Default
 `base_cidr_block` | The root [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that network assets uses for the cluster | `10.0.0.0/16`
 `instance_types` | The EC2 instance types to be used. This variable is a map with two keys: `zookeeper` for the ZooKeeper instances, `bookie` for the BookKeeper bookies and `broker` and `proxy` for Pulsar brokers and bookies | `t2.small` (ZooKeeper), `i3.xlarge` (BookKeeper) and `c5.2xlarge` (Brokers/Proxies)
 
+:::note
+
+This Terraform/Ansible recipe provisions [ZooKeeper](https://zookeeper.apache.org) as the metadata store. For new clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store; deploy it separately following the [Oxia documentation](https://oxia-db.github.io/) and point the brokers and bookies at it as described in [Configure metadata store](administration-metadata-store.md).
+
+:::
+
 ### What is installed
 
 When you run the Ansible playbook, the following AWS resources are used:

--- a/docs/deploy-bare-metal-multi-cluster.md
+++ b/docs/deploy-bare-metal-multi-cluster.md
@@ -68,9 +68,11 @@ Directory | Contains
 `logs` | Logs that the installation creates
 
 
-## Step 1: Deploy ZooKeeper
+## Step 1: Deploy the metadata store
 
-Each Pulsar instance relies on two separate ZooKeeper quorums.
+For new clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store, including for multi-cluster instances. Deploy Oxia following the [Oxia documentation](https://oxia-db.github.io/) and use its `oxia://<host>:<port>/<namespace>` URL for both the local metadata store and the configuration store wherever the steps below reference a connection string. The rest of this step describes the traditional **ZooKeeper** setup.
+
+When you use ZooKeeper, each Pulsar instance relies on two separate ZooKeeper quorums.
 
 * Local ZooKeeper operates at the cluster level and provides cluster-specific configuration management and coordination. Each Pulsar cluster needs a dedicated ZooKeeper cluster.
 * Configuration Store operates at the instance level and provides configuration management for the entire system (and thus across clusters). An independent cluster of machines or the same machines that local ZooKeeper uses can provide the configuration store quorum.
@@ -191,7 +193,7 @@ bin/pulsar-daemon start configuration-store
 
 ## Step 2: Cluster metadata initialization
 
-Once you set up the cluster-specific ZooKeeper and configuration store quorums for your instance, you need to write some metadata to ZooKeeper for each cluster in your instance. **you only need to write these metadata once**.
+Once you set up the cluster-specific metadata store and configuration store quorums for your instance, you need to write some metadata for each cluster in your instance. **you only need to write these metadata once**.
 
 You can initialize this metadata using the [`initialize-cluster-metadata`](reference-cli-tools.md) command of the [`pulsar`](reference-cli-tools.md) CLI tool. The following is an example:
 
@@ -205,6 +207,12 @@ bin/pulsar initialize-cluster-metadata \
     --broker-service-url pulsar://pulsar.us-west.example.com:6650/ \
     --broker-service-url-tls pulsar+ssl://pulsar.us-west.example.com:6651/
 ```
+
+:::tip
+
+If you use Oxia as the metadata store, set both `--metadata-store` and `--configuration-metadata-store` to your Oxia URL, for example `oxia://oxia-1.example.com:6648/pulsar`.
+
+:::
 
 As you can see from the example above, you need to specify the following:
 
@@ -222,11 +230,11 @@ Make sure to run `initialize-cluster-metadata` for each cluster in your instance
 
 BookKeeper provides [persistent message storage](concepts-architecture-overview.md#persistent-storage) for Pulsar.
 
-Each Pulsar broker needs its own cluster of bookies. The BookKeeper cluster shares a local ZooKeeper quorum with the Pulsar cluster.
+Each Pulsar broker needs its own cluster of bookies. The BookKeeper cluster shares the metadata store with the Pulsar cluster.
 
 ### Configure bookies
 
-You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important aspect of configuring each bookie is ensuring that the [`zkServers`](reference-configuration.md#bookkeeper-zkServers) parameter is set to the connection string for the local ZooKeeper of Pulsar cluster.
+You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important aspect of configuring each bookie is ensuring that its `metadataServiceUri` points to the same metadata store as the Pulsar cluster — `metadata-store:oxia://oxia-1.example.com:6648/pulsar` for Oxia (recommended), or the local ZooKeeper connection string.
 
 ### Start bookies
 
@@ -267,17 +275,24 @@ designed to use multiple devices:
 
 ## Step 4: Deploy brokers
 
-Once you set up ZooKeeper, initialize cluster metadata, and spin up BookKeeper bookies, you can deploy brokers.
+Once you set up the metadata store, initialize cluster metadata, and spin up BookKeeper bookies, you can deploy brokers.
 
 ### Broker configuration
 
 You can configure brokers using the [`conf/broker.conf`](reference-configuration.md#broker) configuration file.
 
-The most important element of broker configuration is ensuring that each broker is aware of its local ZooKeeper quorum as well as the configuration store quorum. Make sure that you set the [`metadataStoreUrl`](reference-configuration.md#broker) parameter to reflect the local quorum and the [`configurationMetadataStoreUrl`](reference-configuration.md#broker) parameter to reflect the configuration store quorum (although you need to specify only those ZooKeeper servers located in the same cluster).
+The most important element of broker configuration is ensuring that each broker is aware of its local metadata store as well as the configuration store. Make sure that you set the [`metadataStoreUrl`](reference-configuration.md#broker) parameter to reflect the local metadata store and the [`configurationMetadataStoreUrl`](reference-configuration.md#broker) parameter to reflect the configuration store.
 
 You also need to specify the name of the [cluster](reference-terminology.md#cluster) to which the broker belongs using the [`clusterName`](reference-configuration.md#broker-clusterName) parameter. In addition, you need to match the broker and web service ports provided when you initialize the metadata (especially when you use a different port from default) of the cluster.
 
-The following is an example configuration:
+With Oxia (recommended), point both parameters at your Oxia URL:
+
+```properties
+metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+```
+
+The following is an example configuration with ZooKeeper:
 
 ```properties
 # Local ZooKeeper servers

--- a/docs/deploy-bare-metal-multi-cluster.md
+++ b/docs/deploy-bare-metal-multi-cluster.md
@@ -210,7 +210,7 @@ bin/pulsar initialize-cluster-metadata \
 
 :::tip
 
-If you use Oxia as the metadata store, set both `--metadata-store` and `--configuration-metadata-store` to your Oxia URL, for example `oxia://oxia-1.example.com:6648/pulsar`.
+If you use Oxia as the metadata store, set `--metadata-store` (and, for a multi-cluster instance, `--configuration-metadata-store`) to your Oxia URL, for example `oxia://oxia-1.example.com:6648/broker`.
 
 :::
 
@@ -234,7 +234,7 @@ Each Pulsar broker needs its own cluster of bookies. The BookKeeper cluster shar
 
 ### Configure bookies
 
-You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important aspect of configuring each bookie is ensuring that its `metadataServiceUri` points to the same metadata store as the Pulsar cluster — `metadata-store:oxia://oxia-1.example.com:6648/pulsar` for Oxia (recommended), or the local ZooKeeper connection string.
+You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important aspect of configuring each bookie is ensuring that its `metadataServiceUri` points to the BookKeeper metadata store — `metadata-store:oxia://oxia-1.example.com:6648/bookkeeper` for Oxia (recommended), or the local ZooKeeper connection string.
 
 ### Start bookies
 
@@ -285,11 +285,12 @@ The most important element of broker configuration is ensuring that each broker 
 
 You also need to specify the name of the [cluster](reference-terminology.md#cluster) to which the broker belongs using the [`clusterName`](reference-configuration.md#broker-clusterName) parameter. In addition, you need to match the broker and web service ports provided when you initialize the metadata (especially when you use a different port from default) of the cluster.
 
-With Oxia (recommended), point both parameters at your Oxia URL:
+With Oxia (recommended) — `metadataStoreUrl` is the cluster-local metadata store, `configurationMetadataStoreUrl` is the instance-wide configuration store, and `bookkeeperMetadataServiceUri` uses its own namespace:
 
 ```properties
-metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
-configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+metadataStoreUrl=oxia://oxia-1.example.com:6648/broker
+configurationMetadataStoreUrl=oxia://oxia-config.example.com:6648/broker
+bookkeeperMetadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper
 ```
 
 The following is an example configuration with ZooKeeper:

--- a/docs/deploy-bare-metal.md
+++ b/docs/deploy-bare-metal.md
@@ -272,7 +272,7 @@ bin/pulsar initialize-cluster-metadata \
 
 :::tip
 
-If you use Oxia as the metadata store, set the connection strings to your Oxia URL instead, for example `--metadata-store oxia://oxia-1.example.com:6648/pulsar` and `--configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar`.
+If you use Oxia as the metadata store, set the connection string to your Oxia URL instead, for example `--metadata-store oxia://oxia-1.example.com:6648/broker` (the `--configuration-metadata-store` is optional and defaults to it).
 
 :::
 
@@ -329,7 +329,7 @@ BookKeeper configuration is split across two files:
 You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the metadata store. With Oxia (recommended), use the `metadata-store:` driver:
 
 ```properties
-metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/pulsar
+metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper
 ```
 
 With ZooKeeper, the following is an example:
@@ -478,11 +478,11 @@ Broker configuration is split across two files:
 
 You can configure brokers using the `conf/broker.conf` configuration file. The most important element of broker configuration is ensuring that each broker is aware of the metadata store that you have deployed. Ensure that the [`metadataStoreUrl`](reference-configuration.md#broker) and [`configurationMetadataStoreUrl`](reference-configuration.md#broker) parameters are correct. In this case, since you only have 1 cluster and no configuration store setup, the `configurationMetadataStoreUrl` point to the same `metadataStoreUrl`.
 
-With Oxia (recommended):
+With Oxia (recommended) — `configurationMetadataStoreUrl` can be omitted for a single cluster, but `bookkeeperMetadataServiceUri` is required and uses its own namespace:
 
 ```properties
-metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
-configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+metadataStoreUrl=oxia://oxia-1.example.com:6648/broker
+bookkeeperMetadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/bookkeeper
 ```
 
 With ZooKeeper:

--- a/docs/deploy-bare-metal.md
+++ b/docs/deploy-bare-metal.md
@@ -25,14 +25,14 @@ Also, you need the proper 64-bit JRE/JDK version installed. Please refer to [Pul
 
 :::tip
 
-You can reuse existing Zookeeper clusters.
+You can reuse an existing metadata store (Oxia or ZooKeeper) cluster.
 
 :::
 
 To run Pulsar on bare metal, the following configuration is recommended:
 
 * At least 6 Linux machines or VMs
-  * 3 for running [ZooKeeper](https://zookeeper.apache.org)
+  * 3 for running the metadata store ([Oxia](https://github.com/oxia-db/oxia) recommended, or [ZooKeeper](https://zookeeper.apache.org))
   * 3 for running a Pulsar broker, and a [BookKeeper](https://bookkeeper.apache.org) bookie
 * A single [DNS](https://en.wikipedia.org/wiki/Domain_Name_System) name covering all of the Pulsar broker hosts (optional)
 
@@ -47,9 +47,9 @@ To run Pulsar on bare metal, the following configuration is recommended:
 
 The following is a diagram showing the basic setup:
 
-![Basic setup of Pulsar cluster](/assets/pulsar-basic-setup.png)
+![Basic setup of Pulsar cluster](/assets/pulsar-basic-setup.svg)
 
-In this diagram, connecting clients need to communicate with the Pulsar cluster using a single URL. In this case, `pulsar-cluster.acme.com` abstracts over all of the message-handling brokers. Pulsar message brokers run on machines alongside BookKeeper bookies; brokers and bookies, in turn, rely on ZooKeeper.
+In this diagram, connecting clients need to communicate with the Pulsar cluster using a single URL. In this case, `pulsar-cluster.acme.com` abstracts over all of the message-handling brokers. Pulsar message brokers run on machines alongside BookKeeper bookies; brokers and bookies, in turn, rely on the metadata store.
 
 ### Hardware considerations
 
@@ -192,11 +192,15 @@ tiered-storage-jcloud-@pulsar:version@.nar
 For more details of how to configure tiered storage feature, you can refer to the [Tiered storage cookbook](cookbooks-tiered-storage.md)
 
 
-## Step 1: Deploy a ZooKeeper cluster
+## Step 1: Deploy the metadata store
+
+For new clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store. Deploy an Oxia cluster following the [Oxia documentation](https://oxia-db.github.io/), then use its `oxia://<host>:<port>/<namespace>` URL wherever the steps below reference the metadata store connection string (in [Step 2](#step-2-initialize-cluster-metadata) and in the broker and bookie configuration). When you use Oxia, you can skip the ZooKeeper setup described in the rest of this step.
+
+The remainder of this step describes deploying **ZooKeeper**, the metadata store that ships with the Pulsar binary package.
 
 :::note
 
-If you already have an existing zookeeper cluster and want to use it, you can skip this section.
+If you already have an existing ZooKeeper cluster and want to use it, you can skip this section.
 
 :::
 
@@ -266,6 +270,12 @@ bin/pulsar initialize-cluster-metadata \
     --broker-service-url-tls pulsar+ssl://pulsar.us-west.example.com:6651
 ```
 
+:::tip
+
+If you use Oxia as the metadata store, set the connection strings to your Oxia URL instead, for example `--metadata-store oxia://oxia-1.example.com:6648/pulsar` and `--configuration-metadata-store oxia://oxia-1.example.com:6648/pulsar`.
+
+:::
+
 As you can see from the example above, you will need to specify the following configurations. Items with * are **required** flags.
 
 Flag | Description
@@ -316,7 +326,13 @@ BookKeeper configuration is split across two files:
 
 #### Metadata store connection
 
-You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the ZooKeeper cluster. The following is an example:
+You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](reference-configuration.md#bookkeeper) configuration file. The most important step in configuring bookies for our purposes here is ensuring that `metadataServiceUri` is set to the URI for the metadata store. With Oxia (recommended), use the `metadata-store:` driver:
+
+```properties
+metadataServiceUri=metadata-store:oxia://oxia-1.example.com:6648/pulsar
+```
+
+With ZooKeeper, the following is an example:
 
 ```properties
 metadataServiceUri=zk://zk1.us-west.example.com:2181;zk2.us-west.example.com:2181;zk3.us-west.example.com:2181/ledgers
@@ -460,7 +476,16 @@ Broker configuration is split across two files:
 
 #### Metadata store and cluster settings
 
-You can configure brokers using the `conf/broker.conf` configuration file. The most important element of broker configuration is ensuring that each broker is aware of the ZooKeeper cluster that you have deployed. Ensure that the [`metadataStoreUrl`](reference-configuration.md#broker) and [`configurationMetadataStoreUrl`](reference-configuration.md#broker) parameters are correct. In this case, since you only have 1 cluster and no configuration store setup, the `configurationMetadataStoreUrl` point to the same `metadataStoreUrl`.
+You can configure brokers using the `conf/broker.conf` configuration file. The most important element of broker configuration is ensuring that each broker is aware of the metadata store that you have deployed. Ensure that the [`metadataStoreUrl`](reference-configuration.md#broker) and [`configurationMetadataStoreUrl`](reference-configuration.md#broker) parameters are correct. In this case, since you only have 1 cluster and no configuration store setup, the `configurationMetadataStoreUrl` point to the same `metadataStoreUrl`.
+
+With Oxia (recommended):
+
+```properties
+metadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+configurationMetadataStoreUrl=oxia://oxia-1.example.com:6648/pulsar
+```
+
+With ZooKeeper:
 
 ```properties
 metadataStoreUrl=zk:zk1.us-west.example.com:2181,zk2.us-west.example.com:2181,zk3.us-west.example.com:2181

--- a/docs/deploy-docker.md
+++ b/docs/deploy-docker.md
@@ -9,7 +9,7 @@ To deploy a Pulsar cluster on Docker using Docker commands, you need to complete
 
 ## Step 1: Pull a Pulsar image
 
-To run Pulsar on Docker, you need to create a container for each Pulsar component: ZooKeeper, bookie, and the broker. You can pull the images of ZooKeeper and bookie separately on Docker Hub, and pull the Pulsar image for the broker. You can also pull only one Pulsar image and create three containers with this image. This tutorial takes the second option as an example.
+To run Pulsar on Docker, you need to create a container for each Pulsar component: the metadata store, a bookie, and a broker. This tutorial uses [Oxia](https://github.com/oxia-db/oxia) as the [metadata store](administration-metadata-store.md) (the recommended option for new clusters), which runs from its own image; the bookie and broker run from the Pulsar image.
 
 You can pull a Pulsar image from Docker Hub with the following command. If you do not want to use some connectors, you can use `apachepulsar/pulsar:latest` there.
 ```bash
@@ -18,7 +18,7 @@ docker pull apachepulsar/pulsar-all:latest
 
 ## Step 2: Create a network
 
-To deploy a Pulsar cluster on Docker, you need to create a network and connect the containers of ZooKeeper, bookie, and broker to this network.
+To deploy a Pulsar cluster on Docker, you need to create a network and connect the containers of Oxia, bookie, and broker to this network.
 Use the following command to create the network `pulsar`:
 
 ```bash
@@ -27,31 +27,29 @@ docker network create pulsar
 
 ## Step 3: Create and start containers
 
-### Create a ZooKeeper container
+### Create an Oxia container
 
-Create a ZooKeeper container and start the ZooKeeper service.
+Create an Oxia container and start the Oxia metadata store.
 
 ```bash
-docker run -d -p 2181:2181 --net=pulsar \
-    -e metadataStoreUrl=zk:zookeeper:2181 \
-    -e cluster-name=cluster-a \
-    -v $(pwd)/data/zookeeper:/pulsar/data/zookeeper \
-    --name zookeeper --hostname zookeeper \
-    apachepulsar/pulsar-all:latest \
-    bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && bin/generate-zookeeper-config.sh conf/zookeeper.conf && exec bin/pulsar zookeeper"
+docker run -d -p 6648:6648 --net=pulsar \
+    -v $(pwd)/data/oxia:/data \
+    --name oxia --hostname oxia \
+    oxia/oxia:latest \
+    oxia standalone
 ```
 
 ### Initialize the cluster metadata
 
-After creating the ZooKeeper container successfully, you can use the following command to initialize the cluster metadata.
+After creating the Oxia container successfully, you can use the following command to initialize the cluster metadata.
 
 ```bash
 docker run --net=pulsar \
     --name initialize-pulsar-cluster-metadata \
     apachepulsar/pulsar-all:latest bash -c "bin/pulsar initialize-cluster-metadata \
 --cluster cluster-a \
---zookeeper zookeeper:2181 \
---configuration-store zookeeper:2181 \
+--metadata-store oxia://oxia:6648/default \
+--configuration-store oxia://oxia:6648/default \
 --web-service-url http://broker:8080 \
 --broker-service-url pulsar://broker:6650"
 ```
@@ -61,9 +59,8 @@ docker run --net=pulsar \
 Create a bookie container and start the bookie service.
 
 ```bash
-docker run -d -e clusterName=cluster-a \
-    -e zkServers=zookeeper:2181 --net=pulsar \
-    -e metadataServiceUri=metadata-store:zk:zookeeper:2181 \
+docker run -d -e clusterName=cluster-a --net=pulsar \
+    -e metadataServiceUri=metadata-store:oxia://oxia:6648/default \
     -v $(pwd)/data/bookkeeper:/pulsar/data/bookkeeper \
     --name bookie --hostname bookie \
     apachepulsar/pulsar-all:latest \
@@ -76,8 +73,7 @@ Create a broker container and start the broker service.
 
 ```bash
 docker run -d -p 6650:6650 -p 8080:8080 --net=pulsar \
-    -e metadataStoreUrl=zk:zookeeper:2181 \
-    -e zookeeperServers=zookeeper:2181 \
+    -e metadataStoreUrl=oxia://oxia:6648/default \
     -e clusterName=cluster-a \
     --name broker --hostname broker \
     apachepulsar/pulsar-all:latest \
@@ -113,7 +109,7 @@ Pass configuration properties directly as environment variables in the `docker r
 
 ```bash
 docker run -d \
-    -e metadataStoreUrl=zk:zookeeper:2181 \
+    -e metadataStoreUrl=oxia://oxia:6648/default \
     -e clusterName=cluster-a \
     -e managedLedgerDefaultEnsembleSize=2 \
     -e managedLedgerDefaultWriteQuorum=2 \
@@ -135,7 +131,7 @@ docker run -d --env-file ./broker-config.env \
 Example `broker-config.env` file:
 
 ```properties
-metadataStoreUrl=zk:zookeeper:2181
+metadataStoreUrl=oxia://oxia:6648/default
 clusterName=cluster-a
 managedLedgerDefaultEnsembleSize=2
 managedLedgerDefaultWriteQuorum=2
@@ -162,9 +158,8 @@ Below are examples of commonly used configuration properties for BookKeeper and 
 #### BookKeeper
 
 ```bash
-docker run -d -e clusterName=cluster-a \
-    -e zkServers=zookeeper:2181 --net=pulsar \
-    -e metadataServiceUri=metadata-store:zk:zookeeper:2181 \
+docker run -d -e clusterName=cluster-a --net=pulsar \
+    -e metadataServiceUri=metadata-store:oxia://oxia:6648/default \
     # Storage directories: journal for write-ahead logs, ledgers for actual message data
     -e journalDirectory=/pulsar/data/bookkeeper/journal \
     -e ledgerDirectories=/pulsar/data/bookkeeper/ledgers \
@@ -194,8 +189,7 @@ docker run -d -e clusterName=cluster-a \
 
 ```bash
 docker run -d -p 6650:6650 -p 8080:8080 --net=pulsar \
-    -e metadataStoreUrl=zk:zookeeper:2181 \
-    -e zookeeperServers=zookeeper:2181 \
+    -e metadataStoreUrl=oxia://oxia:6648/default \
     -e clusterName=cluster-a \
     # Ensemble settings: control how messages are replicated across bookies (must not exceed the number of deployed bookies)
     -e managedLedgerDefaultEnsembleSize=2 \

--- a/docs/deploy-docker.md
+++ b/docs/deploy-docker.md
@@ -9,7 +9,7 @@ To deploy a Pulsar cluster on Docker using Docker commands, you need to complete
 
 ## Step 1: Pull a Pulsar image
 
-To run Pulsar on Docker, you need to create a container for each Pulsar component: the metadata store, a bookie, and a broker. This tutorial uses [Oxia](https://github.com/oxia-db/oxia) as the [metadata store](administration-metadata-store.md) (the recommended option for new clusters), which runs from its own image; the bookie and broker run from the Pulsar image.
+To run Pulsar on Docker, you need to create a container for each Pulsar component: the metadata store, a bookie, and a broker. This tutorial uses [Oxia](https://github.com/oxia-db/oxia) as the [metadata store](administration-metadata-store.md) (the recommended option for new clusters), which runs from its own image; the bookie and broker run from the Pulsar image. Oxia standalone serves a single `default` namespace, which both Pulsar and BookKeeper use here; production clusters use separate Oxia namespaces (see [Configure metadata store](administration-metadata-store.md#use-oxia-as-metadata-store)).
 
 You can pull a Pulsar image from Docker Hub with the following command. If you do not want to use some connectors, you can use `apachepulsar/pulsar:latest` there.
 ```bash

--- a/docs/deploy-monitoring.md
+++ b/docs/deploy-monitoring.md
@@ -8,7 +8,7 @@ You can use different ways to monitor a Pulsar cluster, exposing both metrics re
 
 ## Collect metrics
 
-You can collect broker stats, ZooKeeper stats, and BookKeeper stats.
+You can collect broker stats, metadata store stats, and BookKeeper stats.
 
 ### Broker stats
 
@@ -34,9 +34,11 @@ The aggregated broker metrics are also exposed in the [Prometheus](https://prome
 http://$BROKER_ADDRESS:8080/metrics/
 ```
 
-### ZooKeeper stats
+### Metadata store stats
 
-The local ZooKeeper, configuration store server and clients that are shipped with Pulsar can expose detailed stats through Prometheus.
+If you use [Oxia](administration-metadata-store.md) as the metadata store (recommended for new clusters), Oxia exposes its own metrics. Refer to the [Oxia documentation](https://oxia-db.github.io/) for the metrics it provides and how to scrape them.
+
+The stats described below apply when ZooKeeper is the metadata store. The local ZooKeeper, configuration store server and clients that are shipped with Pulsar can expose detailed stats through Prometheus.
 
 ```shell
 http://$LOCAL_ZK_SERVER:8000/metrics

--- a/docs/functions-worker-run-separately.md
+++ b/docs/functions-worker-run-separately.md
@@ -76,7 +76,8 @@ For example, if you use token authentication, you need to configure the followin
 ```yaml
 brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 brokerClientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationMetadataStoreUrl: zk:zookeeper-cluster:2181 # auth requires a connection to zookeeper
+configurationMetadataStoreUrl: oxia://oxia-1.example.com:6648/pulsar # auth requires a connection to the metadata store; Oxia is recommended for new clusters
+# configurationMetadataStoreUrl: zk:zookeeper-cluster:2181 # alternatively, use ZooKeeper as the metadata store
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
 authorizationEnabled: true

--- a/docs/functions-worker-run-separately.md
+++ b/docs/functions-worker-run-separately.md
@@ -76,7 +76,7 @@ For example, if you use token authentication, you need to configure the followin
 ```yaml
 brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
 brokerClientAuthenticationParameters: file:///etc/pulsar/token/admin-token.txt
-configurationMetadataStoreUrl: oxia://oxia-1.example.com:6648/pulsar # auth requires a connection to the metadata store; Oxia is recommended for new clusters
+configurationMetadataStoreUrl: oxia://oxia-1.example.com:6648/broker # auth requires a connection to the metadata store; Oxia is recommended for new clusters
 # configurationMetadataStoreUrl: zk:zookeeper-cluster:2181 # alternatively, use ZooKeeper as the metadata store
 authenticationProviders:
  - "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"

--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -18,7 +18,7 @@ To run Pulsar locally with Docker Compose, follow the steps below.
 
 To get up and run a Pulsar cluster quickly, you can use the following template to create a `compose.yml` file by modifying or adding the configurations in the **environment** section.
 
-This cluster uses [Oxia](https://github.com/oxia-db/oxia) as its [metadata store](administration-metadata-store.md) — the recommended option for new Pulsar clusters.
+This cluster uses [Oxia](https://github.com/oxia-db/oxia) as its [metadata store](administration-metadata-store.md) — the recommended option for new Pulsar clusters. Oxia standalone serves a single `default` namespace, which both Pulsar and BookKeeper use here; production clusters use separate Oxia namespaces (see [Configure metadata store](administration-metadata-store.md#use-oxia-as-metadata-store)).
 
 ```yaml
 version: '3'

--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -18,33 +18,28 @@ To run Pulsar locally with Docker Compose, follow the steps below.
 
 To get up and run a Pulsar cluster quickly, you can use the following template to create a `compose.yml` file by modifying or adding the configurations in the **environment** section.
 
+This cluster uses [Oxia](https://github.com/oxia-db/oxia) as its [metadata store](administration-metadata-store.md) — the recommended option for new Pulsar clusters.
+
 ```yaml
 version: '3'
 networks:
   pulsar:
     driver: bridge
 services:
-  # Start zookeeper
-  zookeeper:
-    image: apachepulsar/pulsar:latest
-    container_name: zookeeper
+  # Start Oxia (metadata store)
+  oxia:
+    image: oxia/oxia:latest
+    container_name: oxia
     restart: on-failure
     networks:
       - pulsar
     volumes:
-      - ./data/zookeeper:/pulsar/data/zookeeper
-    environment:
-      - metadataStoreUrl=zk:zookeeper:2181
-      - PULSAR_MEM=-Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m
+      - oxia-data:/data
     command:
-      - bash
-      - -c
-      - |
-        bin/apply-config-from-env.py conf/zookeeper.conf && \
-        bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
-        exec bin/pulsar zookeeper
+      - oxia
+      - standalone
     healthcheck:
-      test: ["CMD", "bin/pulsar-zookeeper-ruok.sh"]
+      test: ["CMD", "oxia", "health", "--port=6648"]
       interval: 10s
       timeout: 5s
       retries: 30
@@ -62,12 +57,12 @@ services:
       - |
         bin/pulsar initialize-cluster-metadata \
         --cluster cluster-a \
-        --zookeeper zookeeper:2181 \
-        --configuration-store zookeeper:2181 \
+        --metadata-store oxia://oxia:6648/default \
+        --configuration-store oxia://oxia:6648/default \
         --web-service-url http://broker:8080 \
         --broker-service-url pulsar://broker:6650
     depends_on:
-      zookeeper:
+      oxia:
         condition: service_healthy
 
   # Start bookie
@@ -79,20 +74,16 @@ services:
       - pulsar
     environment:
       - clusterName=cluster-a
-      - zkServers=zookeeper:2181
-      - metadataServiceUri=metadata-store:zk:zookeeper:2181
-      # otherwise every time we run docker compose up or down we fail to start due to Cookie
-      # See: https://github.com/apache/bookkeeper/blob/405e72acf42bb1104296447ea8840d805094c787/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java#L57-68
+      - metadataServiceUri=metadata-store:oxia://oxia:6648/default
       - advertisedAddress=bookie
       - BOOKIE_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
     depends_on:
-      zookeeper:
+      oxia:
         condition: service_healthy
       pulsar-init:
         condition: service_completed_successfully
-    # Map the local directory to the container to avoid bookie startup failure due to insufficient container disks.
     volumes:
-      - ./data/bookkeeper:/pulsar/data/bookkeeper
+      - bookie-data:/pulsar/data/bookkeeper
     command: bash -c "bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
 
   # Start broker
@@ -104,8 +95,7 @@ services:
     networks:
       - pulsar
     environment:
-      - metadataStoreUrl=zk:zookeeper:2181
-      - zookeeperServers=zookeeper:2181
+      - metadataStoreUrl=oxia://oxia:6648/default
       - clusterName=cluster-a
       - managedLedgerDefaultEnsembleSize=1
       - managedLedgerDefaultWriteQuorum=1
@@ -114,7 +104,7 @@ services:
       - advertisedListeners=external:pulsar://127.0.0.1:6650
       - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
     depends_on:
-      zookeeper:
+      oxia:
         condition: service_healthy
       bookie:
         condition: service_started
@@ -122,30 +112,13 @@ services:
       - "6650:6650"
       - "8080:8080"
     command: bash -c "bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker"
+
+volumes:
+  oxia-data:
+  bookie-data:
 ```
 
 ## Step 2: Create a Pulsar cluster
-
-As preparation, create the data directories that the `compose.yml` file will bind-mount into the Pulsar containers.
-
-On Linux, the mounted directories need to be owned by uid `10000` -- the default user inside the Pulsar Docker container -- so the containers can write to them:
-
-```bash
-sudo mkdir -p ./data/zookeeper ./data/bookkeeper
-sudo chown -R 10000 data
-```
-
-:::note macOS and Windows (Docker Desktop)
-
-On macOS and Windows, Docker Desktop runs containers inside a Linux VM and handles uid remapping for bind mounts for you, so the `chown -R 10000` step is not required and running it with `sudo` will typically fail or leave the files in a state that prevents `docker compose up` from starting cleanly (the bookie/zookeeper containers fail with permission errors on `./data/...`).
-
-If you see permission errors on startup, remove the `./data` directory (or reset its ownership to your user) and create it without `chown`:
-
-```bash
-mkdir -p ./data/zookeeper ./data/bookkeeper
-```
-
-:::
 
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 
@@ -153,10 +126,16 @@ To create a Pulsar cluster by using the `compose.yml` file, run the following co
 docker compose up -d
 ```
 
+:::note
+
+This cluster persists its metadata and message data in named Docker volumes (`oxia-data` and `bookie-data`), so it survives `docker compose down` and `docker compose up`. To wipe the data and start completely fresh, run `docker compose down -v`.
+
+:::
+
 ## Step 3: Destroy the Pulsar cluster
 
-If you want to destroy the Pulsar cluster with all the containers, run the following command. It will also delete the network that the containers are connected to.
+If you want to destroy the Pulsar cluster with all the containers, run the following command. The `-v` flag also removes the named volumes (the cluster's data), and the network that the containers are connected to.
 
 ```bash
-docker compose down
+docker compose down -v
 ```

--- a/docs/helm-deploy.md
+++ b/docs/helm-deploy.md
@@ -102,6 +102,12 @@ components:
   pulsar_manager: true
 ```
 
+:::tip Use Oxia as the metadata store
+
+For new clusters, [Oxia](https://github.com/oxia-db/oxia) is the recommended metadata store. The Pulsar Helm chart can deploy Oxia instead of ZooKeeper — set `components.oxia: true` and `components.zookeeper: false` in your values file. The chart then points the broker's `metadataStoreUrl` and BookKeeper's `metadataServiceUri` at the Oxia cluster automatically. See the chart's [`values.yaml`](https://github.com/apache/pulsar-helm-chart/blob/master/charts/pulsar/values.yaml) for Oxia options (such as `oxia.initialShardCount` and `oxia.replicationFactor`) and for any feature limitations.
+
+:::
+
 ##### Monitoring Components
 
 The Pulsar Helm Chart installs monitoring components using a dependent Helm chart, [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts). You can customize this Helm chart to specify which monitoring components to install. These components are enabled by default.

--- a/src/components/pages/HomePage/HowPulsarWorks/HowPulsarWorks.tsx
+++ b/src/components/pages/HomePage/HowPulsarWorks/HowPulsarWorks.tsx
@@ -8,7 +8,7 @@ import illustrationMobile from '!!raw-loader!./img/illustration-mobile.svg';
 
 import BookkeeperIcon from './img/bookkeeper.svg';
 import BrokersIcon from './img/brokers.svg';
-import ZookeeperIcon from './img/zookeeper.svg';
+import MetadataStoreIcon from './img/zookeeper.svg';
 import ProducerAndConsumerIcon from './img/producer-and-consumer.svg';
 import Slider from '@site/src/components/ui/Slider/Slider';
 
@@ -25,12 +25,13 @@ const cards: CardProps[] = [
     )
   },
   {
-    title: 'Apache Zookeeper',
-    image: <ZookeeperIcon />,
+    title: 'Metadata Store',
+    image: <MetadataStoreIcon />,
     children: (
       <p>
-        Pulsar and BookKeeper use Apache ZooKeeper to save metadata coordinated between nodes,
+        Pulsar and BookKeeper use a metadata store to save metadata coordinated between nodes,
         such as a list of ledgers per topic, segments per ledger, and mapping of topic bundles to a broker.
+        New clusters use <a href="https://github.com/oxia-db/oxia">Oxia</a> (recommended); Apache ZooKeeper is also supported.
         It’s a cluster of highly available and replicated servers (usually 3).
       </p>
     )

--- a/static/assets/broker-bookie.svg
+++ b/static/assets/broker-bookie.svg
@@ -1,0 +1,60 @@
+<svg viewBox="0 0 720 430" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bbt bbd">
+  <title id="bbt">Brokers and bookies in a Pulsar cluster</title>
+  <desc id="bbd">A producer and consumer connect to one of three brokers; the serving broker fans out to five bookies for storage. An Oxia metadata store sits alongside within the Pulsar cluster.</desc>
+  <defs>
+    <linearGradient id="bx" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f2f8fe"/><stop offset="0.5" stop-color="#cfe0f6"/>
+      <stop offset="0.5" stop-color="#aecbef"/><stop offset="1" stop-color="#6b9bd8"/>
+    </linearGradient>
+    <marker id="g" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#8893a5"/></marker>
+  </defs>
+
+  <rect x="16" y="104" width="688" height="310" rx="12" fill="none" stroke="#333333" stroke-width="1.5" stroke-dasharray="7 5"/>
+  <text x="694" y="404" text-anchor="end" font-family="sans-serif" font-size="17" font-style="italic" font-weight="700" fill="#2f5aa6">Pulsar Cluster</text>
+
+  <!-- Producer / Consumer -->
+  <rect x="232" y="12" width="124" height="48" rx="7" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="294" y="42" text-anchor="middle" font-family="sans-serif" font-size="15" fill="#34425c">Producer</text>
+  <rect x="372" y="12" width="124" height="48" rx="7" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="434" y="42" text-anchor="middle" font-family="sans-serif" font-size="15" fill="#34425c">Consumer</text>
+
+  <!-- Brokers -->
+  <rect x="46" y="150" width="170" height="72" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="131" y="192" text-anchor="middle" font-family="sans-serif" font-size="17" fill="#34425c">Broker 1</text>
+  <rect x="258" y="150" width="170" height="72" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="343" y="192" text-anchor="middle" font-family="sans-serif" font-size="17" fill="#34425c">Broker 2</text>
+  <rect x="470" y="150" width="170" height="72" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="555" y="192" text-anchor="middle" font-family="sans-serif" font-size="17" fill="#34425c">Broker 3</text>
+
+  <!-- Metadata store (was ZK) -->
+  <rect x="566" y="250" width="120" height="52" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+  <text x="626" y="282" text-anchor="middle" font-family="sans-serif" font-size="17" font-weight="600" fill="#34425c">Oxia</text>
+
+  <!-- Bookies -->
+  <g font-family="sans-serif" font-size="13" fill="#34425c" text-anchor="middle">
+    <rect x="42" y="320" width="118" height="74" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+    <text x="101" y="352">Bookie</text><text x="101" y="372">1</text>
+    <rect x="174" y="320" width="118" height="74" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+    <text x="233" y="352">Bookie</text><text x="233" y="372">2</text>
+    <rect x="306" y="320" width="118" height="74" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+    <text x="365" y="352">Bookie</text><text x="365" y="372">3</text>
+    <rect x="438" y="320" width="118" height="74" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+    <text x="497" y="352">Bookie</text><text x="497" y="372">4</text>
+    <rect x="570" y="320" width="118" height="74" rx="8" fill="url(#bx)" stroke="#4d7cbe"/>
+    <text x="629" y="352">Bookie</text><text x="629" y="372">5</text>
+  </g>
+
+  <!-- Broker 2 -> bookies -->
+  <g fill="none" stroke="#8893a5" stroke-width="1.5">
+    <path d="M335,224 L110,318" marker-end="url(#g)"/>
+    <path d="M339,224 L240,318" marker-end="url(#g)"/>
+    <path d="M343,224 L365,316" marker-end="url(#g)"/>
+    <path d="M347,224 L490,318" marker-end="url(#g)"/>
+    <path d="M351,224 L620,318" marker-end="url(#g)"/>
+  </g>
+
+  <!-- Producer -> Broker 2 (down) -->
+  <polygon points="314,64 336,64 336,116 352,116 325,147 298,116 314,116" fill="#f9d2a8" stroke="#e0702c" stroke-width="1.5"/>
+  <!-- Broker 2 -> Consumer (up) -->
+  <polygon points="420,64 447,95 431,95 431,147 409,147 409,95 393,95" fill="#f9d2a8" stroke="#e0702c" stroke-width="1.5"/>
+</svg>

--- a/static/assets/pulsar-basic-setup.svg
+++ b/static/assets/pulsar-basic-setup.svg
@@ -1,0 +1,46 @@
+<svg viewBox="0 0 560 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bttl bdsc">
+  <title id="bttl">Basic setup of a Pulsar cluster</title>
+  <desc id="bdsc">Connecting clients reach a single DNS name that fronts a Pulsar cluster of broker plus bookie nodes; those nodes coordinate through a metadata store, with Oxia as the recommended option.</desc>
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#6f7e95"/></marker>
+  </defs>
+
+  <rect x="24" y="24" width="512" height="392" rx="10" fill="#ffffff" stroke="#2b2b2b" stroke-width="2"/>
+  <text x="52" y="64" font-family="sans-serif" font-size="22" font-weight="700" fill="#222">Pulsar cluster</text>
+
+  <!-- Metadata store node (stacked) -->
+  <rect x="70" y="150" width="150" height="108" rx="6" fill="#fafafa" stroke="#9a9a9a"/>
+  <rect x="78" y="158" width="150" height="108" rx="6" fill="#f4f4f4" stroke="#949494"/>
+  <rect x="86" y="166" width="150" height="108" rx="6" fill="#eef0f2" stroke="#8a8a8a"/>
+  <text x="161" y="214" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#555">Metadata store</text>
+  <text x="161" y="236" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#235aa8">Oxia</text>
+
+  <!-- Broker + bookie node (stacked) -->
+  <rect x="330" y="120" width="168" height="188" rx="8" fill="#fbfbfb" stroke="#9aa0a6"/>
+  <rect x="322" y="128" width="168" height="188" rx="8" fill="#fdfdfd" stroke="#9aa0a6"/>
+  <rect x="314" y="136" width="168" height="188" rx="8" fill="#ffffff" stroke="#9aa0a6"/>
+  <rect x="339" y="162" width="118" height="60" rx="14" fill="#eaf4ff" stroke="#2f9fe0" stroke-width="2"/>
+  <text x="398" y="187" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="700" fill="#1f6fb0">Pulsar</text>
+  <text x="398" y="206" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="700" fill="#1f6fb0">broker</text>
+  <rect x="339" y="236" width="118" height="60" rx="14" fill="#fdf0e0" stroke="#d98a3a" stroke-width="2"/>
+  <text x="398" y="261" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#c0782a">BookKeeper</text>
+  <text x="398" y="280" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#c0782a">bookie</text>
+
+  <!-- broker/bookie -> metadata store -->
+  <path d="M314,214 L240,214" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+
+  <!-- DNS name box -->
+  <rect x="140" y="382" width="300" height="72" rx="4" fill="#f8e6a8" stroke="#d9b24a" stroke-width="1.5"/>
+  <text x="290" y="410" text-anchor="middle" font-family="sans-serif" font-size="15" fill="#5a4a1a">DNS name</text>
+  <text x="290" y="436" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="700" fill="#3a3000">pulsar-cluster.acme.com</text>
+
+  <!-- DNS -> broker/bookie -->
+  <path d="M366,382 L366,352 L398,352 L398,326" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+
+  <!-- Connecting clients -->
+  <rect x="150" y="520" width="280" height="90" rx="2" fill="#ffffff" stroke="#2b2b2b" stroke-width="1.5"/>
+  <text x="290" y="571" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#222">Connecting clients</text>
+
+  <!-- clients -> DNS -->
+  <path d="M290,520 L290,456" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+</svg>

--- a/static/assets/pulsar-service-discovery.svg
+++ b/static/assets/pulsar-service-discovery.svg
@@ -1,0 +1,46 @@
+<svg viewBox="0 0 560 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="sdt sdd">
+  <title id="sdt">Service discovery in Pulsar</title>
+  <desc id="sdd">Connecting clients reach a single DNS name that fronts a Pulsar cluster of broker plus bookie nodes; those nodes coordinate through a metadata store, with Oxia as the recommended option.</desc>
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#6f7e95"/></marker>
+  </defs>
+
+  <rect x="24" y="24" width="512" height="392" rx="10" fill="#ffffff" stroke="#2b2b2b" stroke-width="2"/>
+  <text x="52" y="64" font-family="sans-serif" font-size="22" font-weight="700" fill="#222">Pulsar cluster</text>
+
+  <!-- Metadata store node (stacked) -->
+  <rect x="70" y="150" width="150" height="108" rx="6" fill="#fafafa" stroke="#9a9a9a"/>
+  <rect x="78" y="158" width="150" height="108" rx="6" fill="#f4f4f4" stroke="#949494"/>
+  <rect x="86" y="166" width="150" height="108" rx="6" fill="#eef0f2" stroke="#8a8a8a"/>
+  <text x="161" y="214" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#555">Metadata store</text>
+  <text x="161" y="236" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#235aa8">Oxia</text>
+
+  <!-- Broker + bookie node (stacked) -->
+  <rect x="330" y="120" width="168" height="188" rx="8" fill="#fbfbfb" stroke="#9aa0a6"/>
+  <rect x="322" y="128" width="168" height="188" rx="8" fill="#fdfdfd" stroke="#9aa0a6"/>
+  <rect x="314" y="136" width="168" height="188" rx="8" fill="#ffffff" stroke="#9aa0a6"/>
+  <rect x="339" y="162" width="118" height="60" rx="14" fill="#eaf4ff" stroke="#2f9fe0" stroke-width="2"/>
+  <text x="398" y="187" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="700" fill="#1f6fb0">Pulsar</text>
+  <text x="398" y="206" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="700" fill="#1f6fb0">broker</text>
+  <rect x="339" y="236" width="118" height="60" rx="14" fill="#fdf0e0" stroke="#d98a3a" stroke-width="2"/>
+  <text x="398" y="261" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#c0782a">BookKeeper</text>
+  <text x="398" y="280" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#c0782a">bookie</text>
+
+  <!-- broker/bookie -> metadata store -->
+  <path d="M314,214 L240,214" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+
+  <!-- DNS name box -->
+  <rect x="140" y="382" width="300" height="72" rx="4" fill="#f8e6a8" stroke="#d9b24a" stroke-width="1.5"/>
+  <text x="290" y="410" text-anchor="middle" font-family="sans-serif" font-size="15" fill="#5a4a1a">DNS name</text>
+  <text x="290" y="436" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="700" fill="#3a3000">pulsar-cluster.acme.com</text>
+
+  <!-- DNS -> broker/bookie -->
+  <path d="M366,382 L366,352 L398,352 L398,326" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+
+  <!-- Connecting clients -->
+  <rect x="150" y="520" width="280" height="90" rx="2" fill="#ffffff" stroke="#2b2b2b" stroke-width="1.5"/>
+  <text x="290" y="571" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#222">Connecting clients</text>
+
+  <!-- clients -> DNS -->
+  <path d="M290,520 L290,456" fill="none" stroke="#6f7e95" stroke-width="2" marker-end="url(#a)"/>
+</svg>

--- a/static/assets/pulsar-system-architecture.svg
+++ b/static/assets/pulsar-system-architecture.svg
@@ -1,0 +1,71 @@
+<svg viewBox="0 0 640 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
+  <title id="ttl">Apache Pulsar cluster architecture</title>
+  <desc id="dsc">Producer and consumer apps connect to a Pulsar cluster of stateless brokers, which store data in BookKeeper bookies and coordinate through a metadata store; Oxia is the recommended metadata store, with a configuration store for instance-wide state.</desc>
+  <defs>
+    <linearGradient id="appGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#c2cdf0"/><stop offset="1" stop-color="#8fa3e1"/>
+    </linearGradient>
+    <linearGradient id="brokerGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#dde9fa"/><stop offset="1" stop-color="#6f9fda"/>
+    </linearGradient>
+    <linearGradient id="bookieGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9cc0ea"/><stop offset="1" stop-color="#4f86d0"/>
+    </linearGradient>
+    <linearGradient id="oxiaGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3f7fd0"/><stop offset="1" stop-color="#235aa8"/>
+    </linearGradient>
+    <marker id="aO" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#e8884a"/></marker>
+    <marker id="aOs" markerWidth="9" markerHeight="9" refX="0" refY="3" orient="auto"><path d="M6,0 L0,3 L6,6 Z" fill="#e8884a"/></marker>
+    <marker id="aG" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#6f7e95"/></marker>
+    <marker id="aGs" markerWidth="9" markerHeight="9" refX="0" refY="3" orient="auto"><path d="M6,0 L0,3 L6,6 Z" fill="#6f7e95"/></marker>
+  </defs>
+
+  <!-- Cluster boundary -->
+  <rect x="150" y="32" width="342" height="316" rx="14" fill="#f4f8ff" stroke="#4a78c0" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text x="321" y="50" text-anchor="middle" font-family="sans-serif" font-size="13" font-style="italic" font-weight="700" fill="#2f5aa6">Pulsar Cluster</text>
+
+  <!-- Producer / Consumer apps -->
+  <rect x="18" y="150" width="104" height="58" rx="8" fill="url(#appGrad)" stroke="#6c7fc0"/>
+  <text x="70" y="184" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="600" fill="#1d2c66">Producer App</text>
+  <rect x="518" y="150" width="104" height="58" rx="8" fill="url(#appGrad)" stroke="#6c7fc0"/>
+  <text x="570" y="184" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="600" fill="#1d2c66">Consumer App</text>
+
+  <!-- Brokers (stacked) -->
+  <rect x="238" y="90" width="168" height="64" rx="8" fill="#5f8fcf"/>
+  <rect x="235" y="87" width="168" height="64" rx="8" fill="#6896d4"/>
+  <rect x="232" y="84" width="168" height="64" rx="8" fill="url(#brokerGrad)" stroke="#4f7fc4"/>
+  <text x="316" y="113" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#13284e">Brokers</text>
+  <text x="316" y="130" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#2c4a7a">stateless</text>
+
+  <!-- Bookies (stacked) -->
+  <rect x="202" y="236" width="112" height="60" rx="8" fill="#4178bf"/>
+  <rect x="199" y="233" width="112" height="60" rx="8" fill="#487fc6"/>
+  <rect x="196" y="230" width="112" height="60" rx="8" fill="url(#bookieGrad)" stroke="#3a6fb0"/>
+  <text x="252" y="256" text-anchor="middle" font-family="sans-serif" font-size="13.5" font-weight="700" fill="#ffffff">Bookies</text>
+  <text x="252" y="272" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#e7f1fc">BookKeeper</text>
+
+  <!-- Metadata store (Oxia) -->
+  <rect x="330" y="230" width="142" height="60" rx="8" fill="url(#oxiaGrad)" stroke="#1c4e96"/>
+  <text x="401" y="256" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#ffffff">Metadata store</text>
+  <text x="401" y="272" text-anchor="middle" font-family="sans-serif" font-size="10.5" fill="#dcebff">Oxia (recommended)</text>
+
+  <!-- Configuration store -->
+  <rect x="206" y="306" width="230" height="30" rx="6" fill="#2f68b4" stroke="#1c4e96"/>
+  <text x="321" y="325" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="600" fill="#ffffff">Configuration store — Oxia</text>
+
+  <!-- Arrows: data (orange) -->
+  <path d="M122,176 C170,168 196,140 230,124" fill="none" stroke="#e8884a" stroke-width="2.4" marker-end="url(#aO)"/>
+  <path d="M402,124 C440,140 472,168 518,176" fill="none" stroke="#e8884a" stroke-width="2.4" marker-end="url(#aO)"/>
+  <path d="M300,150 L262,228" fill="none" stroke="#e8884a" stroke-width="2.4" marker-start="url(#aOs)" marker-end="url(#aO)"/>
+
+  <!-- Arrows: metadata / coordination (gray) -->
+  <path d="M352,150 L398,226" fill="none" stroke="#6f7e95" stroke-width="1.8" marker-start="url(#aGs)" marker-end="url(#aG)"/>
+  <path d="M310,262 L328,262" fill="none" stroke="#6f7e95" stroke-width="1.8" marker-start="url(#aGs)" marker-end="url(#aG)"/>
+  <path d="M401,290 L350,306" fill="none" stroke="#6f7e95" stroke-width="1.6"/>
+
+  <!-- Legend -->
+  <line x1="26" y1="250" x2="52" y2="250" stroke="#e8884a" stroke-width="2.4"/>
+  <text x="58" y="254" font-family="sans-serif" font-size="10.5" fill="#3a4a63">message data</text>
+  <line x1="26" y1="268" x2="52" y2="268" stroke="#6f7e95" stroke-width="1.8"/>
+  <text x="58" y="272" font-family="sans-serif" font-size="10.5" fill="#3a4a63">metadata / coordination</text>
+</svg>


### PR DESCRIPTION
## What

Makes **Oxia** the primary/recommended metadata store across the next (5.0) docs, with **ZooKeeper** retained as a fully-supported secondary option. Released `versioned_docs` are unchanged.

## Changes

- **Metadata store & architecture** — `administration-metadata-store` and `concepts-architecture-overview` lead with Oxia; backends reordered (Oxia → ZooKeeper → etcd → RocksDB → memory); configuration-store prose generalized to be backend-neutral.
- **`administration-zk-bk` renamed → "Metadata store & BookKeeper"**, leading with an Oxia section; the ZooKeeper deployment steps are kept as the in-tarball alternative. (Doc id unchanged, so existing links/anchors still resolve.)
- **Deployment guides** — bare-metal, multi-cluster, Helm (documents the `components.oxia` toggle), and AWS lead with Oxia and link to the Oxia docs.
- **Container quickstarts** — docker-compose and `docker run` now run **Oxia standalone** (`oxia/oxia`, `oxia://oxia:6648/default`, `oxia health` healthcheck) with persistent Docker volumes, instead of ZooKeeper.
- **Supporting docs** — proxy, bookkeeper `metadataServiceUri`, functions worker, upgrade, and monitoring show Oxia-first configuration.
- **Homepage** — the "How Pulsar Works" card is now Metadata Store / Oxia.
- **Diagrams** — redrew the four architecture diagrams that showed ZooKeeper (system architecture, basic setup, broker/bookie, service discovery) as SVGs with Oxia. The original PNGs are kept because they are still referenced by older `versioned_docs`.

## Notes

- The local standalone default stays RocksDB (unchanged).
- For Oxia cluster deployment, the docs link to https://oxia-db.github.io/ rather than duplicating it.
- `docusaurus build` (current version) passes.
