### PR TITLE
docs: clarify Helm getting started client setup

### DIFF
--- a/docs/getting-started-helm.md
+++ b/docs/getting-started-helm.md
@@ -292,6 +292,8 @@ webServiceUrl=http://127.0.0.1:61853/
 brokerServiceUrl=pulsar://127.0.0.1:61854/
 ```
 
+Save these URLs because you will need them when configuring `${PULSAR_HOME}/conf/client.conf` in step 4 below.
+
 Then you can proceed with the following steps:
 
 1. Download the Apache Pulsar tarball from the [downloads page](/download/).
@@ -316,7 +318,7 @@ Then you can proceed with the following steps:
 
    In the `${PULSAR_HOME}/conf/client.conf` file, replace `webServiceUrl` and `brokerServiceUrl` with the service URLs you get from the above steps.
 
-5. Create a subscription to consume messages from `apache/pulsar/test-topic`.
+5. In the same terminal where you exported `PULSAR_HOME` in the previous steps, create a subscription to consume messages from `apache/pulsar/test-topic`.
 
    ```bash
    bin/pulsar-client consume -s sub apache/pulsar/test-topic  -n 0

--- a/versioned_docs/version-4.0.x/getting-started-helm.md
+++ b/versioned_docs/version-4.0.x/getting-started-helm.md
@@ -280,6 +280,8 @@ webServiceUrl=http://127.0.0.1:61853/
 brokerServiceUrl=pulsar://127.0.0.1:61854/
 ```
 
+Save these URLs because you will need them when configuring `${PULSAR_HOME}/conf/client.conf` in step 4 below.
+
 Then you can proceed with the following steps:
 
 1. Download the Apache Pulsar tarball from the [downloads page](/download/).
@@ -304,7 +306,7 @@ Then you can proceed with the following steps:
 
    In the `${PULSAR_HOME}/conf/client.conf` file, replace `webServiceUrl` and `brokerServiceUrl` with the service URLs you get from the above steps.
 
-5. Create a subscription to consume messages from `apache/pulsar/test-topic`.
+5. In the same terminal where you exported `PULSAR_HOME` in the previous steps, create a subscription to consume messages from `apache/pulsar/test-topic`.
 
    ```bash
    bin/pulsar-client consume -s sub apache/pulsar/test-topic  -n 0

--- a/versioned_docs/version-4.2.x/getting-started-helm.md
+++ b/versioned_docs/version-4.2.x/getting-started-helm.md
@@ -280,6 +280,8 @@ webServiceUrl=http://127.0.0.1:61853/
 brokerServiceUrl=pulsar://127.0.0.1:61854/
 ```
 
+Save these URLs because you will need them when configuring `${PULSAR_HOME}/conf/client.conf` in step 4 below.
+
 Then you can proceed with the following steps:
 
 1. Download the Apache Pulsar tarball from the [downloads page](/download/).
@@ -304,7 +306,7 @@ Then you can proceed with the following steps:
 
    In the `${PULSAR_HOME}/conf/client.conf` file, replace `webServiceUrl` and `brokerServiceUrl` with the service URLs you get from the above steps.
 
-5. Create a subscription to consume messages from `apache/pulsar/test-topic`.
+5. In the same terminal where you exported `PULSAR_HOME` in the previous steps, create a subscription to consume messages from `apache/pulsar/test-topic`.
 
    ```bash
    bin/pulsar-client consume -s sub apache/pulsar/test-topic  -n 0

--- a/versioned_docs/version-5.0.x/getting-started-helm.md
+++ b/versioned_docs/version-5.0.x/getting-started-helm.md
@@ -292,6 +292,8 @@ webServiceUrl=http://127.0.0.1:61853/
 brokerServiceUrl=pulsar://127.0.0.1:61854/
 ```
 
+Save these URLs because you will need them when configuring `${PULSAR_HOME}/conf/client.conf` in step 4 below.
+
 Then you can proceed with the following steps:
 
 1. Download the Apache Pulsar tarball from the [downloads page](/download/).
@@ -316,7 +318,7 @@ Then you can proceed with the following steps:
 
    In the `${PULSAR_HOME}/conf/client.conf` file, replace `webServiceUrl` and `brokerServiceUrl` with the service URLs you get from the above steps.
 
-5. Create a subscription to consume messages from `apache/pulsar/test-topic`.
+5. In the same terminal where you exported `PULSAR_HOME` in the previous steps, create a subscription to consume messages from `apache/pulsar/test-topic`.
 
    ```bash
    bin/pulsar-client consume -s sub apache/pulsar/test-topic  -n 0


### PR DESCRIPTION
Fixes apache/pulsar#20973

## Motivation
Step 3 of the Kubernetes Helm getting-started guide did not tell users to keep service URLs for later client configuration, or where to run the first `pulsar-client consume` command.

## Modifications
- Add a sentence after the service URL examples telling users to save the URLs for `${PULSAR_HOME}/conf/client.conf`.
- Clarify Step 3 item 5 should run in the same local terminal where `PULSAR_HOME` was exported.
- Propagate the change to supported versioned docs (4.0.x, 4.2.x, 5.0.x).

## Preview
Verified locally with `./preview.sh --clean 5.0.x`.

<img width="1905" height="940" alt="image" src="https://github.com/user-attachments/assets/810dd559-5b90-46f4-aabf-f9df62271d99" />

<img width="1902" height="945" alt="image" src="https://github.com/user-attachments/assets/f05f8faf-3453-46e5-bc26-4252c079c572" />
