### PR TITLE
[fix][doc] Clarify subscription and consumer semantics under geo-replication

### DIFF
--- a/docs/administration-geo.md
+++ b/docs/administration-geo.md
@@ -99,13 +99,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 
@@ -322,7 +324,7 @@ In case of failover, a consumer can restart consuming from the failure point in 
 
 :::note
 
-Replicated subscriptions require [2-way geo-replication](#1-way-and-2-way-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-and-2-way-geo-replication) for configuration requirements.
+Replicated subscriptions require [2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) for configuration requirements.
 
 :::
 

--- a/docs/concepts-replication.md
+++ b/docs/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-3.1.x/administration-geo.md
+++ b/versioned_docs/version-3.1.x/administration-geo.md
@@ -31,13 +31,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![A typical geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 

--- a/versioned_docs/version-3.1.x/concepts-replication.md
+++ b/versioned_docs/version-3.1.x/concepts-replication.md
@@ -8,9 +8,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![A typical geo-replication example with a full-mesh pattern](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -49,7 +84,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![An example of an active-active replication pattern](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-3.2.x/administration-geo.md
+++ b/versioned_docs/version-3.2.x/administration-geo.md
@@ -32,13 +32,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 

--- a/versioned_docs/version-3.2.x/concepts-replication.md
+++ b/versioned_docs/version-3.2.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-3.3.x/administration-geo.md
+++ b/versioned_docs/version-3.3.x/administration-geo.md
@@ -32,13 +32,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 

--- a/versioned_docs/version-3.3.x/concepts-replication.md
+++ b/versioned_docs/version-3.3.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-4.0.x/administration-geo.md
+++ b/versioned_docs/version-4.0.x/administration-geo.md
@@ -99,13 +99,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 
@@ -322,7 +324,7 @@ In case of failover, a consumer can restart consuming from the failure point in 
 
 :::note
 
-Replicated subscriptions require [2-way geo-replication](#1-way-and-2-way-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-and-2-way-geo-replication) for configuration requirements.
+Replicated subscriptions require [2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) for configuration requirements.
 
 :::
 

--- a/versioned_docs/version-4.0.x/concepts-replication.md
+++ b/versioned_docs/version-4.0.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-4.1.x/administration-geo.md
+++ b/versioned_docs/version-4.1.x/administration-geo.md
@@ -99,13 +99,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 
@@ -322,7 +324,7 @@ In case of failover, a consumer can restart consuming from the failure point in 
 
 :::note
 
-Replicated subscriptions require [2-way geo-replication](#1-way-and-2-way-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-and-2-way-geo-replication) for configuration requirements.
+Replicated subscriptions require [2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) for configuration requirements.
 
 :::
 

--- a/versioned_docs/version-4.1.x/concepts-replication.md
+++ b/versioned_docs/version-4.1.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-4.2.x/administration-geo.md
+++ b/versioned_docs/version-4.2.x/administration-geo.md
@@ -99,13 +99,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 
@@ -322,7 +324,7 @@ In case of failover, a consumer can restart consuming from the failure point in 
 
 :::note
 
-Replicated subscriptions require [2-way geo-replication](#1-way-and-2-way-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-and-2-way-geo-replication) for configuration requirements.
+Replicated subscriptions require [2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) for configuration requirements.
 
 :::
 

--- a/versioned_docs/version-4.2.x/concepts-replication.md
+++ b/versioned_docs/version-4.2.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 

--- a/versioned_docs/version-5.0.x/administration-geo.md
+++ b/versioned_docs/version-5.0.x/administration-geo.md
@@ -99,13 +99,15 @@ In normal cases, when connectivity issues are none, messages are replicated imme
 
 Applications can create producers and consumers in any of the clusters, even when the remote clusters are not reachable (like during a network partition).
 
-Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled. Once the replicated subscription is enabled, you can keep the subscription state in synchronization. Therefore, a topic can be asynchronously replicated across multiple geographical regions. In case of failover, a consumer can restart consuming messages from the failure point in a different cluster.
+Producers and consumers can publish messages to and consume messages from any cluster in a Pulsar instance. However, geo-replication replicates topic data, not subscriptions: each subscription is local to the cluster where it is created, and a subscription with the same name in another cluster is a separate subscription with its own cursor, consumers, and backlog. See [Subscriptions and consumers across clusters](concepts-replication.md#subscriptions-and-consumers-across-clusters) for details.
+
+The only subscription-related state that can be synchronized across clusters is the mark-delete position of a [replicated subscription](#replicated-subscriptions). When a replicated subscription is enabled, its state is kept in synchronization, so a consumer can restart consuming messages from the failure point in a different cluster. Because replicated subscriptions are designed for failover and not for active-active consumption, process messages in a single cluster at a time.
 
 ![Geo-replication example with a full-mesh pattern](/assets/geo-replication.png)
 
 In the aforementioned example, the **T1** topic is replicated among three clusters, **Cluster-A**, **Cluster-B**, and **Cluster-C**.
 
-All messages produced in any of the three clusters are delivered to all subscriptions in other clusters. In this case, **C1** and **C2** consumers receive all messages that **P1**, **P2**, and **P3** producers publish. Ordering is still guaranteed on a per-producer basis.
+All messages produced in any of the three clusters are replicated to the other two clusters and are then dispatched to the subscriptions that exist in each cluster. In this case, the **C1** and **C2** consumers each receive all messages that the **P1**, **P2**, and **P3** producers publish, because C1 and C2 belong to separate, independent subscriptions in their own clusters. Ordering is still guaranteed on a per-producer basis.
 
 ## Configure replication
 
@@ -322,7 +324,7 @@ In case of failover, a consumer can restart consuming from the failure point in 
 
 :::note
 
-Replicated subscriptions require [2-way geo-replication](#1-way-and-2-way-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-and-2-way-geo-replication) for configuration requirements.
+Replicated subscriptions require [2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) to be properly configured between all participating clusters. See [1-way and 2-way geo-replication](#1-way-unidirectional-and-2-way-bidirectional-geo-replication) for configuration requirements.
 
 :::
 

--- a/versioned_docs/version-5.0.x/concepts-replication.md
+++ b/versioned_docs/version-5.0.x/concepts-replication.md
@@ -9,9 +9,44 @@ Regardless of industries, when an unforeseen event occurs and brings day-to-day 
 
 Pulsar's geo-replication mechanism is typically used for disaster recovery, enabling the replication of persistently stored message data across multiple data centers. For instance, your application is publishing data in one region and you would like to process it for consumption in other regions. With Pulsar's geo-replication mechanism, messages can be produced and consumed in different geo-locations.
 
-The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters.
+The diagram below illustrates the process of [geo-replication](administration-geo.md). Whenever three producers (P1, P2 and P3) respectively publish messages to the T1 topic in three clusters, those messages are instantly replicated across clusters. Once the messages are replicated, two consumers (C1 and C2) can consume those messages from their clusters. Each consumer consumes through a subscription that is local to its own cluster; see [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters) for how subscriptions behave when a topic is consumed from more than one cluster.
 
 ![Geo-replication example with full-mesh pattern in Pulsar](/assets/full-mesh-replication.svg)
+
+## Subscriptions and consumers across clusters
+
+Geo-replication replicates **topic data**, not subscriptions. A subscription belongs to the cluster where it is created, and each cluster dispatches messages only to the subscriptions that exist locally.
+
+| Item | Replicated across clusters? |
+|------|------------------------------|
+| Messages (topic data) | Yes |
+| Subscriptions, including their cursors, consumers, backlog, and acknowledgment state | No, each cluster keeps its own subscriptions |
+| Mark-delete position of a [replicated subscription](administration-geo.md#replicated-subscriptions) | Yes, if explicitly enabled |
+| Individual acknowledgments | No |
+
+### Subscriptions are local to a cluster
+
+When you use the same subscription name in two clusters, Pulsar creates **two independent subscriptions**, one in each cluster:
+
+* Each subscription has its own cursor, backlog, consumers, and acknowledgment state. Acknowledging a message in one cluster does not advance the cursor of the subscription with the same name in another cluster.
+* Each subscription applies its own [subscription type](concepts-messaging.md#subscription-types) locally. For example, an `exclusive` subscription in one cluster does not prevent a subscription with the same name from being created in another cluster.
+* Each subscription consumes the local copy of the topic, which contains both messages produced locally and messages replicated from other clusters. How complete that copy is depends on the replication configuration: with 1-way geo-replication or [selective replication](administration-geo.md#selective-replication), a cluster receives only part of the topic data, and so do its subscriptions.
+
+For the same reason, a consumer that reconnects to a different cluster with the same subscription name does not resume the original subscription. It triggers the creation of a new, unrelated subscription that only shares the name, as described in [PIP-33: Replicated subscriptions](https://github.com/apache/pulsar/blob/master/pip/pip-33.md).
+
+Because subscriptions are local, they are also managed locally. For example, deleting a geo-replicated topic requires deleting the local subscriptions in every cluster.
+
+### Consumers do not share the workload across clusters
+
+Consumers that use the same subscription name in different clusters do not form a single consumer group, and Pulsar does not distribute messages among them. In the full-mesh example above, if consumer **C1** consumes the **T1** topic as `sub-1` in **Cluster-A** and consumer **C2** consumes the same topic as `sub-1` in **Cluster-B**, both of them receive every message published to **T1** in either cluster, because each cluster dispatches messages from its own copy. As a result, every message is processed once per cluster, which duplicates processing at the application level unless the application handles duplicates.
+
+Reusing a subscription name across clusters therefore does not split the consumption of a replicated topic, because no single subscription spans clusters. To distribute the processing load across regions, shard the workload at the topic or partition level, for example, by using a different topic, or a different subset of partitions, per region.
+
+### Replicated subscriptions: for failover, not for active-active consumption
+
+By default, only messages are replicated. Pulsar also supports [replicated subscriptions](administration-geo.md#replicated-subscriptions), which keep the mark-delete position of a subscription in sync across clusters within a sub-second timeframe. This feature is intended for failover: the consumers of a subscription are active in a single cluster and, if that cluster becomes unavailable, they can restart in another cluster with a subscription of the same name and resume from a consistent position instead of reprocessing the whole topic.
+
+Replicated subscriptions do not create a single subscription that spans clusters. When consumers are active in multiple clusters at the same time, Pulsar does not coordinate message dispatch between them: most messages are processed in both clusters (duplicate processing), and some messages may be processed in either cluster depending on replication timing. For this reason, when replicated subscriptions are enabled, process messages in a single cluster at a time.
 
 ## Replication mechanisms
 
@@ -52,7 +87,7 @@ Using full-mesh replication and applying the [selective message replication](adm
 
 ### Active-active replication
 
-Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers can consume all messages from all data centers.
+Active-active replication is a variation of full-mesh replication, with only two data centers. Producers can run at any data center to produce messages, and consumers in either data center can consume all messages produced in both data centers, because each data center holds a local copy of the topic. This message fan-out does not distribute the processing load across data centers: the consumers in each data center belong to their own local subscription and every subscription receives every message. See [Subscriptions and consumers across clusters](#subscriptions-and-consumers-across-clusters).
 
 ![Example of active-active replication pattern in Pulsar](/assets/active-active-replication.svg)
 


### PR DESCRIPTION
### Motivation

The geo-replication documentation can be read as if a single subscription could be actively consumed from several clusters at the same time. Pulsar does not support that: a subscription is local to the cluster in which it is created, and using the same subscription name in another cluster creates a separate, independent subscription that receives its own copy of the topic data. Only the mark-delete position of an opt-in replicated subscription is synchronized, and that feature targets failover, not active-active consumption.

[PIP-33](https://github.com/apache/pulsar/blob/master/pip/pip-33.md) states the behavior explicitly:

> The only limitation is that subscriptions are currently 'local' to the cluster in which they are created. That is, no state for the subscription is transferred across regions.
> If a consumer reconnects to a new region, it will trigger the creation of a new unrelated subscription, albeit with the same name.

The wording that caused the misreading:

* `concepts-replication.md`: "two consumers (C1 and C2) can consume those messages from their clusters" and "consumers can consume all messages from all data centers", both of which suggest one shared subscription spanning clusters.
* `administration-geo.md`: "subscriptions cannot only be local to the cluster where the subscriptions are created but also can be transferred between clusters after the replicated subscription is enabled". Subscriptions are never transferred; only the mark-delete position is replicated.
* `administration-geo.md`: "All messages produced in any of the three clusters are delivered to all subscriptions in other clusters", which also implies that subscriptions in a cluster do not consume locally produced messages.

### Changes

**`docs/concepts-replication.md`**

* Add a section **"Subscriptions and consumers across clusters"** before "Replication mechanisms":
  * a table of what is and is not replicated across clusters (messages: yes; subscriptions including cursors, consumers, backlog and acknowledgment state: no, each cluster keeps its own; mark-delete position of a replicated subscription: yes, if explicitly enabled; individual acknowledgments: no);
  * *Subscriptions are local to a cluster* — the same subscription name in two clusters creates two independent subscriptions;
  * *Consumers do not share the workload across clusters* — every message is processed once per cluster, and splitting the load across regions must be done at the topic or partition level;
  * *Replicated subscriptions: for failover, not for active-active consumption*.
* Clarify the intro example and the active-active replication pattern so that consumers are no longer described as consuming from a single subscription.

**`docs/administration-geo.md`**

* Rewrite the "subscriptions can be transferred between clusters" sentence and the "delivered to all subscriptions in other clusters" sentence.
* Fix two stale anchors: `#1-way-and-2-way-geo-replication` → `#1-way-unidirectional-and-2-way-bidirectional-geo-replication`.

### Versioned docs

The misleading text exists in released versions, so the change is propagated to the versioned docs:

* `5.0.x`, `4.2.x`, `4.0.x` — applied with `scripts/docs-tool.sh apply_changes_to_versioned_docs`.
* `4.1.x`, `3.3.x`, `3.2.x`, `3.1.x` — these are no longer in the supported version list, but their pages are still published and contain the same text. The patch applies cleanly to `4.1.x`; for the 3.x versions `administration-geo.md` does not contain the 1-way/2-way note (so the anchor hunk does not apply) and `3.1.x` uses different image alt text, so the remaining changes were applied manually while preserving each version's own text.

The added section is byte-identical in `docs/` and in all seven versioned docs.

### Verification

* The new section is identical (4337 characters) across all eight files.
* All 116 relative markdown links in the 16 touched files resolve to an existing file and heading.
* No `.rej`/`.orig` files left behind.
* `yarn build` was not run locally (dependencies not installed); a preview of the new table would be worth a look.
