### PR TITLE
[improve][doc] Document producerConfig.batchingConfig for Pulsar Functions

### DIFF
--- a/docs/functions-cli.md
+++ b/docs/functions-cli.md
@@ -91,8 +91,9 @@ The following table outlines the nested fields and related arguments under the `
 | maxPendingMessagesAcrossPartitions | Int                           | N/A                      | The number of `maxPendingMessages` across all partitions. |
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
-| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>|
+| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`.<br />**Note:** If `batchingConfig.batchBuilder` is also set, that value takes precedence over this one. |
+| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li><br />**Note:** The Go client does not implement `SNAPPY`; a Go function configured with it falls back to `LZ4`. |
+| batchingConfig                     | [BatchingConfig](#batchingconfig) | N/A                  | The batching settings applied to the producer. When omitted, batching is enabled with a maximum publish delay of 10 ms. |
 
 ###### Resources
 
@@ -132,6 +133,33 @@ The following table outlines the nested fields and related arguments under the `
 | producerCryptoFailureAction | ProducerCryptoFailureAction | N/A                      | N/A   |
 | consumerCryptoFailureAction | ConsumerCryptoFailureAction | N/A                      | N/A   |
 
+
+###### BatchingConfig
+
+The following table outlines the nested fields under the `batchingConfig` field of `producerConfig`.
+These settings were introduced by [PIP-401](https://github.com/apache/pulsar/blob/master/pip/pip-401.md).
+
+:::note
+
+`batchingConfig` is currently applied by **Java** functions only. The Python and Go runtimes hard-code
+batching to enabled with a 10 ms maximum publish delay and ignore these settings
+([#26390](https://github.com/apache/pulsar/issues/26390),
+[#26391](https://github.com/apache/pulsar/issues/26391)).
+
+:::
+
+| Field Name                | Type    | Related Command Argument | Description   |
+|---------------------------|---------|--------------------------|---------------|
+| enabled                   | Boolean | N/A                      | Whether the producer batches messages. The default value is `true`. |
+| batchingMaxPublishDelayMs | Int     | N/A                      | The maximum time the producer waits before sending a batch, in milliseconds. The default value is `10`. |
+| batchingMaxMessages       | Int     | N/A                      | The maximum number of messages in a batch. When unset, the client default applies. |
+| batchingMaxBytes          | Int     | N/A                      | The maximum size of a batch, in bytes. When unset, the client default applies. |
+| batchBuilder              | String  | N/A                      | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. Takes precedence over `producerConfig.batchBuilder`. |
+| roundRobinRouterBatchingPartitionSwitchFrequency | Int | N/A | How often the round-robin router switches partitions for non-keyed messages, as a multiple of `batchingMaxPublishDelayMs`. The partition switch period is `frequency * batchingMaxPublishDelayMs`. |
+
+A function that sets no `producerConfig`, or a `producerConfig` with no `batchingConfig`, gets batching
+enabled with a maximum publish delay of 10 ms. This is the behaviour functions had before these settings
+became configurable, and it is the same across the Java, Python, and Go runtimes.
 
 ### Example
 

--- a/versioned_docs/version-4.2.x/functions-cli.md
+++ b/versioned_docs/version-4.2.x/functions-cli.md
@@ -91,8 +91,9 @@ The following table outlines the nested fields and related arguments under the `
 | maxPendingMessagesAcrossPartitions | Int                           | N/A                      | The number of `maxPendingMessages` across all partitions. |
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
-| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>|
+| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`.<br />**Note:** If `batchingConfig.batchBuilder` is also set, that value takes precedence over this one. |
+| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li><br />**Note:** The Go client does not implement `SNAPPY`; a Go function configured with it falls back to `LZ4`. |
+| batchingConfig                     | [BatchingConfig](#batchingconfig) | N/A                  | The batching settings applied to the producer. When omitted, batching is enabled with a maximum publish delay of 10 ms. |
 
 ###### Resources
 
@@ -132,6 +133,33 @@ The following table outlines the nested fields and related arguments under the `
 | producerCryptoFailureAction | ProducerCryptoFailureAction | N/A                      | N/A   |
 | consumerCryptoFailureAction | ConsumerCryptoFailureAction | N/A                      | N/A   |
 
+
+###### BatchingConfig
+
+The following table outlines the nested fields under the `batchingConfig` field of `producerConfig`.
+These settings were introduced by [PIP-401](https://github.com/apache/pulsar/blob/master/pip/pip-401.md).
+
+:::note
+
+`batchingConfig` is currently applied by **Java** functions only. The Python and Go runtimes hard-code
+batching to enabled with a 10 ms maximum publish delay and ignore these settings
+([#26390](https://github.com/apache/pulsar/issues/26390),
+[#26391](https://github.com/apache/pulsar/issues/26391)).
+
+:::
+
+| Field Name                | Type    | Related Command Argument | Description   |
+|---------------------------|---------|--------------------------|---------------|
+| enabled                   | Boolean | N/A                      | Whether the producer batches messages. The default value is `true`. |
+| batchingMaxPublishDelayMs | Int     | N/A                      | The maximum time the producer waits before sending a batch, in milliseconds. The default value is `10`. |
+| batchingMaxMessages       | Int     | N/A                      | The maximum number of messages in a batch. When unset, the client default applies. |
+| batchingMaxBytes          | Int     | N/A                      | The maximum size of a batch, in bytes. When unset, the client default applies. |
+| batchBuilder              | String  | N/A                      | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. Takes precedence over `producerConfig.batchBuilder`. |
+| roundRobinRouterBatchingPartitionSwitchFrequency | Int | N/A | How often the round-robin router switches partitions for non-keyed messages, as a multiple of `batchingMaxPublishDelayMs`. The partition switch period is `frequency * batchingMaxPublishDelayMs`. |
+
+A function that sets no `producerConfig`, or a `producerConfig` with no `batchingConfig`, gets batching
+enabled with a maximum publish delay of 10 ms. This is the behaviour functions had before these settings
+became configurable, and it is the same across the Java, Python, and Go runtimes.
 
 ### Example
 

--- a/versioned_docs/version-5.0.x/functions-cli.md
+++ b/versioned_docs/version-5.0.x/functions-cli.md
@@ -91,8 +91,9 @@ The following table outlines the nested fields and related arguments under the `
 | maxPendingMessagesAcrossPartitions | Int                           | N/A                      | The number of `maxPendingMessages` across all partitions. |
 | useThreadLocalProducers            | Boolean                       | N/A                      | N/A                             |
 | cryptoConfig                       | [CryptoConfig](#cryptoconfig) | N/A                      | Refer to [code](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/CryptoConfig.java).|
-| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`. |
-| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li>|
+| batchBuilder                       | String                        | `--batch-builder`        | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. The default value is `DEFAULT`.<br />**Note:** If `batchingConfig.batchBuilder` is also set, that value takes precedence over this one. |
+| compressionType                      | String                        | N/A                      | Message data compression type used by a producer. The default value is [`LZ4`](https://github.com/lz4/lz4). <br />Available options:<li>`NONE` (no compression)</li><li>[`ZLIB`](https://zlib.net/)<br /></li><li>[`ZSTD`](https://facebook.github.io/zstd/)</li><li>[`SNAPPY`](https://google.github.io/snappy/)</li><br />**Note:** The Go client does not implement `SNAPPY`; a Go function configured with it falls back to `LZ4`. |
+| batchingConfig                     | [BatchingConfig](#batchingconfig) | N/A                  | The batching settings applied to the producer. When omitted, batching is enabled with a maximum publish delay of 10 ms. |
 
 ###### Resources
 
@@ -132,6 +133,33 @@ The following table outlines the nested fields and related arguments under the `
 | producerCryptoFailureAction | ProducerCryptoFailureAction | N/A                      | N/A   |
 | consumerCryptoFailureAction | ConsumerCryptoFailureAction | N/A                      | N/A   |
 
+
+###### BatchingConfig
+
+The following table outlines the nested fields under the `batchingConfig` field of `producerConfig`.
+These settings were introduced by [PIP-401](https://github.com/apache/pulsar/blob/master/pip/pip-401.md).
+
+:::note
+
+`batchingConfig` is currently applied by **Java** functions only. The Python and Go runtimes hard-code
+batching to enabled with a 10 ms maximum publish delay and ignore these settings
+([#26390](https://github.com/apache/pulsar/issues/26390),
+[#26391](https://github.com/apache/pulsar/issues/26391)).
+
+:::
+
+| Field Name                | Type    | Related Command Argument | Description   |
+|---------------------------|---------|--------------------------|---------------|
+| enabled                   | Boolean | N/A                      | Whether the producer batches messages. The default value is `true`. |
+| batchingMaxPublishDelayMs | Int     | N/A                      | The maximum time the producer waits before sending a batch, in milliseconds. The default value is `10`. |
+| batchingMaxMessages       | Int     | N/A                      | The maximum number of messages in a batch. When unset, the client default applies. |
+| batchingMaxBytes          | Int     | N/A                      | The maximum size of a batch, in bytes. When unset, the client default applies. |
+| batchBuilder              | String  | N/A                      | The type of batch construction method. Available values: `DEFAULT` and `KEY_BASED`. Takes precedence over `producerConfig.batchBuilder`. |
+| roundRobinRouterBatchingPartitionSwitchFrequency | Int | N/A | How often the round-robin router switches partitions for non-keyed messages, as a multiple of `batchingMaxPublishDelayMs`. The partition switch period is `frequency * batchingMaxPublishDelayMs`. |
+
+A function that sets no `producerConfig`, or a `producerConfig` with no `batchingConfig`, gets batching
+enabled with a maximum publish delay of 10 ms. This is the behaviour functions had before these settings
+became configurable, and it is the same across the Java, Python, and Go runtimes.
 
 ### Example
 


### PR DESCRIPTION
### Motivation

[PIP-401](https://github.com/apache/pulsar/blob/master/pip/pip-401.md) added a `batchingConfig` field to a function's `producerConfig`, letting a function enable or disable batching and tune the batch size, byte limit, publish delay, and batch builder.

**None of it is documented.** `batchingConfig` appears nowhere in the docs, and the `ProducerConfig` table in `functions-cli.md` lists every sibling field — `maxPendingMessages`, `cryptoConfig`, `batchBuilder`, `compressionType` — but not this one. All six sub-fields are invisible to anyone who has not read `BatchingConfig.java`.

### Modifications

**Add a `BatchingConfig` section** covering the six fields with their defaults (`enabled` = `true`, `batchingMaxPublishDelayMs` = `10`), and a `batchingConfig` row linking to it from the `ProducerConfig` table — the pattern the table already uses for `cryptoConfig` → [CryptoConfig](#cryptoconfig).

**Record that only Java applies it today.** The Python and Go runtimes hard-code batching to enabled with a 10 ms maximum publish delay and ignore `batchingConfig` entirely, tracked as apache/pulsar#26390 and apache/pulsar#26391. Documenting the fields without saying so would just move the surprise rather than remove it: the configuration is accepted, stored, and echoed back by `functions get`, and then ignored.

Two further notes on rows that were **already** in the table, both describing current behaviour:

- **`batchingConfig.batchBuilder` takes precedence over `producerConfig.batchBuilder`**, matching the Java runtime. A user who sets both and sees one ignored has no way to find that out today.
- **The Go client does not implement `SNAPPY`.** `instance.go` maps it to `LZ4` in the default arm of its compression switch, so a Go function configured with `SNAPPY` silently gets `LZ4`. This one is independent of the rest of the PR and easy to drop if you would rather it went separately.

### Versioned docs

Supported versions today are **5.0.x**, **4.2.x**, and **4.0.x**. PIP-401 added `BatchingConfig` in 4.1, so the field exists in 4.2.x and 5.0.x but **not** in 4.0.x, which is left unchanged.

The runtime note is identical in both versioned copies: neither release carries the Python or Go batching support, so `batchingConfig` is still Java-only there.

One remainder, deliberately not included: the `SNAPPY` note also holds for 4.0.x, but the rest of this change does not apply to that version, and a lone compression note there seemed better as its own change than as a stray edit here.

### Follow-up

apache/pulsar#26392 and apache/pulsar#26393 make the Python and Go runtimes honour these settings. When those land, the note in this section needs to become a smaller one — `roundRobinRouterBatchingPartitionSwitchFrequency` stays Java-only, and `maxPendingMessagesAcrossPartitions` has no Go equivalent. I will open that as a separate PR rather than describing behaviour that has not shipped.

### Documentation

This *is* the documentation change.

